### PR TITLE
Enhancement UI for modify today pill number

### DIFF
--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -1,7 +1,6 @@
 import 'package:Pilll/components/molecules/indicator.dart';
 import 'package:Pilll/components/organisms/pill/pill_sheet.dart';
 import 'package:Pilll/domain/record/record_taken_information.dart';
-import 'package:Pilll/entity/pill_mark_type.dart';
 import 'package:Pilll/entity/pill_sheet.dart';
 import 'package:Pilll/entity/pill_sheet_type.dart';
 import 'package:Pilll/entity/weekday.dart';

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -239,13 +239,7 @@ class RecordPage extends HookWidget {
           ? Weekday.Sunday
           : WeekdayFunctions.weekdayFromDate(pillSheet.beginingDate),
       pillMarkTypeBuilder: (number) => store.markFor(number),
-      enabledMarkAnimation: (number) {
-        if (number > pillSheet.typeInfo.dosingPeriod) {
-          return false;
-        }
-        return number > pillSheet.lastTakenPillNumber &&
-            number <= pillSheet.todayPillNumber;
-      },
+      enabledMarkAnimation: (number) => store.shouldPillMarkAnimation(number),
       markSelected: (number) {
         if (number <= pillSheet.lastTakenPillNumber) {
           return;

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -239,18 +239,7 @@ class RecordPage extends HookWidget {
       firstWeekday: pillSheet.beginingDate == null
           ? Weekday.Sunday
           : WeekdayFunctions.weekdayFromDate(pillSheet.beginingDate),
-      pillMarkTypeBuilder: (number) {
-        if (number <= pillSheet.lastTakenPillNumber) {
-          return PillMarkType.done;
-        }
-        if (number > pillSheet.typeInfo.dosingPeriod) {
-          return PillMarkType.notTaken;
-        }
-        if (number < pillSheet.todayPillNumber) {
-          return PillMarkType.normal;
-        }
-        return PillMarkType.normal;
-      },
+      pillMarkTypeBuilder: (number) => store.markFor(number),
       enabledMarkAnimation: (number) {
         if (number > pillSheet.typeInfo.dosingPeriod) {
           return false;

--- a/lib/domain/settings/modifing_pill_number.dart
+++ b/lib/domain/settings/modifing_pill_number.dart
@@ -1,17 +1,17 @@
+import 'package:Pilll/components/atoms/buttons.dart';
 import 'package:Pilll/components/organisms/pill/pill_sheet.dart';
 import 'package:Pilll/components/atoms/color.dart';
 import 'package:Pilll/components/atoms/font.dart';
 import 'package:Pilll/components/atoms/text_color.dart';
+import 'package:Pilll/entity/pill_mark_type.dart';
 import 'package:Pilll/util/formatter/date_time_formatter.dart';
 import 'package:flutter/material.dart';
 
 class ModifingPillNumberPage extends StatefulWidget {
-  final PillMarkTypeBuilder pillMarkTypeBuilder;
   final PillMarkSelected markSelected;
 
   const ModifingPillNumberPage({
     Key key,
-    @required this.pillMarkTypeBuilder,
     @required this.markSelected,
   }) : super(key: key);
 
@@ -20,6 +20,7 @@ class ModifingPillNumberPage extends StatefulWidget {
 }
 
 class _ModifingPillNumberPageState extends State<ModifingPillNumberPage> {
+  int selectedPillMarkNumber;
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -49,13 +50,23 @@ class _ModifingPillNumberPageState extends State<ModifingPillNumberPage> {
             SizedBox(height: 56),
             Center(
               child: PillSheet(
-                pillMarkTypeBuilder: widget.pillMarkTypeBuilder,
+                pillMarkTypeBuilder: (number) {
+                  if (selectedPillMarkNumber == number) {
+                    return PillMarkType.selected;
+                  }
+                  return PillMarkType.normal;
+                },
                 enabledMarkAnimation: null,
                 markSelected: (number) {
-                  setState(() => widget.markSelected(number));
+                  setState(() => selectedPillMarkNumber = number);
                 },
               ),
             ),
+            SizedBox(height: 20),
+            PrimaryButton(
+              onPressed: () => widget.markSelected(selectedPillMarkNumber),
+              text: "変更する",
+            )
           ],
         ),
       ),

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -193,9 +193,6 @@ class SettingsPage extends HookWidget {
                         Navigator.pop(context);
                         pillSheetStore.modifyBeginingDate(number);
                       },
-                      pillMarkTypeBuilder: (number) {
-                        return PillMarkType.normal;
-                      },
                     );
                   }));
                 }),

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -71,7 +71,7 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   }
 
   PillMarkType markFor(int number) {
-    if (number <= state.entity.lastTakenPillNumber) {
+    if (number == state.entity.todayPillNumber && !state.entity.allTaken) {
       return PillMarkType.done;
     }
     if (number > state.entity.typeInfo.dosingPeriod) {
@@ -87,7 +87,9 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
     if (number > state.entity.typeInfo.dosingPeriod) {
       return false;
     }
-    return number > state.entity.lastTakenPillNumber &&
-        number <= state.entity.todayPillNumber;
+    if (state.entity.allTaken) {
+      return false;
+    }
+    return number == state.entity.todayPillNumber;
   }
 }

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -71,14 +71,14 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   }
 
   PillMarkType markFor(int number) {
-    if (number == state.entity.todayPillNumber && !state.entity.allTaken) {
+    if (number < state.entity.todayPillNumber) {
+      return PillMarkType.done;
+    }
+    if (number == state.entity.todayPillNumber && state.entity.allTaken) {
       return PillMarkType.done;
     }
     if (number > state.entity.typeInfo.dosingPeriod) {
       return PillMarkType.notTaken;
-    }
-    if (number < state.entity.todayPillNumber) {
-      return PillMarkType.normal;
     }
     return PillMarkType.normal;
   }

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -82,4 +82,12 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
     }
     return PillMarkType.normal;
   }
+
+  bool shouldPillMarkAnimation(int number) {
+    if (number > state.entity.typeInfo.dosingPeriod) {
+      return false;
+    }
+    return number > state.entity.lastTakenPillNumber &&
+        number <= state.entity.todayPillNumber;
+  }
 }

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:Pilll/entity/pill_mark_type.dart';
 import 'package:Pilll/entity/pill_sheet.dart';
 import 'package:Pilll/service/pill_sheet.dart';
 import 'package:Pilll/state/pill_sheet.dart';
@@ -67,5 +68,18 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
 
   void update(PillSheetModel entity) {
     state = state.copyWith(entity: entity);
+  }
+
+  PillMarkType markFor(int number) {
+    if (number <= state.entity.lastTakenPillNumber) {
+      return PillMarkType.done;
+    }
+    if (number > state.entity.typeInfo.dosingPeriod) {
+      return PillMarkType.notTaken;
+    }
+    if (number < state.entity.todayPillNumber) {
+      return PillMarkType.normal;
+    }
+    return PillMarkType.normal;
   }
 }

--- a/test/pill_sheet/pill_sheet_store_test.dart
+++ b/test/pill_sheet/pill_sheet_store_test.dart
@@ -1,3 +1,4 @@
+import 'package:Pilll/entity/pill_mark_type.dart';
 import 'package:Pilll/entity/pill_sheet.dart';
 import 'package:Pilll/entity/pill_sheet_type.dart';
 import 'package:Pilll/service/today.dart';
@@ -63,5 +64,61 @@ void main() {
     final expected = DateTime.parse("2020-11-22");
     final actual = store.calcBeginingDateFromNextTodayPillNumber(2);
     expect(isSameDay(expected, actual), isTrue);
+  });
+  group("#markFor", () {
+    test("it is alredy taken all", () async {
+      final mockTodayRepository = MockTodayRepository();
+      todayRepository = mockTodayRepository;
+      when(todayRepository.today()).thenReturn(DateTime.parse("2020-11-23"));
+
+      final pillSheetEntity =
+          PillSheetModel.create(PillSheetType.pillsheet_21).copyWith(
+        beginingDate: DateTime.parse("2020-11-21"),
+        lastTakenDate: DateTime.parse("2020-11-23"),
+        createdAt: DateTime.parse("2020-11-21"),
+      );
+      final state = PillSheetState(entity: pillSheetEntity);
+
+      final service = MockPillSheetService();
+      when(service.fetchLast())
+          .thenAnswer((realInvocation) => Future.value(state.entity));
+      when(service.subscribeForLatestPillSheet())
+          .thenAnswer((realInvocation) => Stream.empty());
+
+      final store = PillSheetStateStore(service);
+      await Future.delayed(Duration(milliseconds: 100));
+      expect(state.entity.allTaken, isTrue);
+      expect(store.markFor(1), PillMarkType.done);
+      expect(store.markFor(2), PillMarkType.done);
+      expect(store.markFor(3), PillMarkType.done);
+      expect(store.markFor(4), PillMarkType.normal);
+    });
+    test("it is not taken all", () async {
+      final mockTodayRepository = MockTodayRepository();
+      todayRepository = mockTodayRepository;
+      when(todayRepository.today()).thenReturn(DateTime.parse("2020-11-23"));
+
+      final pillSheetEntity =
+          PillSheetModel.create(PillSheetType.pillsheet_21).copyWith(
+        beginingDate: DateTime.parse("2020-11-21"),
+        lastTakenDate: DateTime.parse("2020-11-22"),
+        createdAt: DateTime.parse("2020-11-21"),
+      );
+      final state = PillSheetState(entity: pillSheetEntity);
+
+      final service = MockPillSheetService();
+      when(service.fetchLast())
+          .thenAnswer((realInvocation) => Future.value(state.entity));
+      when(service.subscribeForLatestPillSheet())
+          .thenAnswer((realInvocation) => Stream.empty());
+
+      final store = PillSheetStateStore(service);
+      await Future.delayed(Duration(milliseconds: 100));
+      expect(state.entity.allTaken, isFalse);
+      expect(store.markFor(1), PillMarkType.done);
+      expect(store.markFor(2), PillMarkType.done);
+      expect(store.markFor(3), PillMarkType.normal);
+      expect(store.markFor(4), PillMarkType.normal);
+    });
   });
 }

--- a/test/pill_sheet/pill_sheet_store_test.dart
+++ b/test/pill_sheet/pill_sheet_store_test.dart
@@ -121,4 +121,56 @@ void main() {
       expect(store.markFor(4), PillMarkType.normal);
     });
   });
+  group("#shouldPillMarkAnimation", () {
+    test("it is alredy taken all", () async {
+      final mockTodayRepository = MockTodayRepository();
+      todayRepository = mockTodayRepository;
+      when(todayRepository.today()).thenReturn(DateTime.parse("2020-11-23"));
+
+      final pillSheetEntity =
+          PillSheetModel.create(PillSheetType.pillsheet_21).copyWith(
+        beginingDate: DateTime.parse("2020-11-21"),
+        lastTakenDate: DateTime.parse("2020-11-23"),
+        createdAt: DateTime.parse("2020-11-21"),
+      );
+      final state = PillSheetState(entity: pillSheetEntity);
+
+      final service = MockPillSheetService();
+      when(service.fetchLast())
+          .thenAnswer((realInvocation) => Future.value(state.entity));
+      when(service.subscribeForLatestPillSheet())
+          .thenAnswer((realInvocation) => Stream.empty());
+
+      final store = PillSheetStateStore(service);
+      await Future.delayed(Duration(milliseconds: 100));
+      expect(state.entity.allTaken, isTrue);
+      for (int i = 1; i <= pillSheetEntity.pillSheetType.totalCount; i++) {
+        expect(store.shouldPillMarkAnimation(i), isFalse);
+      }
+    });
+    test("it is not taken all", () async {
+      final mockTodayRepository = MockTodayRepository();
+      todayRepository = mockTodayRepository;
+      when(todayRepository.today()).thenReturn(DateTime.parse("2020-11-23"));
+
+      final pillSheetEntity =
+          PillSheetModel.create(PillSheetType.pillsheet_21).copyWith(
+        beginingDate: DateTime.parse("2020-11-21"),
+        lastTakenDate: DateTime.parse("2020-11-22"),
+        createdAt: DateTime.parse("2020-11-21"),
+      );
+      final state = PillSheetState(entity: pillSheetEntity);
+
+      final service = MockPillSheetService();
+      when(service.fetchLast())
+          .thenAnswer((realInvocation) => Future.value(state.entity));
+      when(service.subscribeForLatestPillSheet())
+          .thenAnswer((realInvocation) => Stream.empty());
+
+      final store = PillSheetStateStore(service);
+      await Future.delayed(Duration(milliseconds: 100));
+      expect(state.entity.allTaken, isFalse);
+      expect(store.shouldPillMarkAnimation(3), isTrue);
+    });
+  });
 }


### PR DESCRIPTION
## What
今日飲むピル番号変更画面において、番号をタップしたらすぐにモーダルが閉じるようにするのではなく、新しく用意した完了ボタンを押した時にDBに書き込む処理にした

## Why
どのピル番号に変更されたのかぱっと見理解しづらいのでワンクッション挟むようにした

## ScreenShot
<img width="320px" src="https://user-images.githubusercontent.com/10897361/99937777-d4551200-2da9-11eb-99a4-4cc1ade049b5.png" />