### PR TITLE
Bugfix for register pill sheet when completed initial settings

### DIFF
--- a/lib/domain/initial_setting/initial_setting_4_page.dart
+++ b/lib/domain/initial_setting/initial_setting_4_page.dart
@@ -94,7 +94,7 @@ class InitialSetting4Page extends HookWidget {
                 spacing: 8,
                 children: <Widget>[
                   PrimaryButton(
-                    text: "設定",
+                    text: "完了",
                     onPressed: () {
                       store
                           .register(state.entity.copyWith(isOnReminder: true))

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -1,7 +1,6 @@
 import 'package:Pilll/database/database.dart';
 import 'package:Pilll/components/organisms/pill/pill_sheet_type_select_page.dart';
 import 'package:Pilll/components/organisms/setting/setting_menstruation_page.dart';
-import 'package:Pilll/entity/pill_mark_type.dart';
 import 'package:Pilll/entity/pill_sheet.dart';
 import 'package:Pilll/entity/pill_sheet_type.dart';
 import 'package:Pilll/entity/user.dart';

--- a/lib/entity/initial_setting.dart
+++ b/lib/entity/initial_setting.dart
@@ -11,8 +11,8 @@ part 'initial_setting.freezed.dart';
 abstract class InitialSettingModel implements _$InitialSettingModel {
   InitialSettingModel._();
   factory InitialSettingModel.initial({
-    int fromMenstruation,
-    int durationMenstruation,
+    @Default(2) int fromMenstruation,
+    @Default(4) int durationMenstruation,
     @Default(22) int reminderHour,
     @Default(0) int reminderMinute,
     @Default(false) bool isOnReminder,
@@ -29,11 +29,13 @@ abstract class InitialSettingModel implements _$InitialSettingModel {
         ],
         isOnReminder: isOnReminder,
       );
-  PillSheetModel buildPillSheet() => todayPillNumber != null ? PillSheetModel(
-        beginingDate: _beginingDate(),
-        lastTakenDate: _lastTakenDate(),
-        typeInfo: _typeInfo(),
-      ) : null;
+  PillSheetModel buildPillSheet() => todayPillNumber != null
+      ? PillSheetModel(
+          beginingDate: _beginingDate(),
+          lastTakenDate: _lastTakenDate(),
+          typeInfo: _typeInfo(),
+        )
+      : null;
 
   DateTime _beginingDate() {
     return today().subtract(Duration(days: todayPillNumber - 1));

--- a/lib/entity/initial_setting.dart
+++ b/lib/entity/initial_setting.dart
@@ -29,11 +29,11 @@ abstract class InitialSettingModel implements _$InitialSettingModel {
         ],
         isOnReminder: isOnReminder,
       );
-  PillSheetModel buildPillSheet() => PillSheetModel(
+  PillSheetModel buildPillSheet() => todayPillNumber != null ? PillSheetModel(
         beginingDate: _beginingDate(),
         lastTakenDate: _lastTakenDate(),
         typeInfo: _typeInfo(),
-      );
+      ) : null;
 
   DateTime _beginingDate() {
     return today().subtract(Duration(days: todayPillNumber - 1));

--- a/lib/entity/initial_setting.freezed.dart
+++ b/lib/entity/initial_setting.freezed.dart
@@ -15,8 +15,8 @@ class _$InitialSettingModelTearOff {
 
 // ignore: unused_element
   _InitialSettingModel initial(
-      {int fromMenstruation,
-      int durationMenstruation,
+      {int fromMenstruation = 2,
+      int durationMenstruation = 4,
       int reminderHour = 22,
       int reminderMinute = 0,
       bool isOnReminder = false,
@@ -208,20 +208,24 @@ class __$InitialSettingModelCopyWithImpl<$Res>
 /// @nodoc
 class _$_InitialSettingModel extends _InitialSettingModel {
   _$_InitialSettingModel(
-      {this.fromMenstruation,
-      this.durationMenstruation,
+      {this.fromMenstruation = 2,
+      this.durationMenstruation = 4,
       this.reminderHour = 22,
       this.reminderMinute = 0,
       this.isOnReminder = false,
       this.todayPillNumber,
       this.pillSheetType})
-      : assert(reminderHour != null),
+      : assert(fromMenstruation != null),
+        assert(durationMenstruation != null),
+        assert(reminderHour != null),
         assert(reminderMinute != null),
         assert(isOnReminder != null),
         super._();
 
+  @JsonKey(defaultValue: 2)
   @override
   final int fromMenstruation;
+  @JsonKey(defaultValue: 4)
   @override
   final int durationMenstruation;
   @JsonKey(defaultValue: 22)

--- a/lib/service/initial_setting.dart
+++ b/lib/service/initial_setting.dart
@@ -4,7 +4,7 @@ import 'package:Pilll/service/setting.dart';
 import 'package:riverpod/all.dart';
 
 abstract class InitialSettingServiceInterface {
-  Future<void> register(InitialSettingModel initialSetting) async {
+  Future<void> register(InitialSettingModel initialSetting) {
     throw new UnimplementedError("Should call subclass");
   }
 }
@@ -18,7 +18,7 @@ class InitialSettingService extends InitialSettingServiceInterface {
 
   InitialSettingService(this.settingService, this.pillSheetService);
 
-  Future<void> register(InitialSettingModel initialSetting) async {
+  Future<void> register(InitialSettingModel initialSetting) {
     var setting = initialSetting.buildSetting();
     return settingService.update(setting).then((_) {
       final pillSheet = initialSetting.buildPillSheet();

--- a/lib/service/initial_setting.dart
+++ b/lib/service/initial_setting.dart
@@ -1,25 +1,31 @@
-import 'package:Pilll/database/database.dart';
 import 'package:Pilll/entity/initial_setting.dart';
-import 'package:Pilll/entity/setting.dart';
-import 'package:Pilll/entity/user.dart';
+import 'package:Pilll/service/pill_sheet.dart';
+import 'package:Pilll/service/setting.dart';
 import 'package:riverpod/all.dart';
 
 abstract class InitialSettingInterface {
-  Future<Setting> register(InitialSettingModel initialSetting);
+  Future<void> register(InitialSettingModel initialSetting) async {
+    throw new UnimplementedError("Should call subclass");
+  }
 }
 
-final initialSettingServiceProvider =
-    Provider((ref) => InitialSettingPage(ref.watch(databaseProvider)));
+final initialSettingServiceProvider = Provider((ref) => InitialSettingPage(
+    ref.watch(settingServiceProvider), ref.watch(pillSheetServiceProvider)));
 
 class InitialSettingPage extends InitialSettingInterface {
-  final DatabaseConnection _database;
-  InitialSettingPage(this._database);
+  final SettingServiceInterface settingService;
+  final PillSheetServiceInterface pillSheetService;
 
-  Future<Setting> register(InitialSettingModel initialSetting) {
+  InitialSettingPage(this.settingService, this.pillSheetService);
+
+  Future<void> register(InitialSettingModel initialSetting) async {
     var setting = initialSetting.buildSetting();
-    return _database
-        .userReference()
-        .update({UserFirestoreFieldKeys.settings: setting.toJson()}).then(
-            (_) => setting);
+    return settingService.update(setting).then((_) {
+      final pillSheet = initialSetting.buildPillSheet();
+      if (pillSheet == null) {
+        return Future.value();
+      }
+      return pillSheetService.register(pillSheet);
+    });
   }
 }

--- a/lib/service/initial_setting.dart
+++ b/lib/service/initial_setting.dart
@@ -3,20 +3,20 @@ import 'package:Pilll/service/pill_sheet.dart';
 import 'package:Pilll/service/setting.dart';
 import 'package:riverpod/all.dart';
 
-abstract class InitialSettingInterface {
+abstract class InitialSettingServiceInterface {
   Future<void> register(InitialSettingModel initialSetting) async {
     throw new UnimplementedError("Should call subclass");
   }
 }
 
-final initialSettingServiceProvider = Provider((ref) => InitialSettingPage(
+final initialSettingServiceProvider = Provider((ref) => InitialSettingService(
     ref.watch(settingServiceProvider), ref.watch(pillSheetServiceProvider)));
 
-class InitialSettingPage extends InitialSettingInterface {
+class InitialSettingService extends InitialSettingServiceInterface {
   final SettingServiceInterface settingService;
   final PillSheetServiceInterface pillSheetService;
 
-  InitialSettingPage(this.settingService, this.pillSheetService);
+  InitialSettingService(this.settingService, this.pillSheetService);
 
   Future<void> register(InitialSettingModel initialSetting) async {
     var setting = initialSetting.buildSetting();

--- a/lib/store/initial_setting.dart
+++ b/lib/store/initial_setting.dart
@@ -14,7 +14,7 @@ class InitialSettingStateStore extends StateNotifier<InitialSettingState> {
             InitialSettingModel.initial(),
           ),
         );
-  InitialSettingInterface get _service => _read(initialSettingServiceProvider);
+  InitialSettingServiceInterface get _service => _read(initialSettingServiceProvider);
 
   void modify(InitialSettingModel Function(InitialSettingModel model) closure) {
     state = state.copyWith(entity: closure(state.entity));

--- a/lib/store/setting.dart
+++ b/lib/store/setting.dart
@@ -65,15 +65,21 @@ class SettingStateStore extends StateNotifier<SettingState> {
   }
 
   void addReminderTimes(ReminderTime reminderTime) {
-    _modifyReminderTimes(state.entity.reminderTimes..add(reminderTime));
+    List<ReminderTime> copied = [...state.entity.reminderTimes];
+    copied.add(reminderTime);
+    _modifyReminderTimes(copied);
   }
 
   void editReminderTime(int index, ReminderTime reminderTime) {
-    _modifyReminderTimes(state.entity.reminderTimes..[index] = reminderTime);
+    List<ReminderTime> copied = [...state.entity.reminderTimes];
+    copied[index] = reminderTime;
+    _modifyReminderTimes(copied);
   }
 
   void deleteReminderTimes(int index) {
-    _modifyReminderTimes(state.entity.reminderTimes..removeAt(index));
+    List<ReminderTime> copied = [...state.entity.reminderTimes];
+    copied.removeAt(index);
+    _modifyReminderTimes(copied);
   }
 
   void modifyIsOnReminder(bool isOnReminder) {

--- a/test/domain/settings/store_test.dart
+++ b/test/domain/settings/store_test.dart
@@ -45,7 +45,11 @@ void main() {
       ]))).thenAnswer((realInvocation) => Future.value(setting));
 
       store.addReminderTimes(ReminderTime(hour: 3, minute: 0));
-      verify(service.update(setting));
+      verify(service.update(setting.copyWith(reminderTimes: [
+        ReminderTime(hour: 1, minute: 0),
+        ReminderTime(hour: 2, minute: 0),
+        ReminderTime(hour: 3, minute: 0),
+      ])));
     });
     test(
         "return exception when setting has reminderTimes count is ${ReminderTime.maximumCount}",
@@ -96,7 +100,9 @@ void main() {
       ]))).thenAnswer((realInvocation) => Future.value(setting));
 
       store.deleteReminderTimes(1);
-      verify(service.update(setting));
+      verify(service.update(setting.copyWith(reminderTimes: [
+        ReminderTime(hour: 1, minute: 0),
+      ])));
     });
     test(
         "return exception when setting has remindertimes count is ${ReminderTime.minimumCount}",

--- a/test/service/initial_setting_test.dart
+++ b/test/service/initial_setting_test.dart
@@ -1,0 +1,56 @@
+import 'package:Pilll/entity/initial_setting.dart';
+import 'package:Pilll/entity/pill_sheet.dart';
+import 'package:Pilll/entity/pill_sheet_type.dart';
+import 'package:Pilll/entity/setting.dart';
+import 'package:Pilll/service/initial_setting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../helper/mock.dart';
+
+void main() {
+  group("#register", () {
+    test("when today pill number is not null", () async {
+      final initialSetting = InitialSettingModel.initial(
+        todayPillNumber: 1,
+        pillSheetType: PillSheetType.pillsheet_21,
+      );
+      final settingService = MockSettingService();
+      final settingEntity = initialSetting.buildSetting();
+      when(settingService.update(settingEntity))
+          .thenAnswer((realInvocation) => Future.value(settingEntity));
+
+      final pillSheetEntity = initialSetting.buildPillSheet();
+      final pillSheetService = MockPillSheetService();
+      when(pillSheetService.register(any))
+          .thenAnswer((realInvocation) => Future.value(pillSheetEntity));
+
+      final service = InitialSettingService(settingService, pillSheetService);
+      await service.register(initialSetting);
+
+      verify(settingService.update(settingEntity));
+      verify(pillSheetService.register(any));
+    });
+    test("when today pill number is null", () async {
+      final initialSetting = InitialSettingModel.initial(
+        todayPillNumber: null,
+        pillSheetType: PillSheetType.pillsheet_21,
+      );
+      final settingService = MockSettingService();
+      final settingEntity = initialSetting.buildSetting();
+      when(settingService.update(settingEntity))
+          .thenAnswer((realInvocation) => Future.value(settingEntity));
+
+      final pillSheetEntity = initialSetting.buildPillSheet();
+      final pillSheetService = MockPillSheetService();
+      when(pillSheetService.register(any))
+          .thenAnswer((realInvocation) => Future.value(pillSheetEntity));
+
+      final service = InitialSettingService(settingService, pillSheetService);
+      await service.register(initialSetting);
+
+      verify(settingService.update(settingEntity));
+      verifyNever(pillSheetService.register(any));
+    });
+  });
+}


### PR DESCRIPTION
## What
- 初期設定が終わってもピルシートが作られないバグを修正
- 初期設定の整理期間にデフォルト値を設ける。今は適当に 2 日目から 4 日続くにしている
- 初期設定の最後のページのボタンの文言を `完了` にする