### PR TITLE
Bugfix about subscribe last pill sheet

### DIFF
--- a/lib/service/pill_sheet.dart
+++ b/lib/service/pill_sheet.dart
@@ -34,12 +34,16 @@ class PillSheetService extends PillSheetServiceInterface {
     return pillSheetModel;
   }
 
-  @override
-  Future<PillSheetModel> fetchLast() {
+  Query _queryOfFetchLastPillSheet() {
     return _database
         .pillSheetsReference()
         .orderBy(PillSheetFirestoreKey.createdAt)
-        .limitToLast(1)
+        .limitToLast(1);
+  }
+
+  @override
+  Future<PillSheetModel> fetchLast() {
+    return _queryOfFetchLastPillSheet()
         .get()
         .then((event) => _filterForLatestPillSheet(event));
   }
@@ -79,10 +83,7 @@ class PillSheetService extends PillSheetServiceInterface {
   }
 
   Stream<PillSheetModel> subscribeForLatestPillSheet() {
-    return _database
-        .pillSheetsReference()
-        .orderBy(PillSheetFirestoreKey.createdAt)
-        .limitToLast(1)
+    return _queryOfFetchLastPillSheet()
         .snapshots()
         .map((event) => _filterForLatestPillSheet(event));
   }

--- a/lib/service/pill_sheet.dart
+++ b/lib/service/pill_sheet.dart
@@ -81,6 +81,8 @@ class PillSheetService extends PillSheetServiceInterface {
   Stream<PillSheetModel> subscribeForLatestPillSheet() {
     return _database
         .pillSheetsReference()
+        .orderBy(PillSheetFirestoreKey.createdAt)
+        .limitToLast(1)
         .snapshots()
         .map((event) => _filterForLatestPillSheet(event));
   }


### PR DESCRIPTION
## What
subscribeしていた最後に作ったピルシートを取得するQueryの条件が間違っていたので修正。created_atの順番で最後の一見だけをフィルタリングするようにした

## Why
ピルシートに対する操作を複数回行うと(ピルシートを複数個)作るとすでに破棄したはずのピルシートデータにたいして処理を行い表示がおかしくなっていた