### PR TITLE
Control events about modify today pill number

### DIFF
--- a/lib/components/organisms/pill/pill_mark.dart
+++ b/lib/components/organisms/pill/pill_mark.dart
@@ -40,10 +40,8 @@ class _PillMarkState extends State<PillMark> with TickerProviderStateMixin {
 
   @override
   void dispose() {
-    if (widget.hasRippleAnimation) {
-      _controller?.dispose();
-      _controller = null;
-    }
+    _controller?.dispose();
+    _controller = null;
     super.dispose();
   }
 

--- a/lib/components/organisms/pill/pill_mark.dart
+++ b/lib/components/organisms/pill/pill_mark.dart
@@ -25,16 +25,15 @@ class _PillMarkState extends State<PillMark> with TickerProviderStateMixin {
 
   @override
   void initState() {
-    if (widget.hasRippleAnimation) {
-      _controller = AnimationController(
-        duration: const Duration(milliseconds: 2000),
-        vsync: this,
-      );
-      // NOTE: This statement for avoid of tester.pumpAndSettle exception about timeout
-      if (!Environment.isTest) {
-        _controller.repeat();
-      }
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 2000),
+      vsync: this,
+    );
+    // NOTE: This statement for avoid of tester.pumpAndSettle exception about timeout
+    if (!Environment.isTest) {
+      _controller.repeat();
     }
+
     super.initState();
   }
 

--- a/lib/domain/settings/modifing_pill_number.dart
+++ b/lib/domain/settings/modifing_pill_number.dart
@@ -64,7 +64,9 @@ class _ModifingPillNumberPageState extends State<ModifingPillNumberPage> {
             ),
             SizedBox(height: 20),
             PrimaryButton(
-              onPressed: () => widget.markSelected(selectedPillMarkNumber),
+              onPressed: selectedPillMarkNumber != null
+                  ? () => widget.markSelected(selectedPillMarkNumber)
+                  : null,
               text: "変更する",
             )
           ],


### PR DESCRIPTION
## What
今日飲むピル番号変更のボタンについて、まだ何も選択されていない場合はボタンを disable 状態にする

## Why
変なデータ送られても困るからdisable状態に。戻りたい場合は左上の戻るボタンから戻って貰う形で