### PR TITLE
Bugfix for ripple animation

### DIFF
--- a/lib/components/organisms/pill/pill_mark.dart
+++ b/lib/components/organisms/pill/pill_mark.dart
@@ -40,10 +40,8 @@ class _PillMarkState extends State<PillMark> with TickerProviderStateMixin {
 
   @override
   void dispose() {
-    if (widget.hasRippleAnimation) {
-      _controller?.dispose();
-      _controller = null;
-    }
+    _controller?.dispose();
+    _controller = null;
     super.dispose();
   }
 

--- a/lib/components/organisms/pill/pill_mark.dart
+++ b/lib/components/organisms/pill/pill_mark.dart
@@ -25,16 +25,15 @@ class _PillMarkState extends State<PillMark> with TickerProviderStateMixin {
 
   @override
   void initState() {
-    if (widget.hasRippleAnimation) {
-      _controller = AnimationController(
-        duration: const Duration(milliseconds: 2000),
-        vsync: this,
-      );
-      // NOTE: This statement for avoid of tester.pumpAndSettle exception about timeout
-      if (!Environment.isTest) {
-        _controller.repeat();
-      }
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 2000),
+      vsync: this,
+    );
+    // NOTE: This statement for avoid of tester.pumpAndSettle exception about timeout
+    if (!Environment.isTest) {
+      _controller.repeat();
     }
+
     super.initState();
   }
 


### PR DESCRIPTION
## What
animation controllerに対するinstantiateとdisposeのメソッドに対して条件分岐しない

## why
stateful widget だと instantiate 時点animationが必要な条件が一致しないことでリップルアニメーションが発生しない事があるロジックになっていた。たとえばピル番号変更で起きやすい