### PR TITLE
:memo: using 0.18.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   intl: ^0.16.1
   firebase_core: ^0.5.0
   firebase_analytics: ^6.0.0
-  firebase_auth: ^0.18.0
+  firebase_auth: ^0.18.0+1
   cloud_firestore: ^0.14.0+2
 
 


### PR DESCRIPTION
## What
firebase_auth の最新版を使う

## Why
https://github.com/bannzai/Pilll/pull/18
のコミット漏れ