### PR TITLE
Fix project configurations

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -8,3 +8,4 @@ GeneratedPluginRegistrant.java
 google-services.json
 _google-services.json
 key.properties
+_key.properties

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -2,5 +2,3 @@
 #include "Generated.xcconfig"
 
 OTHER_SWIFT_FLAGS = $(inherited) "-D" "DEBUG"
-PRODUCT_BUNDLE_IDENTIFIER=com.mizuki.Ohashi.Pilll.development
-DISPLAY_NAME=Pilll-dev

--- a/ios/Flutter/Development.xcconfig
+++ b/ios/Flutter/Development.xcconfig
@@ -1,1 +1,3 @@
 FLUTTER_FLAVOR=Development
+PRODUCT_BUNDLE_IDENTIFIER=com.mizuki.Ohashi.Pilll.development
+DISPLAY_NAME=Pilll-dev

--- a/ios/Flutter/Production.xcconfig
+++ b/ios/Flutter/Production.xcconfig
@@ -1,1 +1,3 @@
 FLUTTER_FLAVOR=Production
+PRODUCT_BUNDLE_IDENTIFIER=com.mizuki.Ohashi.Pilll
+DISPLAY_NAME=Pilll

--- a/ios/Flutter/Release-Development.xcconfig
+++ b/ios/Flutter/Release-Development.xcconfig
@@ -1,6 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
-#include "Generated.xcconfig"
-TRACK_WIDGET_CREATION=
-PRODUCT_BUNDLE_IDENTIFIER=com.mizuki.Ohashi.Pilll.adhoc
-DISPLAY_NAME=Pilll.AdHoc
+#include "Release.xcconfig"
 #include "Development.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -2,5 +2,3 @@
 #include "Generated.xcconfig"
 
 TRACK_WIDGET_CREATION=
-PRODUCT_BUNDLE_IDENTIFIER=com.mizuki.Ohashi.Pilll
-DISPLAY_NAME=Pilll

--- a/ios/scripts/prepare_firebase_config.sh
+++ b/ios/scripts/prepare_firebase_config.sh
@@ -5,10 +5,10 @@ DIR=$CWD/../Firebase
 echo "Replacing for $CONFIGURATION"
 if [[ $CONFIGURATION == *"Development" ]]; then
     cp $DIR/GoogleService-Info-Development.plist $DIR/GoogleService-Info.plist
-elif [[ $CONFIGURATION == "Debug"* ]]; then
-    cp $DIR/GoogleService-Info-Development.plist $DIR/GoogleService-Info.plist
 elif [[ $CONFIGURATION == *"Production" ]]; then
     cp $DIR/GoogleService-Info-Production.plist $DIR/GoogleService-Info.plist
+elif [[ $CONFIGURATION == "Debug"* ]]; then
+    cp $DIR/GoogleService-Info-Development.plist $DIR/GoogleService-Info.plist
 elif [[ $CONFIGURATION == "Release"* ]]; then
     cp $DIR/GoogleService-Info-Production.plist $DIR/GoogleService-Info.plist
 else


### PR DESCRIPTION
## What
- _keystore.propertiesをgitigrnoreに追加
- iOSのxcconfigを全体的に修正
  * Bundle Identifier の .AdHocの廃止

## Why
きっかけはもともとAdHoc用のbundle identifierを用意していたが、identifierを変えたことによりPush通知の証明書の設定が無効になってしまった。
development用と一緒なidentifierでよいか。と思ったので直したが、よく読み直したらもともとの意図とは別の設定になっていたのでついでにそれも直した

- DevelopmentとProductionを対にする
  * GoogleService-Info.plistの設定を環境ごとにわける
  * Bundle Identifierをわける
  * DisplayNameをわける
- DebugとReleaseを対にする
  * Bulid Environmentの最適化オプションの設定など