### PR TITLE
Add test case for settings

### DIFF
--- a/lib/service/setting.dart
+++ b/lib/service/setting.dart
@@ -8,6 +8,7 @@ import 'package:Pilll/service/user.dart';
 import 'package:riverpod/all.dart';
 
 abstract class SettingServiceInterface {
+  Future<Setting> fetch();
   Future<Setting> update(Setting setting);
   Stream<Setting> subscribe();
 }
@@ -24,6 +25,11 @@ final userSettingProvider = FutureProvider((ref) async {
 class SettingService extends SettingServiceInterface {
   final DatabaseConnection _database;
   SettingService(this._database);
+
+  Future<Setting> fetch() {
+    return _database.userReference().get().then((event) =>
+        Setting.fromJson(event.data()[UserFirestoreFieldKeys.settings]));
+  }
 
   Stream<Setting> subscribe() {
     return _database

--- a/lib/settings/list/reminder_times.dart
+++ b/lib/settings/list/reminder_times.dart
@@ -1,6 +1,5 @@
 import 'package:Pilll/main/components/indicator.dart';
 import 'package:Pilll/model/setting.dart';
-import 'package:Pilll/settings/list/settings.dart';
 import 'package:Pilll/state/setting.dart';
 import 'package:Pilll/store/setting.dart';
 import 'package:Pilll/theme/color.dart';

--- a/lib/settings/list/reminder_times.dart
+++ b/lib/settings/list/reminder_times.dart
@@ -1,4 +1,6 @@
+import 'package:Pilll/main/components/indicator.dart';
 import 'package:Pilll/model/setting.dart';
+import 'package:Pilll/settings/list/settings.dart';
 import 'package:Pilll/state/setting.dart';
 import 'package:Pilll/store/setting.dart';
 import 'package:Pilll/theme/color.dart';
@@ -14,6 +16,10 @@ import 'package:hooks_riverpod/all.dart';
 class ReminderTimes extends HookWidget {
   @override
   Widget build(BuildContext context) {
+    final state = useProvider(settingStoreProvider.state);
+    if (state.entity == null) {
+      return Indicator();
+    }
     return Scaffold(
       backgroundColor: PilllColors.background,
       appBar: AppBar(
@@ -29,14 +35,13 @@ class ReminderTimes extends HookWidget {
       ),
       body: Container(
         child: ListView(
-          children: [..._components(context), _footer(context)],
+          children: [..._components(context, state), _footer(context)],
         ),
       ),
     );
   }
 
-  List<Widget> _components(BuildContext context) {
-    final state = useProvider(settingStoreProvider.state);
+  List<Widget> _components(BuildContext context, SettingState state) {
     return state.entity.reminderTimes
         .asMap()
         .map((offset, reminderTime) =>

--- a/lib/settings/list/reminder_times.dart
+++ b/lib/settings/list/reminder_times.dart
@@ -1,6 +1,4 @@
-import 'package:Pilll/main/components/setting_menstruation_page.dart';
 import 'package:Pilll/model/setting.dart';
-import 'package:Pilll/model/user_error.dart';
 import 'package:Pilll/state/setting.dart';
 import 'package:Pilll/store/setting.dart';
 import 'package:Pilll/theme/color.dart';

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -5,13 +5,12 @@ import 'package:Pilll/service/pill_sheet.dart';
 import 'package:Pilll/state/pill_sheet.dart';
 import 'package:riverpod/riverpod.dart';
 
-final pillSheetStoreProvider =
-    StateNotifierProvider((ref) => PillSheetStateStore(ref.read));
+final pillSheetStoreProvider = StateNotifierProvider(
+    (ref) => PillSheetStateStore(ref.watch(pillSheetServiceProvider)));
 
 class PillSheetStateStore extends StateNotifier<PillSheetState> {
-  final Reader _read;
-  PillSheetServiceInterface get _service => _read(pillSheetServiceProvider);
-  PillSheetStateStore(this._read) : super(PillSheetState()) {
+  final PillSheetServiceInterface _service;
+  PillSheetStateStore(this._service) : super(PillSheetState()) {
     _reset();
   }
 

--- a/lib/store/setting.dart
+++ b/lib/store/setting.dart
@@ -7,19 +7,18 @@ import 'package:Pilll/service/setting.dart';
 import 'package:Pilll/state/setting.dart';
 import 'package:riverpod/riverpod.dart';
 
-final settingStoreProvider =
-    StateNotifierProvider((ref) => SettingStateStore(ref.read));
+final settingStoreProvider = StateNotifierProvider(
+    (ref) => SettingStateStore(ref.watch(settingServiceProvider)));
 
 class SettingStateStore extends StateNotifier<SettingState> {
-  final Reader _read;
-  SettingServiceInterface get _service => _read(settingServiceProvider);
-  SettingStateStore(this._read) : super(SettingState()) {
+  final SettingServiceInterface _service;
+  SettingStateStore(this._service) : super(SettingState()) {
     _reset();
   }
 
   void _reset() {
     Future(() async {
-      state = SettingState(entity: await _read(userSettingProvider.future));
+      state = SettingState(entity: await _service.fetch());
       _subscribe();
     });
   }

--- a/lib/store/setting.dart
+++ b/lib/store/setting.dart
@@ -17,10 +17,11 @@ class SettingStateStore extends StateNotifier<SettingState> {
   }
 
   void _reset() {
-    Future(() async {
-      state = SettingState(entity: await _service.fetch());
-      _subscribe();
-    });
+    _service
+        .fetch()
+        .then((entity) => SettingState(entity: entity))
+        .then((state) => this.state = state)
+        .then((_) => _subscribe());
   }
 
   StreamSubscription canceller;

--- a/test/helper/mock.dart
+++ b/test/helper/mock.dart
@@ -1,4 +1,5 @@
 import 'package:Pilll/service/pill_sheet.dart';
+import 'package:Pilll/service/setting.dart';
 import 'package:Pilll/service/today.dart';
 import 'package:mockito/mockito.dart';
 
@@ -6,3 +7,5 @@ class MockPillSheetRepository extends Mock
     implements PillSheetServiceInterface {}
 
 class MockTodayRepository extends Mock implements TodayServiceInterface {}
+
+class MockSettingService extends Mock implements SettingService {}

--- a/test/setting/reminder_times_widget_test.dart
+++ b/test/setting/reminder_times_widget_test.dart
@@ -8,7 +8,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/all.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:mockito/mockito.dart';
 
+import '../helper/mock.dart';
 import '../helper/supported_device.dart';
 
 void main() {
@@ -20,54 +22,63 @@ void main() {
     testWidgets(
         'when setting has one reminder times. one reminder times mean requires minimum count',
         (WidgetTester tester) async {
-      await tester.runAsync(() async {
-        final store = SettingStateStore(null);
-        // ignore: invalid_use_of_protected_member
-        store.state = SettingState(
-          entity: Setting(
-            fromMenstruation: 1,
-            durationMenstruation: 2,
-            isOnReminder: false,
-            pillSheetTypeRawPath: PillSheetType.pillsheet_21.rawPath,
-            reminderTimes: [ReminderTime(hour: 10, minute: 0)],
-          ),
-        );
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              settingStoreProvider.overrideWithProvider(
-                Provider(
-                  (ref) => store,
-                ),
-              )
-            ],
-            child: MaterialApp(home: ReminderTimes()),
-          ),
-        );
-        expect(find.text("通知時間の追加"), findsOneWidget);
-        expect(find.byWidgetPredicate((widget) => Widget is Dismissible),
-            findsNothing);
-      });
+      SupportedDeviceType.iPhone5SE2nd.binding(tester.binding.window);
+
+      final service = MockSettingService();
+      final entity = Setting(
+        fromMenstruation: 1,
+        durationMenstruation: 2,
+        isOnReminder: false,
+        pillSheetTypeRawPath: PillSheetType.pillsheet_21.rawPath,
+        reminderTimes: [
+          ReminderTime(hour: 10, minute: 0),
+        ],
+      );
+      when(service.fetch())
+          .thenAnswer((realInvocation) => Future.value(entity));
+      when(service.subscribe())
+          .thenAnswer((realInvocation) => Stream.value(entity));
+
+      final store = SettingStateStore(service);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            settingStoreProvider.overrideWithProvider(
+              Provider(
+                (ref) => store,
+              ),
+            )
+          ],
+          child: MaterialApp(home: ReminderTimes()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text("通知時間の追加"), findsOneWidget);
+      expect(find.byWidgetPredicate((widget) => Widget is Dismissible),
+          findsNothing);
     });
     testWidgets('when setting has maximum count reminder times︎',
         (WidgetTester tester) async {
       SupportedDeviceType.iPhone5SE2nd.binding(tester.binding.window);
 
-      final store = SettingStateStore(null);
-      // ignore: invalid_use_of_protected_member
-      store.state = SettingState(
-        entity: Setting(
-          fromMenstruation: 1,
-          durationMenstruation: 2,
-          isOnReminder: false,
-          pillSheetTypeRawPath: PillSheetType.pillsheet_21.rawPath,
-          reminderTimes: [
-            ReminderTime(hour: 10, minute: 0),
-            ReminderTime(hour: 11, minute: 0),
-            ReminderTime(hour: 12, minute: 0)
-          ],
-        ),
+      final service = MockSettingService();
+      final entity = Setting(
+        fromMenstruation: 1,
+        durationMenstruation: 2,
+        isOnReminder: false,
+        pillSheetTypeRawPath: PillSheetType.pillsheet_21.rawPath,
+        reminderTimes: [
+          ReminderTime(hour: 10, minute: 0),
+          ReminderTime(hour: 11, minute: 0),
+          ReminderTime(hour: 12, minute: 0)
+        ],
       );
+      when(service.fetch())
+          .thenAnswer((realInvocation) => Future.value(entity));
+      when(service.subscribe())
+          .thenAnswer((realInvocation) => Stream.value(entity));
+      final store = SettingStateStore(service);
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -85,8 +96,8 @@ void main() {
       expect(find.text("通知時間の追加"), findsNothing);
       expect(find.byWidgetPredicate((widget) {
         print(widget);
-        return true;
-      }), findsWidgets);
+        return widget is Dismissible;
+      }), findsNWidgets(3));
     });
   });
 }

--- a/test/setting/reminder_times_widget_test.dart
+++ b/test/setting/reminder_times_widget_test.dart
@@ -3,14 +3,18 @@ import 'package:Pilll/model/setting.dart';
 import 'package:Pilll/settings/list/reminder_times.dart';
 import 'package:Pilll/state/setting.dart';
 import 'package:Pilll/store/setting.dart';
+import 'package:Pilll/util/environment.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/all.dart';
+import 'package:intl/date_symbol_data_local.dart';
+
+import '../helper/supported_device.dart';
 
 void main() {
   setUp(() {
-    WidgetsBinding.instance.renderView.configuration =
-        new TestViewConfiguration(size: const Size(375.0, 667.0));
+    initializeDateFormatting('ja_JP');
+    Environment.isTest = true;
   });
   group("appearance widgets dependend on reminderTimes", () {
     testWidgets(
@@ -45,10 +49,10 @@ void main() {
             findsNothing);
       });
     });
-  });
-  testWidgets('when setting has maximum count reminder times︎',
-      (WidgetTester tester) async {
-    await tester.runAsync(() async {
+    testWidgets('when setting has maximum count reminder times︎',
+        (WidgetTester tester) async {
+      SupportedDeviceType.iPhone5SE2nd.binding(tester.binding.window);
+
       final store = SettingStateStore(null);
       // ignore: invalid_use_of_protected_member
       store.state = SettingState(
@@ -76,9 +80,13 @@ void main() {
           child: MaterialApp(home: ReminderTimes()),
         ),
       );
+      await tester.pumpAndSettle();
+
       expect(find.text("通知時間の追加"), findsNothing);
-      expect(find.byWidgetPredicate((widget) => Widget is Dismissible),
-          findsNWidgets(3));
+      expect(find.byWidgetPredicate((widget) {
+        print(widget);
+        return true;
+      }), findsWidgets);
     });
   });
 }

--- a/test/setting/reminder_times_widget_test.dart
+++ b/test/setting/reminder_times_widget_test.dart
@@ -13,7 +13,8 @@ void main() {
         new TestViewConfiguration(size: const Size(375.0, 667.0));
   });
   group("appearance widgets dependend on reminderTimes", () {
-    testWidgets('when setting has one reminder times︎',
+    testWidgets(
+        'when setting has one reminder times. one reminder times mean requires minimum count',
         (WidgetTester tester) async {
       await tester.runAsync(() async {
         final store = SettingStateStore(null);
@@ -40,7 +41,44 @@ void main() {
           ),
         );
         expect(find.text("通知時間の追加"), findsOneWidget);
+        expect(find.byWidgetPredicate((widget) => Widget is Dismissible),
+            findsNothing);
       });
+    });
+  });
+  testWidgets('when setting has maximum count reminder times︎',
+      (WidgetTester tester) async {
+    await tester.runAsync(() async {
+      final store = SettingStateStore(null);
+      // ignore: invalid_use_of_protected_member
+      store.state = SettingState(
+        entity: Setting(
+          fromMenstruation: 1,
+          durationMenstruation: 2,
+          isOnReminder: false,
+          pillSheetTypeRawPath: PillSheetType.pillsheet_21.rawPath,
+          reminderTimes: [
+            ReminderTime(hour: 10, minute: 0),
+            ReminderTime(hour: 11, minute: 0),
+            ReminderTime(hour: 12, minute: 0)
+          ],
+        ),
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            settingStoreProvider.overrideWithProvider(
+              Provider(
+                (ref) => store,
+              ),
+            )
+          ],
+          child: MaterialApp(home: ReminderTimes()),
+        ),
+      );
+      expect(find.text("通知時間の追加"), findsNothing);
+      expect(find.byWidgetPredicate((widget) => Widget is Dismissible),
+          findsNWidgets(3));
     });
   });
 }

--- a/test/setting/reminder_times_widget_test.dart
+++ b/test/setting/reminder_times_widget_test.dart
@@ -1,7 +1,6 @@
 import 'package:Pilll/model/pill_sheet_type.dart';
 import 'package:Pilll/model/setting.dart';
 import 'package:Pilll/settings/list/reminder_times.dart';
-import 'package:Pilll/state/setting.dart';
 import 'package:Pilll/store/setting.dart';
 import 'package:Pilll/util/environment.dart';
 import 'package:flutter/material.dart';

--- a/test/setting/reminder_times_widget_test.dart
+++ b/test/setting/reminder_times_widget_test.dart
@@ -51,7 +51,7 @@ void main() {
           child: MaterialApp(home: ReminderTimes()),
         ),
       );
-      await tester.pumpAndSettle();
+      await tester.pumpAndSettle(Duration(milliseconds: 500));
 
       expect(find.text("通知時間の追加"), findsOneWidget);
       expect(find.byWidgetPredicate((widget) => Widget is Dismissible),
@@ -90,7 +90,7 @@ void main() {
           child: MaterialApp(home: ReminderTimes()),
         ),
       );
-      await tester.pumpAndSettle();
+      await tester.pumpAndSettle(Duration(milliseconds: 500));
 
       expect(find.text("通知時間の追加"), findsNothing);
       expect(find.byWidgetPredicate((widget) => widget is Dismissible),

--- a/test/setting/reminder_times_widget_test.dart
+++ b/test/setting/reminder_times_widget_test.dart
@@ -1,0 +1,46 @@
+import 'package:Pilll/model/pill_sheet_type.dart';
+import 'package:Pilll/model/setting.dart';
+import 'package:Pilll/settings/list/reminder_times.dart';
+import 'package:Pilll/state/setting.dart';
+import 'package:Pilll/store/setting.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/all.dart';
+
+void main() {
+  setUp(() {
+    WidgetsBinding.instance.renderView.configuration =
+        new TestViewConfiguration(size: const Size(375.0, 667.0));
+  });
+  group("appearance widgets dependend on reminderTimes", () {
+    testWidgets('when setting has one reminder times︎',
+        (WidgetTester tester) async {
+      await tester.runAsync(() async {
+        final store = SettingStateStore(null);
+        // ignore: invalid_use_of_protected_member
+        store.state = SettingState(
+          entity: Setting(
+            fromMenstruation: 1,
+            durationMenstruation: 2,
+            isOnReminder: false,
+            pillSheetTypeRawPath: PillSheetType.pillsheet_21.rawPath,
+            reminderTimes: [ReminderTime(hour: 10, minute: 0)],
+          ),
+        );
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              settingStoreProvider.overrideWithProvider(
+                Provider(
+                  (ref) => store,
+                ),
+              )
+            ],
+            child: MaterialApp(home: ReminderTimes()),
+          ),
+        );
+        expect(find.text("通知時間の追加"), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/setting/reminder_times_widget_test.dart
+++ b/test/setting/reminder_times_widget_test.dart
@@ -93,10 +93,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text("通知時間の追加"), findsNothing);
-      expect(find.byWidgetPredicate((widget) {
-        print(widget);
-        return widget is Dismissible;
-      }), findsNWidgets(3));
+      expect(find.byWidgetPredicate((widget) => widget is Dismissible),
+          findsNWidgets(3));
     });
   });
 }

--- a/test/setting/store_test.dart
+++ b/test/setting/store_test.dart
@@ -28,6 +28,12 @@ void main() {
         isOnReminder: false,
         pillSheetTypeRawPath: PillSheetType.pillsheet_28_4.rawPath,
       );
+
+      when(service.fetch())
+          .thenAnswer((realInvocation) => Future.value(setting));
+      when(service.subscribe())
+          .thenAnswer((realInvocation) => Stream.value(setting));
+
       final store = SettingStateStore(service);
 
       when(service.update(setting.copyWith(reminderTimes: [
@@ -42,14 +48,19 @@ void main() {
     test(
         "return exception when setting has reminderTimes count is ${ReminderTime.maximumCount}",
         () {
+      final service = MockSettingService();
       final setting = _FakeSetting([
         ReminderTime(hour: 1, minute: 0),
         ReminderTime(hour: 2, minute: 0),
         ReminderTime(hour: 3, minute: 0)
       ]);
-      final store = SettingStateStore(null);
-      // ignore: invalid_use_of_protected_member
-      store.state = SettingState(entity: setting);
+      when(service.fetch())
+          .thenAnswer((realInvocation) => Future.value(setting));
+      when(service.subscribe())
+          .thenAnswer((realInvocation) => Stream.value(setting));
+
+      final store = SettingStateStore(service);
+
       expect(() => store.addReminderTimes(ReminderTime(hour: 4, minute: 0)),
           throwsException);
     });
@@ -67,6 +78,11 @@ void main() {
         isOnReminder: false,
         pillSheetTypeRawPath: PillSheetType.pillsheet_28_4.rawPath,
       );
+      when(service.fetch())
+          .thenAnswer((realInvocation) => Future.value(setting));
+      when(service.subscribe())
+          .thenAnswer((realInvocation) => Stream.value(setting));
+
       final store = SettingStateStore(service);
 
       when(service.update(setting.copyWith(reminderTimes: [
@@ -79,10 +95,16 @@ void main() {
     test(
         "return exception when setting has remindertimes count is ${ReminderTime.minimumCount}",
         () {
+      final service = MockSettingService();
       final setting = _FakeSetting([
         ReminderTime(hour: 1, minute: 0),
       ]);
-      final store = SettingStateStore(null);
+      when(service.fetch())
+          .thenAnswer((realInvocation) => Future.value(setting));
+      when(service.subscribe())
+          .thenAnswer((realInvocation) => Stream.value(setting));
+
+      final store = SettingStateStore(service);
       // ignore: invalid_use_of_protected_member
       store.state = SettingState(entity: setting);
       expect(() => store.deleteReminderTimes(0), throwsException);

--- a/test/setting/store_test.dart
+++ b/test/setting/store_test.dart
@@ -35,6 +35,8 @@ void main() {
           .thenAnswer((realInvocation) => Stream.value(setting));
 
       final store = SettingStateStore(service);
+      // ignore: invalid_use_of_protected_member
+      store.state = SettingState(entity: setting);
 
       when(service.update(setting.copyWith(reminderTimes: [
         ReminderTime(hour: 1, minute: 0),
@@ -60,6 +62,8 @@ void main() {
           .thenAnswer((realInvocation) => Stream.value(setting));
 
       final store = SettingStateStore(service);
+      // ignore: invalid_use_of_protected_member
+      store.state = SettingState(entity: setting);
 
       expect(() => store.addReminderTimes(ReminderTime(hour: 4, minute: 0)),
           throwsException);
@@ -84,6 +88,8 @@ void main() {
           .thenAnswer((realInvocation) => Stream.value(setting));
 
       final store = SettingStateStore(service);
+      // ignore: invalid_use_of_protected_member
+      store.state = SettingState(entity: setting);
 
       when(service.update(setting.copyWith(reminderTimes: [
         ReminderTime(hour: 1, minute: 0),

--- a/test/setting/store_test.dart
+++ b/test/setting/store_test.dart
@@ -29,8 +29,6 @@ void main() {
         pillSheetTypeRawPath: PillSheetType.pillsheet_28_4.rawPath,
       );
       final store = SettingStateStore(service);
-      // ignore: invalid_use_of_protected_member
-      store.state = SettingState(entity: setting);
 
       when(service.update(setting.copyWith(reminderTimes: [
         ReminderTime(hour: 1, minute: 0),
@@ -70,8 +68,6 @@ void main() {
         pillSheetTypeRawPath: PillSheetType.pillsheet_28_4.rawPath,
       );
       final store = SettingStateStore(service);
-      // ignore: invalid_use_of_protected_member
-      store.state = SettingState(entity: setting);
 
       when(service.update(setting.copyWith(reminderTimes: [
         ReminderTime(hour: 1, minute: 0),

--- a/test/setting/store_test.dart
+++ b/test/setting/store_test.dart
@@ -42,7 +42,9 @@ void main() {
       store.addReminderTimes(ReminderTime(hour: 3, minute: 0));
       verify(service.update(setting));
     });
-    test("return exception when ${ReminderTime.maximumCount}", () {
+    test(
+        "return exception when setting has reminderTimes count is ${ReminderTime.maximumCount}",
+        () {
       final setting = _FakeSetting([
         ReminderTime(hour: 1, minute: 0),
         ReminderTime(hour: 2, minute: 0),
@@ -53,6 +55,42 @@ void main() {
       store.state = SettingState(entity: setting);
       expect(() => store.addReminderTimes(ReminderTime(hour: 4, minute: 0)),
           throwsException);
+    });
+  });
+  group("#deleteReminderTimes", () {
+    test("when deleted reminder times ${ReminderTime.maximumCount}", () {
+      final service = MockSettingService();
+      final setting = Setting(
+        reminderTimes: [
+          ReminderTime(hour: 1, minute: 0),
+          ReminderTime(hour: 2, minute: 0),
+        ],
+        durationMenstruation: 1,
+        fromMenstruation: 1,
+        isOnReminder: false,
+        pillSheetTypeRawPath: PillSheetType.pillsheet_28_4.rawPath,
+      );
+      final store = SettingStateStore(service);
+      // ignore: invalid_use_of_protected_member
+      store.state = SettingState(entity: setting);
+
+      when(service.update(setting.copyWith(reminderTimes: [
+        ReminderTime(hour: 1, minute: 0),
+      ]))).thenAnswer((realInvocation) => Future.value(setting));
+
+      store.deleteReminderTimes(1);
+      verify(service.update(setting));
+    });
+    test(
+        "return exception when setting has remindertimes count is ${ReminderTime.minimumCount}",
+        () {
+      final setting = _FakeSetting([
+        ReminderTime(hour: 1, minute: 0),
+      ]);
+      final store = SettingStateStore(null);
+      // ignore: invalid_use_of_protected_member
+      store.state = SettingState(entity: setting);
+      expect(() => store.deleteReminderTimes(0), throwsException);
     });
   });
 }

--- a/test/setting/store_test.dart
+++ b/test/setting/store_test.dart
@@ -1,4 +1,3 @@
-import 'package:Pilll/model/pill_sheet.dart';
 import 'package:Pilll/model/pill_sheet_type.dart';
 import 'package:Pilll/model/setting.dart';
 import 'package:Pilll/state/setting.dart';

--- a/test/setting/store_test.dart
+++ b/test/setting/store_test.dart
@@ -1,0 +1,58 @@
+import 'package:Pilll/model/pill_sheet.dart';
+import 'package:Pilll/model/pill_sheet_type.dart';
+import 'package:Pilll/model/setting.dart';
+import 'package:Pilll/state/setting.dart';
+import 'package:Pilll/store/setting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../helper/mock.dart';
+
+class _FakeSetting extends Fake implements Setting {
+  final List<ReminderTime> fakeReminderTimes;
+  _FakeSetting(this.fakeReminderTimes);
+  @override
+  List<ReminderTime> get reminderTimes => fakeReminderTimes;
+}
+
+void main() {
+  group("#addReminderTimes", () {
+    test("when added reminder times ${ReminderTime.maximumCount}", () {
+      final service = MockSettingService();
+      final setting = Setting(
+        reminderTimes: [
+          ReminderTime(hour: 1, minute: 0),
+          ReminderTime(hour: 2, minute: 0),
+        ],
+        durationMenstruation: 1,
+        fromMenstruation: 1,
+        isOnReminder: false,
+        pillSheetTypeRawPath: PillSheetType.pillsheet_28_4.rawPath,
+      );
+      final store = SettingStateStore(service);
+      // ignore: invalid_use_of_protected_member
+      store.state = SettingState(entity: setting);
+
+      when(service.update(setting.copyWith(reminderTimes: [
+        ReminderTime(hour: 1, minute: 0),
+        ReminderTime(hour: 2, minute: 0),
+        ReminderTime(hour: 3, minute: 0),
+      ]))).thenAnswer((realInvocation) => Future.value(setting));
+
+      store.addReminderTimes(ReminderTime(hour: 3, minute: 0));
+      verify(service.update(setting));
+    });
+    test("return exception when ${ReminderTime.maximumCount}", () {
+      final setting = _FakeSetting([
+        ReminderTime(hour: 1, minute: 0),
+        ReminderTime(hour: 2, minute: 0),
+        ReminderTime(hour: 3, minute: 0)
+      ]);
+      final store = SettingStateStore(null);
+      // ignore: invalid_use_of_protected_member
+      store.state = SettingState(entity: setting);
+      expect(() => store.addReminderTimes(ReminderTime(hour: 4, minute: 0)),
+          throwsException);
+    });
+  });
+}


### PR DESCRIPTION
## What
https://github.com/bannzai/Pilll/pull/38#issuecomment-713348517 で書いたコードのテストコードの追加

> storeの通知時刻の設定時間の数が最低1つだということを保証するテスト書く(Exceptionが帰ってくる
> storeの通知時刻の設定時間の数が上限3つだということを保証するテスト書く(Exceptionが帰ってくる
> WidgetTest でDimissableが出ているかどうかでUI的に削除できるかどうかのテスト書く
> WidgetTest でAdd Buttonが出ているかどうかでUI的に削除できるかどうかのテスト書く

それに伴い store に injectするのは生のserviceにする

## Why
riverpod 等を導入してから書いてなかったので簡単なテストだけど効果的なので書いていく