### PR TITLE
Add router and fix transition to home

### DIFF
--- a/lib/initial_setting/initial_setting.dart
+++ b/lib/initial_setting/initial_setting.dart
@@ -13,13 +13,6 @@ class InitialSettingModel extends ChangeNotifier {
   int durationMenstruation;
   int hour;
   int minute;
-
-  void done() {
-    SharedPreferences.getInstance().then((storage) {
-      storage.setBool(BoolKey.didEndInitialSetting, true);
-      notifyListeners();
-    });
-  }
 }
 
 class InitialSetting extends StatelessWidget {

--- a/lib/initial_setting/initial_setting.dart
+++ b/lib/initial_setting/initial_setting.dart
@@ -7,8 +7,6 @@ import 'package:Pilll/util/shared_preference/keys.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-typedef InitialSettingCallback = void Function(InitialSettingModel);
-
 class InitialSettingModel extends ChangeNotifier {
   PillSheetType pillSheetType;
   int fromMenstruation;

--- a/lib/initial_setting/initial_setting_2.dart
+++ b/lib/initial_setting/initial_setting_2.dart
@@ -1,3 +1,4 @@
+import 'package:Pilll/main/application/router.dart';
 import 'package:Pilll/theme/color.dart';
 import 'package:Pilll/initial_setting/initial_setting_3.dart';
 import 'package:Pilll/main/record/pill_sheet.dart';
@@ -78,7 +79,9 @@ class InitialSetting2 extends StatelessWidget {
                     FlatButton(
                       child: Text("スキップ"),
                       textColor: TextColor.gray,
-                      onPressed: () {},
+                      onPressed: () {
+                        Navigator.popAndPushNamed(context, Routes.main);
+                      },
                     ),
                   ],
                 ),

--- a/lib/initial_setting/initial_setting_2.dart
+++ b/lib/initial_setting/initial_setting_2.dart
@@ -80,7 +80,7 @@ class InitialSetting2 extends StatelessWidget {
                       child: Text("スキップ"),
                       textColor: TextColor.gray,
                       onPressed: () {
-                        Navigator.popAndPushNamed(context, Routes.main);
+                        Router.endInitialSetting(context);
                       },
                     ),
                   ],

--- a/lib/initial_setting/initial_setting_3.dart
+++ b/lib/initial_setting/initial_setting_3.dart
@@ -204,7 +204,7 @@ class _InitialSetting3State extends State<InitialSetting3> {
                     child: Text("スキップ"),
                     textColor: TextColor.gray,
                     onPressed: () {
-                      Navigator.popAndPushNamed(context, Routes.main);
+                      Router.endInitialSetting(context);
                     },
                   ),
                 ],

--- a/lib/initial_setting/initial_setting_3.dart
+++ b/lib/initial_setting/initial_setting_3.dart
@@ -1,3 +1,4 @@
+import 'package:Pilll/main/application/router.dart';
 import 'package:Pilll/theme/color.dart';
 import 'package:Pilll/initial_setting/initial_setting.dart';
 import 'package:Pilll/initial_setting/initial_setting_4.dart';
@@ -202,7 +203,9 @@ class _InitialSetting3State extends State<InitialSetting3> {
                   FlatButton(
                     child: Text("スキップ"),
                     textColor: TextColor.gray,
-                    onPressed: () {},
+                    onPressed: () {
+                      Navigator.popAndPushNamed(context, Routes.main);
+                    },
                   ),
                 ],
               ),

--- a/lib/initial_setting/initial_setting_4.dart
+++ b/lib/initial_setting/initial_setting_4.dart
@@ -42,7 +42,7 @@ class _InitialSetting4State extends State<InitialSetting4> {
   }
 
   void _done() {
-    Navigator.popAndPushNamed(context, Routes.main);
+    Router.endInitialSetting(context);
   }
 
   void _showDurationModalSheet(BuildContext context) {

--- a/lib/initial_setting/initial_setting_4.dart
+++ b/lib/initial_setting/initial_setting_4.dart
@@ -1,3 +1,4 @@
+import 'package:Pilll/main/application/router.dart';
 import 'package:Pilll/theme/color.dart';
 import 'package:Pilll/initial_setting/initial_setting.dart';
 import 'package:Pilll/theme/font.dart';
@@ -40,7 +41,9 @@ class _InitialSetting4State extends State<InitialSetting4> {
         t.year, t.month, t.day, 22, 0, t.second, t.millisecond, t.microsecond);
   }
 
-  void _done() {}
+  void _done() {
+    Navigator.popAndPushNamed(context, Routes.main);
+  }
 
   void _showDurationModalSheet(BuildContext context) {
     showModalBottomSheet(
@@ -131,14 +134,12 @@ class _InitialSetting4State extends State<InitialSetting4> {
                     child: Text(
                       "設定",
                     ),
-                    onPressed: !_canNext(context)
-                        ? null
-                        : context.watch<InitialSettingModel>().done,
+                    onPressed: !_canNext(context) ? null : _done,
                   ),
                   FlatButton(
                     child: Text("スキップ"),
                     textColor: TextColor.gray,
-                    onPressed: Provider.of<InitialSettingModel>(context).done,
+                    onPressed: _done,
                   ),
                 ],
               ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,21 +53,20 @@ class MyApp extends StatelessWidget {
             textTheme: ButtonTextTheme.primary,
           ),
         ),
-        home: MyHomePage(),
+        home: Main(),
       ),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key}) : super(key: key);
+class Main extends StatefulWidget {
+  Main({Key key}) : super(key: key);
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  _MainState createState() => _MainState();
 }
 
-class _MyHomePageState extends State<MyHomePage>
-    with SingleTickerProviderStateMixin {
+class _MainState extends State<Main> with SingleTickerProviderStateMixin {
   TabController _tabController;
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,9 +46,7 @@ class App extends StatelessWidget {
             textTheme: ButtonTextTheme.primary,
           ),
         ),
-        home: HomePage(),
         routes: Router.routes(),
-        initialRoute: Routes.root,
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,21 +1,14 @@
 import 'package:Pilll/main/record/pill_sheet_model.dart';
 import 'package:Pilll/model/pill_sheet_type.dart';
-import 'package:Pilll/settings/settings.dart';
 import 'package:Pilll/theme/color.dart';
 import 'package:Pilll/initial_setting/initial_setting.dart';
-import 'package:Pilll/initial_setting/initial_setting_1.dart';
-import 'package:Pilll/main/record/pill_sheet.dart';
-import 'package:Pilll/main/record/record_taken_information.dart';
-import 'package:Pilll/theme/text_color.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_analytics/observer.dart';
-import 'package:Pilll/util/shared_preference/keys.dart';
-import 'package:Pilll/util/shared_preference/shared_preference.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
+
+import 'main/home/home.dart';
 
 void main() {
   initializeDateFormatting('ja_JP');
@@ -54,128 +47,6 @@ class App extends StatelessWidget {
           ),
         ),
         home: HomePage(),
-      ),
-    );
-  }
-}
-
-class HomePage extends StatefulWidget {
-  HomePage({Key key}) : super(key: key);
-
-  @override
-  _HomePageState createState() => _HomePageState();
-}
-
-class _HomePageState extends State<HomePage>
-    with SingleTickerProviderStateMixin {
-  TabController _tabController;
-
-  @override
-  void initState() {
-    super.initState();
-    _tabController = TabController(length: 3, vsync: this);
-    _tabController.addListener(_handleTabSelection);
-  }
-
-  void _handleTabSelection() {
-    setState(() {});
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return SharedPreferencesBuilder<bool>(
-        preferenceKey: BoolKey.didEndInitialSetting,
-        builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
-          // TODO:
-          // if (!snapshot.hasData) {
-          //   return InitialSetting();
-          // }
-          // if (!snapshot.data) {
-          //   return InitialSetting();
-          // }
-          return DefaultTabController(
-            length: 3,
-            child: Scaffold(
-              backgroundColor: PilllColors.background,
-              appBar: AppBar(
-                title: Text('Pilll'),
-                backgroundColor: PilllColors.primary,
-              ),
-              bottomNavigationBar: Container(
-                decoration: BoxDecoration(
-                  border: Border(
-                      top: BorderSide(width: 1, color: PilllColors.border)),
-                ),
-                child: Ink(
-                  color: PilllColors.bottomBar,
-                  child: SafeArea(
-                    child: TabBar(
-                      controller: _tabController,
-                      labelColor: PilllColors.primary,
-                      indicatorColor: Colors.transparent,
-                      unselectedLabelColor: TextColor.gray,
-                      tabs: <Tab>[
-                        Tab(
-                            text: "ピル",
-                            icon: SvgPicture.asset("images/tab_icon_pill.svg",
-                                color: _tabController.index == 0
-                                    ? PilllColors.primary
-                                    : TextColor.gray)),
-                        Tab(
-                            text: "2020/07",
-                            icon: SvgPicture.asset(
-                                "images/tab_icon_calendar.svg",
-                                color: _tabController.index == 1
-                                    ? PilllColors.primary
-                                    : TextColor.gray)),
-                        Tab(
-                            text: "設定",
-                            icon: SvgPicture.asset(
-                                "images/tab_icon_setting.svg",
-                                color: _tabController.index == 2
-                                    ? PilllColors.primary
-                                    : TextColor.gray)),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-              body: TabBarView(
-                controller: _tabController,
-                children: <Widget>[
-                  Settings(),
-                  _recordView(),
-                  _recordView(),
-                  // Settings(),
-                ],
-              ),
-            ),
-          );
-        });
-  }
-
-  Center _recordView() {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[
-          SizedBox(height: 60),
-          RecordTakenInformation(),
-          SizedBox(height: 24),
-          PillSheet(),
-          SizedBox(height: 24),
-          Container(
-            height: 44,
-            width: 180,
-            child: RaisedButton(
-              child: Text("飲んだ"),
-              color: PilllColors.primary,
-              textColor: Colors.white,
-              onPressed: () {},
-            ),
-          ),
-          SizedBox(height: 8),
-        ],
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,15 +53,14 @@ class MyApp extends StatelessWidget {
             textTheme: ButtonTextTheme.primary,
           ),
         ),
-        home: MyHomePage(title: 'Flutter Demo Home Page'),
+        home: MyHomePage(),
       ),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
-  final String title;
+  MyHomePage({Key key}) : super(key: key);
 
   @override
   _MyHomePageState createState() => _MyHomePageState();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
 
+import 'main/application/router.dart';
 import 'main/home/home.dart';
 
 void main() {
@@ -30,7 +31,6 @@ class App extends StatelessWidget {
         ),
       ],
       child: MaterialApp(
-        title: 'Flutter Demo',
         navigatorObservers: [
           FirebaseAnalyticsObserver(analytics: analytics),
         ],
@@ -47,6 +47,8 @@ class App extends StatelessWidget {
           ),
         ),
         home: HomePage(),
+        routes: Router.routes(),
+        initialRoute: Routes.root,
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,10 +20,10 @@ import 'package:provider/provider.dart';
 void main() {
   initializeDateFormatting('ja_JP');
   // debugPaintSizeEnabled = true;
-  runApp(MyApp());
+  runApp(App());
 }
 
-class MyApp extends StatelessWidget {
+class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     FirebaseAnalytics analytics = FirebaseAnalytics();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,20 +53,21 @@ class MyApp extends StatelessWidget {
             textTheme: ButtonTextTheme.primary,
           ),
         ),
-        home: Main(),
+        home: HomePage(),
       ),
     );
   }
 }
 
-class Main extends StatefulWidget {
-  Main({Key key}) : super(key: key);
+class HomePage extends StatefulWidget {
+  HomePage({Key key}) : super(key: key);
 
   @override
-  _MainState createState() => _MainState();
+  _HomePageState createState() => _HomePageState();
 }
 
-class _MainState extends State<Main> with SingleTickerProviderStateMixin {
+class _HomePageState extends State<HomePage>
+    with SingleTickerProviderStateMixin {
   TabController _tabController;
 
   @override

--- a/lib/main/application/router.dart
+++ b/lib/main/application/router.dart
@@ -1,13 +1,14 @@
 import 'package:Pilll/initial_setting/initial_setting.dart';
-import 'package:Pilll/main.dart';
+import 'package:Pilll/main/home/home.dart';
+import 'package:Pilll/main/root/root.dart';
 import 'package:flutter/material.dart';
 
 class Router {
   static Map<String, WidgetBuilder> routes() {
     return {
-      Routes.root: (BuildContext context) => (MyHomePage()),
+      Routes.root: (BuildContext context) => (Root()),
       Routes.initialSetting: (BuildContext context) => (InitialSetting()),
-      Routes.main: (BuildContext context) => (MyHomePage()),
+      Routes.main: (BuildContext context) => (HomePage()),
     };
   }
 }

--- a/lib/main/application/router.dart
+++ b/lib/main/application/router.dart
@@ -1,7 +1,9 @@
 import 'package:Pilll/initial_setting/initial_setting.dart';
 import 'package:Pilll/main/home/home.dart';
 import 'package:Pilll/main/root/root.dart';
+import 'package:Pilll/util/shared_preference/keys.dart';
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class Router {
   static Map<String, WidgetBuilder> routes() {
@@ -10,6 +12,13 @@ class Router {
       Routes.initialSetting: (BuildContext context) => (InitialSetting()),
       Routes.main: (BuildContext context) => (HomePage()),
     };
+  }
+
+  static void endInitialSetting(BuildContext context) {
+    SharedPreferences.getInstance().then((storage) {
+      storage.setBool(BoolKey.didEndInitialSetting, true);
+      Navigator.popAndPushNamed(context, Routes.main);
+    });
   }
 }
 

--- a/lib/main/application/router.dart
+++ b/lib/main/application/router.dart
@@ -1,0 +1,19 @@
+import 'package:Pilll/initial_setting/initial_setting.dart';
+import 'package:Pilll/main.dart';
+import 'package:flutter/material.dart';
+
+class Router {
+  static Map<String, WidgetBuilder> routes() {
+    return {
+      Routes.root: (BuildContext context) => (MyHomePage()),
+      Routes.initialSetting: (BuildContext context) => (InitialSetting()),
+      Routes.main: (BuildContext context) => (MyHomePage()),
+    };
+  }
+}
+
+class Routes {
+  static String root = '/';
+  static String initialSetting = '/initial-setting';
+  static String main = '/main';
+}

--- a/lib/main/home/home.dart
+++ b/lib/main/home/home.dart
@@ -3,8 +3,6 @@ import 'package:Pilll/main/record/record_taken_information.dart';
 import 'package:Pilll/settings/settings.dart';
 import 'package:Pilll/theme/color.dart';
 import 'package:Pilll/theme/text_color.dart';
-import 'package:Pilll/util/shared_preference/keys.dart';
-import 'package:Pilll/util/shared_preference/shared_preference.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 

--- a/lib/main/home/home.dart
+++ b/lib/main/home/home.dart
@@ -1,0 +1,131 @@
+import 'package:Pilll/initial_setting/pill_sheet.dart';
+import 'package:Pilll/main/record/record_taken_information.dart';
+import 'package:Pilll/settings/settings.dart';
+import 'package:Pilll/theme/color.dart';
+import 'package:Pilll/theme/text_color.dart';
+import 'package:Pilll/util/shared_preference/keys.dart';
+import 'package:Pilll/util/shared_preference/shared_preference.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+
+class HomePage extends StatefulWidget {
+  HomePage({Key key}) : super(key: key);
+
+  @override
+  _HomePageState createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage>
+    with SingleTickerProviderStateMixin {
+  TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+    _tabController.addListener(_handleTabSelection);
+  }
+
+  void _handleTabSelection() {
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SharedPreferencesBuilder<bool>(
+        preferenceKey: BoolKey.didEndInitialSetting,
+        builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
+          // TODO:
+          // if (!snapshot.hasData) {
+          //   return InitialSetting();
+          // }
+          // if (!snapshot.data) {
+          //   return InitialSetting();
+          // }
+          return DefaultTabController(
+            length: 3,
+            child: Scaffold(
+              backgroundColor: PilllColors.background,
+              appBar: AppBar(
+                title: Text('Pilll'),
+                backgroundColor: PilllColors.primary,
+              ),
+              bottomNavigationBar: Container(
+                decoration: BoxDecoration(
+                  border: Border(
+                      top: BorderSide(width: 1, color: PilllColors.border)),
+                ),
+                child: Ink(
+                  color: PilllColors.bottomBar,
+                  child: SafeArea(
+                    child: TabBar(
+                      controller: _tabController,
+                      labelColor: PilllColors.primary,
+                      indicatorColor: Colors.transparent,
+                      unselectedLabelColor: TextColor.gray,
+                      tabs: <Tab>[
+                        Tab(
+                            text: "ピル",
+                            icon: SvgPicture.asset("images/tab_icon_pill.svg",
+                                color: _tabController.index == 0
+                                    ? PilllColors.primary
+                                    : TextColor.gray)),
+                        Tab(
+                            text: "2020/07",
+                            icon: SvgPicture.asset(
+                                "images/tab_icon_calendar.svg",
+                                color: _tabController.index == 1
+                                    ? PilllColors.primary
+                                    : TextColor.gray)),
+                        Tab(
+                            text: "設定",
+                            icon: SvgPicture.asset(
+                                "images/tab_icon_setting.svg",
+                                color: _tabController.index == 2
+                                    ? PilllColors.primary
+                                    : TextColor.gray)),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              body: TabBarView(
+                controller: _tabController,
+                children: <Widget>[
+                  Settings(),
+                  _recordView(),
+                  _recordView(),
+                  // Settings(),
+                ],
+              ),
+            ),
+          );
+        });
+  }
+
+  Center _recordView() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: <Widget>[
+          SizedBox(height: 60),
+          RecordTakenInformation(),
+          SizedBox(height: 24),
+          PillSheet(),
+          SizedBox(height: 24),
+          Container(
+            height: 44,
+            width: 180,
+            child: RaisedButton(
+              child: Text("飲んだ"),
+              color: PilllColors.primary,
+              textColor: Colors.white,
+              onPressed: () {},
+            ),
+          ),
+          SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main/home/home.dart
+++ b/lib/main/home/home.dart
@@ -32,75 +32,62 @@ class _HomePageState extends State<HomePage>
 
   @override
   Widget build(BuildContext context) {
-    return SharedPreferencesBuilder<bool>(
-        preferenceKey: BoolKey.didEndInitialSetting,
-        builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
-          // TODO:
-          // if (!snapshot.hasData) {
-          //   return InitialSetting();
-          // }
-          // if (!snapshot.data) {
-          //   return InitialSetting();
-          // }
-          return DefaultTabController(
-            length: 3,
-            child: Scaffold(
-              backgroundColor: PilllColors.background,
-              appBar: AppBar(
-                title: Text('Pilll'),
-                backgroundColor: PilllColors.primary,
-              ),
-              bottomNavigationBar: Container(
-                decoration: BoxDecoration(
-                  border: Border(
-                      top: BorderSide(width: 1, color: PilllColors.border)),
-                ),
-                child: Ink(
-                  color: PilllColors.bottomBar,
-                  child: SafeArea(
-                    child: TabBar(
-                      controller: _tabController,
-                      labelColor: PilllColors.primary,
-                      indicatorColor: Colors.transparent,
-                      unselectedLabelColor: TextColor.gray,
-                      tabs: <Tab>[
-                        Tab(
-                            text: "ピル",
-                            icon: SvgPicture.asset("images/tab_icon_pill.svg",
-                                color: _tabController.index == 0
-                                    ? PilllColors.primary
-                                    : TextColor.gray)),
-                        Tab(
-                            text: "2020/07",
-                            icon: SvgPicture.asset(
-                                "images/tab_icon_calendar.svg",
-                                color: _tabController.index == 1
-                                    ? PilllColors.primary
-                                    : TextColor.gray)),
-                        Tab(
-                            text: "設定",
-                            icon: SvgPicture.asset(
-                                "images/tab_icon_setting.svg",
-                                color: _tabController.index == 2
-                                    ? PilllColors.primary
-                                    : TextColor.gray)),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-              body: TabBarView(
+    return DefaultTabController(
+      length: 3,
+      child: Scaffold(
+        backgroundColor: PilllColors.background,
+        appBar: AppBar(
+          title: Text('Pilll'),
+          backgroundColor: PilllColors.primary,
+        ),
+        bottomNavigationBar: Container(
+          decoration: BoxDecoration(
+            border:
+                Border(top: BorderSide(width: 1, color: PilllColors.border)),
+          ),
+          child: Ink(
+            color: PilllColors.bottomBar,
+            child: SafeArea(
+              child: TabBar(
                 controller: _tabController,
-                children: <Widget>[
-                  Settings(),
-                  _recordView(),
-                  _recordView(),
-                  // Settings(),
+                labelColor: PilllColors.primary,
+                indicatorColor: Colors.transparent,
+                unselectedLabelColor: TextColor.gray,
+                tabs: <Tab>[
+                  Tab(
+                      text: "ピル",
+                      icon: SvgPicture.asset("images/tab_icon_pill.svg",
+                          color: _tabController.index == 0
+                              ? PilllColors.primary
+                              : TextColor.gray)),
+                  Tab(
+                      text: "2020/07",
+                      icon: SvgPicture.asset("images/tab_icon_calendar.svg",
+                          color: _tabController.index == 1
+                              ? PilllColors.primary
+                              : TextColor.gray)),
+                  Tab(
+                      text: "設定",
+                      icon: SvgPicture.asset("images/tab_icon_setting.svg",
+                          color: _tabController.index == 2
+                              ? PilllColors.primary
+                              : TextColor.gray)),
                 ],
               ),
             ),
-          );
-        });
+          ),
+        ),
+        body: TabBarView(
+          controller: _tabController,
+          children: <Widget>[
+            Settings(),
+            _recordView(),
+            _recordView(),
+            // Settings(),
+          ],
+        ),
+      ),
+    );
   }
 
   Center _recordView() {

--- a/lib/main/root/root.dart
+++ b/lib/main/root/root.dart
@@ -1,0 +1,31 @@
+import 'package:Pilll/main/application/router.dart';
+import 'package:Pilll/util/shared_preference/keys.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class Root extends StatefulWidget {
+  Root({Key key}) : super(key: key);
+
+  @override
+  RootState createState() => RootState();
+}
+
+class RootState extends State<Root> {
+  @override
+  void initState() {
+    super.initState();
+    SharedPreferences.getInstance().then((storage) {
+      if (storage.getBool(BoolKey.didEndInitialSetting)) {
+        Navigator.popAndPushNamed(context, Routes.main);
+      } else {
+        Navigator.popAndPushNamed(context, Routes.initialSetting);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: Implement
+    return Container();
+  }
+}

--- a/lib/main/root/root.dart
+++ b/lib/main/root/root.dart
@@ -1,6 +1,9 @@
 import 'package:Pilll/main/application/router.dart';
+import 'package:Pilll/theme/color.dart';
+import 'package:Pilll/theme/text_color.dart';
 import 'package:Pilll/util/shared_preference/keys.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class Root extends StatefulWidget {
@@ -25,7 +28,13 @@ class RootState extends State<Root> {
 
   @override
   Widget build(BuildContext context) {
-    // TODO: Implement
-    return Container();
+    return Scaffold(
+      backgroundColor: PilllColors.background,
+      appBar: AppBar(
+        title: Text('Pilll'),
+        backgroundColor: PilllColors.primary,
+      ),
+      body: Container(),
+    );
   }
 }

--- a/lib/main/root/root.dart
+++ b/lib/main/root/root.dart
@@ -18,11 +18,16 @@ class RootState extends State<Root> {
   void initState() {
     super.initState();
     SharedPreferences.getInstance().then((storage) {
-      if (storage.getBool(BoolKey.didEndInitialSetting)) {
-        Navigator.popAndPushNamed(context, Routes.main);
-      } else {
+      bool didEndInitialSetting = storage.getBool(BoolKey.didEndInitialSetting);
+      if (didEndInitialSetting == null) {
         Navigator.popAndPushNamed(context, Routes.initialSetting);
+        return;
       }
+      if (!didEndInitialSetting) {
+        Navigator.popAndPushNamed(context, Routes.initialSetting);
+        return;
+      }
+      Navigator.popAndPushNamed(context, Routes.main);
     });
   }
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -17,7 +17,7 @@ void main() {
   });
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(App());
 
     // Verify that our counter starts at 0.
     // expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## What
- SharedPreferenceをルートにするをやめる
- Navigatorを使ってmain,initialSettingの遷移をおこなう
- RootをおいてinitialStateのタイミングで切り分けることにした
- 初期設定のスキップや設定完了したときのイベントとして画面遷移するように入れた

## Why
SharedPreference経由でやろうとするとイベントを伝えるのが大変そうだから辞めたのと、Routerでやるのが本来は正しいな。と思い直した