### PR TITLE
Add config for deploy android app

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -7,3 +7,4 @@ gradle-wrapper.jar
 GeneratedPluginRegistrant.java
 google-services.json
 _google-services.json
+key.properties

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,6 +26,11 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+  keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 android {
     compileSdkVersion 28
 
@@ -46,11 +51,17 @@ android {
         versionName flutterVersionName
     }
 
+    signingConfigs {
+        release {
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+            storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties['storePassword']
+        }
+    }
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
         }
     }
 


### PR DESCRIPTION
## What
- key.propertiesをgitignoreに追加
- app/build.gradleにrelease用のconfigを追加

## Why
reference: https://flutter.dev/docs/deployment/android#signing-the-app
https://devcenter.bitrise.io/getting-started/getting-started-with-flutter-apps/