### PR TITLE
Fix generate key of user.privates

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -1,5 +1,6 @@
 import 'package:Pilll/auth/auth.dart';
 import 'package:Pilll/entity/diary.dart';
+import 'package:Pilll/entity/user.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:hooks_riverpod/all.dart';
 
@@ -52,9 +53,10 @@ class DatabaseConnection {
       .collection(_CollectionPath.diaries(_userID))
       .doc(diary.id);
 
-  DocumentReference userPrivateReference() => FirebaseFirestore.instance
-      .collection(_CollectionPath.userPrivates(_userID))
-      .doc(_userID);
+  DocumentReference userPrivateReference(User user) =>
+      FirebaseFirestore.instance
+          .collection(_CollectionPath.userPrivates(_userID))
+          .doc(user.privateDocumentID);
 
   Future<T> transaction<T>(TransactionHandler<T> transactionHandler) {
     return FirebaseFirestore.instance.runTransaction(transactionHandler);

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -1,6 +1,5 @@
 import 'package:Pilll/auth/auth.dart';
 import 'package:Pilll/entity/diary.dart';
-import 'package:Pilll/entity/user.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:hooks_riverpod/all.dart';
 
@@ -53,8 +52,9 @@ class DatabaseConnection {
       .collection(_CollectionPath.diaries(_userID))
       .doc(diary.id);
 
-  CollectionReference userPrivatesReference() => FirebaseFirestore.instance
-      .collection(_CollectionPath.userPrivates(_userID));
+  DocumentReference userPrivateReference() => FirebaseFirestore.instance
+      .collection(_CollectionPath.userPrivates(_userID))
+      .doc(_userID);
 
   Future<T> transaction<T>(TransactionHandler<T> transactionHandler) {
     return FirebaseFirestore.instance.runTransaction(transactionHandler);

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -1,5 +1,6 @@
 import 'package:Pilll/auth/auth.dart';
 import 'package:Pilll/entity/diary.dart';
+import 'package:Pilll/entity/user.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:hooks_riverpod/all.dart';
 
@@ -52,9 +53,8 @@ class DatabaseConnection {
       .collection(_CollectionPath.diaries(_userID))
       .doc(diary.id);
 
-  DocumentReference userPrivateReference() => FirebaseFirestore.instance
-      .collection(_CollectionPath.userPrivates(_userID))
-      .doc(_userID);
+  CollectionReference userPrivatesReference() => FirebaseFirestore.instance
+      .collection(_CollectionPath.userPrivates(_userID));
 
   Future<T> transaction<T>(TransactionHandler<T> transactionHandler) {
     return FirebaseFirestore.instance.runTransaction(transactionHandler);

--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -20,11 +20,12 @@ class Root extends HookWidget {
     return useProvider(authStateChangesProvider).when(data: (authInfo) {
       print("when success: ${authInfo.uid}");
       final userService = UserService(DatabaseConnection(authInfo.uid));
-      userService.prepare().then((_) {
+      userService.prepare().then((user) {
         return FirebaseMessaging()
             .getToken()
             .then(
-              (token) => userService.registerRemoteNotificationToken(token),
+              (token) =>
+                  userService.registerRemoteNotificationToken(user, token),
             )
             .then(
               (_) => userService.fetch(),

--- a/lib/entity/pill_sheet_type.dart
+++ b/lib/entity/pill_sheet_type.dart
@@ -11,11 +11,11 @@ extension PillSheetTypeFunctions on PillSheetType {
   static final String firestoreCollectionPath = "pill_sheet_types";
   static PillSheetType fromRawPath(String rawPath) {
     switch (rawPath) {
-      case "21錠タイプ":
+      case "pillsheet_21":
         return PillSheetType.pillsheet_21;
-      case "28錠タイプ(4錠偽薬)":
+      case "pillsheet_28_4":
         return PillSheetType.pillsheet_28_4;
-      case "28錠タイプ(7錠偽薬)":
+      case "pillsheet_28_7":
         return PillSheetType.pillsheet_28_7;
       default:
         assert(false);
@@ -37,7 +37,19 @@ extension PillSheetTypeFunctions on PillSheetType {
     }
   }
 
-  String get rawPath => name;
+  String get rawPath {
+    switch (this) {
+      case PillSheetType.pillsheet_21:
+        return "pillsheet_21";
+      case PillSheetType.pillsheet_28_4:
+        return "pillsheet_28_4";
+      case PillSheetType.pillsheet_28_7:
+        return "pillsheet_28_7";
+      default:
+        throw ArgumentError.notNull(
+            "unexpected null value for PillSheetType.rawPath");
+    }
+  }
 
   List<String> get examples {
     switch (this) {

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -21,6 +21,7 @@ class UserAlreadyExists implements Exception {
 
 extension UserPrivateFirestoreFieldKeys on String {
   static final fcmToken = 'fcmToken';
+  static final id = 'id';
 }
 
 @freezed
@@ -43,6 +44,8 @@ extension UserFirestoreFieldKeys on String {
 @freezed
 abstract class User implements _$User {
   String get documentID => anonymouseUserID;
+  String get privateDocumentID =>
+      documentID + "_${createdAt.toUtc().millisecondsSinceEpoch}";
 
   User._();
   factory User({

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -36,6 +36,7 @@ abstract class UserPrivate implements _$UserPrivate {
 extension UserFirestoreFieldKeys on String {
   static final anonymouseUserID = "anonymouseUserID";
   static final settings = "settings";
+  static final createdAt = "createdAt";
 }
 
 @freezed

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -20,7 +20,6 @@ class UserAlreadyExists implements Exception {
 
 extension UserPrivateFirestoreFieldKeys on String {
   static final fcmToken = 'fcmToken';
-  static final createdAt = "createdAt";
 }
 
 @freezed
@@ -37,6 +36,7 @@ abstract class UserPrivate implements _$UserPrivate {
 extension UserFirestoreFieldKeys on String {
   static final anonymouseUserID = "anonymouseUserID";
   static final settings = "settings";
+  static final createdAt = "createdAt";
 }
 
 @freezed

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -1,3 +1,4 @@
+import 'package:Pilll/entity/firestore_timestamp_converter.dart';
 import 'package:Pilll/entity/setting.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -45,8 +46,16 @@ abstract class User implements _$User {
 
   User._();
   factory User({
-    @required String anonymouseUserID,
-    @JsonKey(name: "settings") Setting setting,
+    @required
+        String anonymouseUserID,
+    @JsonKey(name: "settings")
+        Setting setting,
+    @JsonKey(
+      fromJson: TimestampConverter.timestampToDateTime,
+      toJson: TimestampConverter.dateTimeToTimestamp,
+    )
+    @required
+        DateTime createdAt,
   }) = _User;
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -20,6 +20,7 @@ class UserAlreadyExists implements Exception {
 
 extension UserPrivateFirestoreFieldKeys on String {
   static final fcmToken = 'fcmToken';
+  static final createdAt = "createdAt";
 }
 
 @freezed
@@ -36,7 +37,6 @@ abstract class UserPrivate implements _$UserPrivate {
 extension UserFirestoreFieldKeys on String {
   static final anonymouseUserID = "anonymouseUserID";
   static final settings = "settings";
-  static final createdAt = "createdAt";
 }
 
 @freezed

--- a/lib/entity/user.freezed.dart
+++ b/lib/entity/user.freezed.dart
@@ -160,11 +160,17 @@ class _$UserTearOff {
 
 // ignore: unused_element
   _User call(
-      {@required String anonymouseUserID,
-      @JsonKey(name: "settings") Setting setting}) {
+      {@required
+          String anonymouseUserID,
+      @JsonKey(name: "settings")
+          Setting setting,
+      @required
+      @JsonKey(fromJson: TimestampConverter.timestampToDateTime, toJson: TimestampConverter.dateTimeToTimestamp)
+          DateTime createdAt}) {
     return _User(
       anonymouseUserID: anonymouseUserID,
       setting: setting,
+      createdAt: createdAt,
     );
   }
 
@@ -183,6 +189,10 @@ mixin _$User {
   String get anonymouseUserID;
   @JsonKey(name: "settings")
   Setting get setting;
+  @JsonKey(
+      fromJson: TimestampConverter.timestampToDateTime,
+      toJson: TimestampConverter.dateTimeToTimestamp)
+  DateTime get createdAt;
 
   Map<String, dynamic> toJson();
   $UserCopyWith<User> get copyWith;
@@ -193,7 +203,11 @@ abstract class $UserCopyWith<$Res> {
   factory $UserCopyWith(User value, $Res Function(User) then) =
       _$UserCopyWithImpl<$Res>;
   $Res call(
-      {String anonymouseUserID, @JsonKey(name: "settings") Setting setting});
+      {String anonymouseUserID,
+      @JsonKey(name: "settings")
+          Setting setting,
+      @JsonKey(fromJson: TimestampConverter.timestampToDateTime, toJson: TimestampConverter.dateTimeToTimestamp)
+          DateTime createdAt});
 
   $SettingCopyWith<$Res> get setting;
 }
@@ -210,12 +224,15 @@ class _$UserCopyWithImpl<$Res> implements $UserCopyWith<$Res> {
   $Res call({
     Object anonymouseUserID = freezed,
     Object setting = freezed,
+    Object createdAt = freezed,
   }) {
     return _then(_value.copyWith(
       anonymouseUserID: anonymouseUserID == freezed
           ? _value.anonymouseUserID
           : anonymouseUserID as String,
       setting: setting == freezed ? _value.setting : setting as Setting,
+      createdAt:
+          createdAt == freezed ? _value.createdAt : createdAt as DateTime,
     ));
   }
 
@@ -236,7 +253,11 @@ abstract class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
       __$UserCopyWithImpl<$Res>;
   @override
   $Res call(
-      {String anonymouseUserID, @JsonKey(name: "settings") Setting setting});
+      {String anonymouseUserID,
+      @JsonKey(name: "settings")
+          Setting setting,
+      @JsonKey(fromJson: TimestampConverter.timestampToDateTime, toJson: TimestampConverter.dateTimeToTimestamp)
+          DateTime createdAt});
 
   @override
   $SettingCopyWith<$Res> get setting;
@@ -255,12 +276,15 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
   $Res call({
     Object anonymouseUserID = freezed,
     Object setting = freezed,
+    Object createdAt = freezed,
   }) {
     return _then(_User(
       anonymouseUserID: anonymouseUserID == freezed
           ? _value.anonymouseUserID
           : anonymouseUserID as String,
       setting: setting == freezed ? _value.setting : setting as Setting,
+      createdAt:
+          createdAt == freezed ? _value.createdAt : createdAt as DateTime,
     ));
   }
 }
@@ -270,9 +294,15 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
 /// @nodoc
 class _$_User extends _User {
   _$_User(
-      {@required this.anonymouseUserID,
-      @JsonKey(name: "settings") this.setting})
+      {@required
+          this.anonymouseUserID,
+      @JsonKey(name: "settings")
+          this.setting,
+      @required
+      @JsonKey(fromJson: TimestampConverter.timestampToDateTime, toJson: TimestampConverter.dateTimeToTimestamp)
+          this.createdAt})
       : assert(anonymouseUserID != null),
+        assert(createdAt != null),
         super._();
 
   factory _$_User.fromJson(Map<String, dynamic> json) =>
@@ -283,10 +313,15 @@ class _$_User extends _User {
   @override
   @JsonKey(name: "settings")
   final Setting setting;
+  @override
+  @JsonKey(
+      fromJson: TimestampConverter.timestampToDateTime,
+      toJson: TimestampConverter.dateTimeToTimestamp)
+  final DateTime createdAt;
 
   @override
   String toString() {
-    return 'User(anonymouseUserID: $anonymouseUserID, setting: $setting)';
+    return 'User(anonymouseUserID: $anonymouseUserID, setting: $setting, createdAt: $createdAt)';
   }
 
   @override
@@ -297,14 +332,19 @@ class _$_User extends _User {
                 const DeepCollectionEquality()
                     .equals(other.anonymouseUserID, anonymouseUserID)) &&
             (identical(other.setting, setting) ||
-                const DeepCollectionEquality().equals(other.setting, setting)));
+                const DeepCollectionEquality()
+                    .equals(other.setting, setting)) &&
+            (identical(other.createdAt, createdAt) ||
+                const DeepCollectionEquality()
+                    .equals(other.createdAt, createdAt)));
   }
 
   @override
   int get hashCode =>
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(anonymouseUserID) ^
-      const DeepCollectionEquality().hash(setting);
+      const DeepCollectionEquality().hash(setting) ^
+      const DeepCollectionEquality().hash(createdAt);
 
   @override
   _$UserCopyWith<_User> get copyWith =>
@@ -319,8 +359,13 @@ class _$_User extends _User {
 abstract class _User extends User {
   _User._() : super._();
   factory _User(
-      {@required String anonymouseUserID,
-      @JsonKey(name: "settings") Setting setting}) = _$_User;
+      {@required
+          String anonymouseUserID,
+      @JsonKey(name: "settings")
+          Setting setting,
+      @required
+      @JsonKey(fromJson: TimestampConverter.timestampToDateTime, toJson: TimestampConverter.dateTimeToTimestamp)
+          DateTime createdAt}) = _$_User;
 
   factory _User.fromJson(Map<String, dynamic> json) = _$_User.fromJson;
 
@@ -329,6 +374,11 @@ abstract class _User extends User {
   @override
   @JsonKey(name: "settings")
   Setting get setting;
+  @override
+  @JsonKey(
+      fromJson: TimestampConverter.timestampToDateTime,
+      toJson: TimestampConverter.dateTimeToTimestamp)
+  DateTime get createdAt;
   @override
   _$UserCopyWith<_User> get copyWith;
 }

--- a/lib/entity/user.g.dart
+++ b/lib/entity/user.g.dart
@@ -23,10 +23,13 @@ _$_User _$_$_UserFromJson(Map<String, dynamic> json) {
     setting: json['settings'] == null
         ? null
         : Setting.fromJson(json['settings'] as Map<String, dynamic>),
+    createdAt:
+        TimestampConverter.timestampToDateTime(json['createdAt'] as Timestamp),
   );
 }
 
 Map<String, dynamic> _$_$_UserToJson(_$_User instance) => <String, dynamic>{
       'anonymouseUserID': instance.anonymouseUserID,
       'settings': instance.setting,
+      'createdAt': TimestampConverter.dateTimeToTimestamp(instance.createdAt),
     };

--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -53,6 +53,7 @@ class UserService extends UserServiceInterface {
       {
         UserFirestoreFieldKeys.anonymouseUserID:
             auth.FirebaseAuth.instance.currentUser.uid,
+        UserFirestoreFieldKeys.createdAt: DateTime.now(),
       },
       SetOptions(merge: true),
     );

--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -59,11 +59,9 @@ class UserService extends UserServiceInterface {
   }
 
   Future<void> registerRemoteNotificationToken(String token) {
-    return _database.userPrivatesReference().doc().set(
-      {
-        UserPrivateFirestoreFieldKeys.fcmToken: token,
-        UserPrivateFirestoreFieldKeys.createdAt: DateTime.now(),
-      },
+    print("token: $token");
+    return _database.userPrivateReference().set(
+      {UserPrivateFirestoreFieldKeys.fcmToken: token},
       SetOptions(merge: true),
     );
   }

--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -59,9 +59,11 @@ class UserService extends UserServiceInterface {
   }
 
   Future<void> registerRemoteNotificationToken(String token) {
-    print("token: $token");
-    return _database.userPrivateReference().set(
-      {UserPrivateFirestoreFieldKeys.fcmToken: token},
+    return _database.userPrivatesReference().doc().set(
+      {
+        UserPrivateFirestoreFieldKeys.fcmToken: token,
+        UserPrivateFirestoreFieldKeys.createdAt: DateTime.now(),
+      },
       SetOptions(merge: true),
     );
   }

--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -60,7 +60,6 @@ class UserService extends UserServiceInterface {
   }
 
   Future<void> registerRemoteNotificationToken(String token) {
-    print("token: $token");
     return _database.userPrivateReference().set(
       {UserPrivateFirestoreFieldKeys.fcmToken: token},
       SetOptions(merge: true),

--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -8,7 +8,7 @@ abstract class UserServiceInterface {
   Future<User> prepare();
   Future<User> fetch();
   Future<User> subscribe();
-  Future<void> registerRemoteNotificationToken(String token);
+  Future<void> registerRemoteNotificationToken(User user, String token);
 }
 
 final userServiceProvider =
@@ -49,18 +49,29 @@ class UserService extends UserServiceInterface {
   }
 
   Future<void> _create() {
-    return _database.userReference().set(
-      {
-        UserFirestoreFieldKeys.anonymouseUserID:
-            auth.FirebaseAuth.instance.currentUser.uid,
-        UserFirestoreFieldKeys.createdAt: DateTime.now(),
-      },
-      SetOptions(merge: true),
-    );
+    return _database
+        .userReference()
+        .set(
+          {
+            UserFirestoreFieldKeys.anonymouseUserID:
+                auth.FirebaseAuth.instance.currentUser.uid,
+            UserFirestoreFieldKeys.createdAt: DateTime.now(),
+          },
+          SetOptions(merge: true),
+        )
+        .then((_) => fetch())
+        .then((user) {
+          return _database.userPrivateReference(user).set(
+            {
+              UserPrivateFirestoreFieldKeys.id: user.privateDocumentID,
+            },
+            SetOptions(merge: true),
+          );
+        });
   }
 
-  Future<void> registerRemoteNotificationToken(String token) {
-    return _database.userPrivateReference().set(
+  Future<void> registerRemoteNotificationToken(User user, String token) {
+    return _database.userPrivateReference(user).set(
       {UserPrivateFirestoreFieldKeys.fcmToken: token},
       SetOptions(merge: true),
     );


### PR DESCRIPTION
## What
user/privatesのidをクライアントからのcreated_atを符号化したものとidをもとに作成する

## Why
さすがにuser/:idだけがわかっている状態だけだと脆弱なのでcreated_atもつけるようにする。まあ今の所privateと書いておきながら漏れてもそんなに大きな影響があるものはないが...