### PR TITLE
Add migrate function to Flutter

### DIFF
--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -30,7 +30,7 @@ class Root extends HookWidget {
               (_) => userService.fetch(),
             )
             .then((user) {
-          _transition(context, user);
+          _transition(context, user, userService);
         });
       });
       return Scaffold(
@@ -53,9 +53,14 @@ class Root extends HookWidget {
     });
   }
 
-  void _transition(BuildContext context, User user) async {
-    if (user.setting == null) {
-      Navigator.popAndPushNamed(context, Routes.initialSetting);
+  void _transition(
+      BuildContext context, User user, UserServiceInterface service) async {
+    if (!user.migratedFlutter) {
+      service
+          .deleteSettings()
+          .then((_) => service.setFlutterMigrationFlag())
+          .then(
+              (_) => Navigator.popAndPushNamed(context, Routes.initialSetting));
       return;
     }
     final storage = await SharedPreferences.getInstance();

--- a/lib/entity/initial_setting.freezed.dart
+++ b/lib/entity/initial_setting.freezed.dart
@@ -49,9 +49,9 @@ mixin _$InitialSettingModel {
   PillSheetType get pillSheetType;
 
   @optionalTypeArgs
-  Result when<Result extends Object>({
+  TResult when<TResult extends Object>({
     @required
-        Result initial(
+        TResult initial(
             int fromMenstruation,
             int durationMenstruation,
             int reminderHour,
@@ -61,8 +61,8 @@ mixin _$InitialSettingModel {
             PillSheetType pillSheetType),
   });
   @optionalTypeArgs
-  Result maybeWhen<Result extends Object>({
-    Result initial(
+  TResult maybeWhen<TResult extends Object>({
+    TResult initial(
         int fromMenstruation,
         int durationMenstruation,
         int reminderHour,
@@ -70,16 +70,16 @@ mixin _$InitialSettingModel {
         bool isOnReminder,
         int todayPillNumber,
         PillSheetType pillSheetType),
-    @required Result orElse(),
+    @required TResult orElse(),
   });
   @optionalTypeArgs
-  Result map<Result extends Object>({
-    @required Result initial(_InitialSettingModel value),
+  TResult map<TResult extends Object>({
+    @required TResult initial(_InitialSettingModel value),
   });
   @optionalTypeArgs
-  Result maybeMap<Result extends Object>({
-    Result initial(_InitialSettingModel value),
-    @required Result orElse(),
+  TResult maybeMap<TResult extends Object>({
+    TResult initial(_InitialSettingModel value),
+    @required TResult orElse(),
   });
 
   $InitialSettingModelCopyWith<InitialSettingModel> get copyWith;
@@ -292,9 +292,9 @@ class _$_InitialSettingModel extends _InitialSettingModel {
 
   @override
   @optionalTypeArgs
-  Result when<Result extends Object>({
+  TResult when<TResult extends Object>({
     @required
-        Result initial(
+        TResult initial(
             int fromMenstruation,
             int durationMenstruation,
             int reminderHour,
@@ -310,8 +310,8 @@ class _$_InitialSettingModel extends _InitialSettingModel {
 
   @override
   @optionalTypeArgs
-  Result maybeWhen<Result extends Object>({
-    Result initial(
+  TResult maybeWhen<TResult extends Object>({
+    TResult initial(
         int fromMenstruation,
         int durationMenstruation,
         int reminderHour,
@@ -319,7 +319,7 @@ class _$_InitialSettingModel extends _InitialSettingModel {
         bool isOnReminder,
         int todayPillNumber,
         PillSheetType pillSheetType),
-    @required Result orElse(),
+    @required TResult orElse(),
   }) {
     assert(orElse != null);
     if (initial != null) {
@@ -331,8 +331,8 @@ class _$_InitialSettingModel extends _InitialSettingModel {
 
   @override
   @optionalTypeArgs
-  Result map<Result extends Object>({
-    @required Result initial(_InitialSettingModel value),
+  TResult map<TResult extends Object>({
+    @required TResult initial(_InitialSettingModel value),
   }) {
     assert(initial != null);
     return initial(this);
@@ -340,9 +340,9 @@ class _$_InitialSettingModel extends _InitialSettingModel {
 
   @override
   @optionalTypeArgs
-  Result maybeMap<Result extends Object>({
-    Result initial(_InitialSettingModel value),
-    @required Result orElse(),
+  TResult maybeMap<TResult extends Object>({
+    TResult initial(_InitialSettingModel value),
+    @required TResult orElse(),
   }) {
     assert(orElse != null);
     if (initial != null) {

--- a/lib/entity/setting.dart
+++ b/lib/entity/setting.dart
@@ -31,13 +31,6 @@ abstract class ReminderTime implements _$ReminderTime {
 
 @freezed
 abstract class Setting implements _$Setting {
-  static final requiredFirestoreKeys = [
-    "pillSheetTypeRawPath",
-    "fromMenstruation",
-    "durationMenstruation",
-    "reminderTimes",
-    "isOnReminder"
-  ];
   Setting._();
   @JsonSerializable(explicitToJson: true)
   factory Setting({

--- a/lib/entity/setting.dart
+++ b/lib/entity/setting.dart
@@ -31,6 +31,13 @@ abstract class ReminderTime implements _$ReminderTime {
 
 @freezed
 abstract class Setting implements _$Setting {
+  static final requiredFirestoreKeys = [
+    "pillSheetTypeRawPath",
+    "fromMenstruation",
+    "durationMenstruation",
+    "reminderTimes",
+    "isOnReminder"
+  ];
   Setting._();
   @JsonSerializable(explicitToJson: true)
   factory Setting({

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -36,7 +36,6 @@ abstract class UserPrivate implements _$UserPrivate {
 extension UserFirestoreFieldKeys on String {
   static final anonymouseUserID = "anonymouseUserID";
   static final settings = "settings";
-  static final migratedFlutter = "migratedFlutter";
 }
 
 @freezed
@@ -47,7 +46,6 @@ abstract class User implements _$User {
   factory User({
     @required String anonymouseUserID,
     @JsonKey(name: "settings") Setting setting,
-    @Default(false) bool migratedFlutter,
   }) = _User;
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -36,6 +36,7 @@ abstract class UserPrivate implements _$UserPrivate {
 extension UserFirestoreFieldKeys on String {
   static final anonymouseUserID = "anonymouseUserID";
   static final settings = "settings";
+  static final migratedFlutter = "migratedFlutter";
 }
 
 @freezed
@@ -46,6 +47,7 @@ abstract class User implements _$User {
   factory User({
     @required String anonymouseUserID,
     @JsonKey(name: "settings") Setting setting,
+    @Default(false) bool migratedFlutter,
   }) = _User;
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);

--- a/lib/entity/user.freezed.dart
+++ b/lib/entity/user.freezed.dart
@@ -161,12 +161,10 @@ class _$UserTearOff {
 // ignore: unused_element
   _User call(
       {@required String anonymouseUserID,
-      @JsonKey(name: 'settings') Setting setting,
-      bool migratedFlutter = false}) {
+      @JsonKey(name: 'settings') Setting setting}) {
     return _User(
       anonymouseUserID: anonymouseUserID,
       setting: setting,
-      migratedFlutter: migratedFlutter,
     );
   }
 
@@ -185,7 +183,6 @@ mixin _$User {
   String get anonymouseUserID;
   @JsonKey(name: 'settings')
   Setting get setting;
-  bool get migratedFlutter;
 
   Map<String, dynamic> toJson();
   $UserCopyWith<User> get copyWith;
@@ -196,9 +193,7 @@ abstract class $UserCopyWith<$Res> {
   factory $UserCopyWith(User value, $Res Function(User) then) =
       _$UserCopyWithImpl<$Res>;
   $Res call(
-      {String anonymouseUserID,
-      @JsonKey(name: 'settings') Setting setting,
-      bool migratedFlutter});
+      {String anonymouseUserID, @JsonKey(name: 'settings') Setting setting});
 
   $SettingCopyWith<$Res> get setting;
 }
@@ -215,16 +210,12 @@ class _$UserCopyWithImpl<$Res> implements $UserCopyWith<$Res> {
   $Res call({
     Object anonymouseUserID = freezed,
     Object setting = freezed,
-    Object migratedFlutter = freezed,
   }) {
     return _then(_value.copyWith(
       anonymouseUserID: anonymouseUserID == freezed
           ? _value.anonymouseUserID
           : anonymouseUserID as String,
       setting: setting == freezed ? _value.setting : setting as Setting,
-      migratedFlutter: migratedFlutter == freezed
-          ? _value.migratedFlutter
-          : migratedFlutter as bool,
     ));
   }
 
@@ -245,9 +236,7 @@ abstract class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
       __$UserCopyWithImpl<$Res>;
   @override
   $Res call(
-      {String anonymouseUserID,
-      @JsonKey(name: 'settings') Setting setting,
-      bool migratedFlutter});
+      {String anonymouseUserID, @JsonKey(name: 'settings') Setting setting});
 
   @override
   $SettingCopyWith<$Res> get setting;
@@ -266,16 +255,12 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
   $Res call({
     Object anonymouseUserID = freezed,
     Object setting = freezed,
-    Object migratedFlutter = freezed,
   }) {
     return _then(_User(
       anonymouseUserID: anonymouseUserID == freezed
           ? _value.anonymouseUserID
           : anonymouseUserID as String,
       setting: setting == freezed ? _value.setting : setting as Setting,
-      migratedFlutter: migratedFlutter == freezed
-          ? _value.migratedFlutter
-          : migratedFlutter as bool,
     ));
   }
 }
@@ -286,10 +271,8 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
 class _$_User extends _User {
   _$_User(
       {@required this.anonymouseUserID,
-      @JsonKey(name: 'settings') this.setting,
-      this.migratedFlutter = false})
+      @JsonKey(name: 'settings') this.setting})
       : assert(anonymouseUserID != null),
-        assert(migratedFlutter != null),
         super._();
 
   factory _$_User.fromJson(Map<String, dynamic> json) =>
@@ -300,13 +283,10 @@ class _$_User extends _User {
   @override
   @JsonKey(name: 'settings')
   final Setting setting;
-  @JsonKey(defaultValue: false)
-  @override
-  final bool migratedFlutter;
 
   @override
   String toString() {
-    return 'User(anonymouseUserID: $anonymouseUserID, setting: $setting, migratedFlutter: $migratedFlutter)';
+    return 'User(anonymouseUserID: $anonymouseUserID, setting: $setting)';
   }
 
   @override
@@ -317,19 +297,14 @@ class _$_User extends _User {
                 const DeepCollectionEquality()
                     .equals(other.anonymouseUserID, anonymouseUserID)) &&
             (identical(other.setting, setting) ||
-                const DeepCollectionEquality()
-                    .equals(other.setting, setting)) &&
-            (identical(other.migratedFlutter, migratedFlutter) ||
-                const DeepCollectionEquality()
-                    .equals(other.migratedFlutter, migratedFlutter)));
+                const DeepCollectionEquality().equals(other.setting, setting)));
   }
 
   @override
   int get hashCode =>
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(anonymouseUserID) ^
-      const DeepCollectionEquality().hash(setting) ^
-      const DeepCollectionEquality().hash(migratedFlutter);
+      const DeepCollectionEquality().hash(setting);
 
   @override
   _$UserCopyWith<_User> get copyWith =>
@@ -345,8 +320,7 @@ abstract class _User extends User {
   _User._() : super._();
   factory _User(
       {@required String anonymouseUserID,
-      @JsonKey(name: 'settings') Setting setting,
-      bool migratedFlutter}) = _$_User;
+      @JsonKey(name: 'settings') Setting setting}) = _$_User;
 
   factory _User.fromJson(Map<String, dynamic> json) = _$_User.fromJson;
 
@@ -355,8 +329,6 @@ abstract class _User extends User {
   @override
   @JsonKey(name: 'settings')
   Setting get setting;
-  @override
-  bool get migratedFlutter;
   @override
   _$UserCopyWith<_User> get copyWith;
 }

--- a/lib/entity/user.freezed.dart
+++ b/lib/entity/user.freezed.dart
@@ -161,10 +161,12 @@ class _$UserTearOff {
 // ignore: unused_element
   _User call(
       {@required String anonymouseUserID,
-      @JsonKey(name: 'settings') Setting setting}) {
+      @JsonKey(name: 'settings') Setting setting,
+      bool migratedFlutter = false}) {
     return _User(
       anonymouseUserID: anonymouseUserID,
       setting: setting,
+      migratedFlutter: migratedFlutter,
     );
   }
 
@@ -183,6 +185,7 @@ mixin _$User {
   String get anonymouseUserID;
   @JsonKey(name: 'settings')
   Setting get setting;
+  bool get migratedFlutter;
 
   Map<String, dynamic> toJson();
   $UserCopyWith<User> get copyWith;
@@ -193,7 +196,9 @@ abstract class $UserCopyWith<$Res> {
   factory $UserCopyWith(User value, $Res Function(User) then) =
       _$UserCopyWithImpl<$Res>;
   $Res call(
-      {String anonymouseUserID, @JsonKey(name: 'settings') Setting setting});
+      {String anonymouseUserID,
+      @JsonKey(name: 'settings') Setting setting,
+      bool migratedFlutter});
 
   $SettingCopyWith<$Res> get setting;
 }
@@ -210,12 +215,16 @@ class _$UserCopyWithImpl<$Res> implements $UserCopyWith<$Res> {
   $Res call({
     Object anonymouseUserID = freezed,
     Object setting = freezed,
+    Object migratedFlutter = freezed,
   }) {
     return _then(_value.copyWith(
       anonymouseUserID: anonymouseUserID == freezed
           ? _value.anonymouseUserID
           : anonymouseUserID as String,
       setting: setting == freezed ? _value.setting : setting as Setting,
+      migratedFlutter: migratedFlutter == freezed
+          ? _value.migratedFlutter
+          : migratedFlutter as bool,
     ));
   }
 
@@ -236,7 +245,9 @@ abstract class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
       __$UserCopyWithImpl<$Res>;
   @override
   $Res call(
-      {String anonymouseUserID, @JsonKey(name: 'settings') Setting setting});
+      {String anonymouseUserID,
+      @JsonKey(name: 'settings') Setting setting,
+      bool migratedFlutter});
 
   @override
   $SettingCopyWith<$Res> get setting;
@@ -255,12 +266,16 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
   $Res call({
     Object anonymouseUserID = freezed,
     Object setting = freezed,
+    Object migratedFlutter = freezed,
   }) {
     return _then(_User(
       anonymouseUserID: anonymouseUserID == freezed
           ? _value.anonymouseUserID
           : anonymouseUserID as String,
       setting: setting == freezed ? _value.setting : setting as Setting,
+      migratedFlutter: migratedFlutter == freezed
+          ? _value.migratedFlutter
+          : migratedFlutter as bool,
     ));
   }
 }
@@ -271,8 +286,10 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
 class _$_User extends _User {
   _$_User(
       {@required this.anonymouseUserID,
-      @JsonKey(name: 'settings') this.setting})
+      @JsonKey(name: 'settings') this.setting,
+      this.migratedFlutter = false})
       : assert(anonymouseUserID != null),
+        assert(migratedFlutter != null),
         super._();
 
   factory _$_User.fromJson(Map<String, dynamic> json) =>
@@ -283,10 +300,13 @@ class _$_User extends _User {
   @override
   @JsonKey(name: 'settings')
   final Setting setting;
+  @JsonKey(defaultValue: false)
+  @override
+  final bool migratedFlutter;
 
   @override
   String toString() {
-    return 'User(anonymouseUserID: $anonymouseUserID, setting: $setting)';
+    return 'User(anonymouseUserID: $anonymouseUserID, setting: $setting, migratedFlutter: $migratedFlutter)';
   }
 
   @override
@@ -297,14 +317,19 @@ class _$_User extends _User {
                 const DeepCollectionEquality()
                     .equals(other.anonymouseUserID, anonymouseUserID)) &&
             (identical(other.setting, setting) ||
-                const DeepCollectionEquality().equals(other.setting, setting)));
+                const DeepCollectionEquality()
+                    .equals(other.setting, setting)) &&
+            (identical(other.migratedFlutter, migratedFlutter) ||
+                const DeepCollectionEquality()
+                    .equals(other.migratedFlutter, migratedFlutter)));
   }
 
   @override
   int get hashCode =>
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(anonymouseUserID) ^
-      const DeepCollectionEquality().hash(setting);
+      const DeepCollectionEquality().hash(setting) ^
+      const DeepCollectionEquality().hash(migratedFlutter);
 
   @override
   _$UserCopyWith<_User> get copyWith =>
@@ -320,7 +345,8 @@ abstract class _User extends User {
   _User._() : super._();
   factory _User(
       {@required String anonymouseUserID,
-      @JsonKey(name: 'settings') Setting setting}) = _$_User;
+      @JsonKey(name: 'settings') Setting setting,
+      bool migratedFlutter}) = _$_User;
 
   factory _User.fromJson(Map<String, dynamic> json) = _$_User.fromJson;
 
@@ -329,6 +355,8 @@ abstract class _User extends User {
   @override
   @JsonKey(name: 'settings')
   Setting get setting;
+  @override
+  bool get migratedFlutter;
   @override
   _$UserCopyWith<_User> get copyWith;
 }

--- a/lib/entity/user.freezed.dart
+++ b/lib/entity/user.freezed.dart
@@ -161,10 +161,12 @@ class _$UserTearOff {
 // ignore: unused_element
   _User call(
       {@required String anonymouseUserID,
-      @JsonKey(name: "settings") Setting setting}) {
+      @JsonKey(name: 'settings') Setting setting,
+      bool migratedFlutter = false}) {
     return _User(
       anonymouseUserID: anonymouseUserID,
       setting: setting,
+      migratedFlutter: migratedFlutter,
     );
   }
 
@@ -181,8 +183,9 @@ const $User = _$UserTearOff();
 /// @nodoc
 mixin _$User {
   String get anonymouseUserID;
-  @JsonKey(name: "settings")
+  @JsonKey(name: 'settings')
   Setting get setting;
+  bool get migratedFlutter;
 
   Map<String, dynamic> toJson();
   $UserCopyWith<User> get copyWith;
@@ -193,7 +196,9 @@ abstract class $UserCopyWith<$Res> {
   factory $UserCopyWith(User value, $Res Function(User) then) =
       _$UserCopyWithImpl<$Res>;
   $Res call(
-      {String anonymouseUserID, @JsonKey(name: "settings") Setting setting});
+      {String anonymouseUserID,
+      @JsonKey(name: 'settings') Setting setting,
+      bool migratedFlutter});
 
   $SettingCopyWith<$Res> get setting;
 }
@@ -210,12 +215,16 @@ class _$UserCopyWithImpl<$Res> implements $UserCopyWith<$Res> {
   $Res call({
     Object anonymouseUserID = freezed,
     Object setting = freezed,
+    Object migratedFlutter = freezed,
   }) {
     return _then(_value.copyWith(
       anonymouseUserID: anonymouseUserID == freezed
           ? _value.anonymouseUserID
           : anonymouseUserID as String,
       setting: setting == freezed ? _value.setting : setting as Setting,
+      migratedFlutter: migratedFlutter == freezed
+          ? _value.migratedFlutter
+          : migratedFlutter as bool,
     ));
   }
 
@@ -236,7 +245,9 @@ abstract class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
       __$UserCopyWithImpl<$Res>;
   @override
   $Res call(
-      {String anonymouseUserID, @JsonKey(name: "settings") Setting setting});
+      {String anonymouseUserID,
+      @JsonKey(name: 'settings') Setting setting,
+      bool migratedFlutter});
 
   @override
   $SettingCopyWith<$Res> get setting;
@@ -255,12 +266,16 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
   $Res call({
     Object anonymouseUserID = freezed,
     Object setting = freezed,
+    Object migratedFlutter = freezed,
   }) {
     return _then(_User(
       anonymouseUserID: anonymouseUserID == freezed
           ? _value.anonymouseUserID
           : anonymouseUserID as String,
       setting: setting == freezed ? _value.setting : setting as Setting,
+      migratedFlutter: migratedFlutter == freezed
+          ? _value.migratedFlutter
+          : migratedFlutter as bool,
     ));
   }
 }
@@ -271,8 +286,10 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
 class _$_User extends _User {
   _$_User(
       {@required this.anonymouseUserID,
-      @JsonKey(name: "settings") this.setting})
+      @JsonKey(name: 'settings') this.setting,
+      this.migratedFlutter = false})
       : assert(anonymouseUserID != null),
+        assert(migratedFlutter != null),
         super._();
 
   factory _$_User.fromJson(Map<String, dynamic> json) =>
@@ -281,12 +298,15 @@ class _$_User extends _User {
   @override
   final String anonymouseUserID;
   @override
-  @JsonKey(name: "settings")
+  @JsonKey(name: 'settings')
   final Setting setting;
+  @JsonKey(defaultValue: false)
+  @override
+  final bool migratedFlutter;
 
   @override
   String toString() {
-    return 'User(anonymouseUserID: $anonymouseUserID, setting: $setting)';
+    return 'User(anonymouseUserID: $anonymouseUserID, setting: $setting, migratedFlutter: $migratedFlutter)';
   }
 
   @override
@@ -297,14 +317,19 @@ class _$_User extends _User {
                 const DeepCollectionEquality()
                     .equals(other.anonymouseUserID, anonymouseUserID)) &&
             (identical(other.setting, setting) ||
-                const DeepCollectionEquality().equals(other.setting, setting)));
+                const DeepCollectionEquality()
+                    .equals(other.setting, setting)) &&
+            (identical(other.migratedFlutter, migratedFlutter) ||
+                const DeepCollectionEquality()
+                    .equals(other.migratedFlutter, migratedFlutter)));
   }
 
   @override
   int get hashCode =>
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(anonymouseUserID) ^
-      const DeepCollectionEquality().hash(setting);
+      const DeepCollectionEquality().hash(setting) ^
+      const DeepCollectionEquality().hash(migratedFlutter);
 
   @override
   _$UserCopyWith<_User> get copyWith =>
@@ -320,15 +345,18 @@ abstract class _User extends User {
   _User._() : super._();
   factory _User(
       {@required String anonymouseUserID,
-      @JsonKey(name: "settings") Setting setting}) = _$_User;
+      @JsonKey(name: 'settings') Setting setting,
+      bool migratedFlutter}) = _$_User;
 
   factory _User.fromJson(Map<String, dynamic> json) = _$_User.fromJson;
 
   @override
   String get anonymouseUserID;
   @override
-  @JsonKey(name: "settings")
+  @JsonKey(name: 'settings')
   Setting get setting;
+  @override
+  bool get migratedFlutter;
   @override
   _$UserCopyWith<_User> get copyWith;
 }

--- a/lib/entity/user.g.dart
+++ b/lib/entity/user.g.dart
@@ -23,10 +23,12 @@ _$_User _$_$_UserFromJson(Map<String, dynamic> json) {
     setting: json['settings'] == null
         ? null
         : Setting.fromJson(json['settings'] as Map<String, dynamic>),
+    migratedFlutter: json['migratedFlutter'] as bool ?? false,
   );
 }
 
 Map<String, dynamic> _$_$_UserToJson(_$_User instance) => <String, dynamic>{
       'anonymouseUserID': instance.anonymouseUserID,
       'settings': instance.setting,
+      'migratedFlutter': instance.migratedFlutter,
     };

--- a/lib/entity/user.g.dart
+++ b/lib/entity/user.g.dart
@@ -23,12 +23,10 @@ _$_User _$_$_UserFromJson(Map<String, dynamic> json) {
     setting: json['settings'] == null
         ? null
         : Setting.fromJson(json['settings'] as Map<String, dynamic>),
-    migratedFlutter: json['migratedFlutter'] as bool ?? false,
   );
 }
 
 Map<String, dynamic> _$_$_UserToJson(_$_User instance) => <String, dynamic>{
       'anonymouseUserID': instance.anonymouseUserID,
       'settings': instance.setting,
-      'migratedFlutter': instance.migratedFlutter,
     };

--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -10,6 +10,8 @@ abstract class UserServiceInterface {
   Future<User> prepare();
   Future<User> fetch();
   Future<User> subscribe();
+  Future<void> deleteSettings();
+  Future<void> setFlutterMigrationFlag();
   Future<void> registerRemoteNotificationToken(String token);
 }
 
@@ -50,6 +52,19 @@ class UserService extends UserServiceInterface {
     }).asFuture();
   }
 
+  Future<void> deleteSettings() {
+    return _database
+        .userReference()
+        .update({UserFirestoreFieldKeys.settings: FieldValue.delete()});
+  }
+
+  Future<void> setFlutterMigrationFlag() {
+    return _database.userReference().set(
+      {UserFirestoreFieldKeys.migratedFlutter: true},
+      SetOptions(merge: true),
+    );
+  }
+
   Future<void> _create() {
     return _database
         .userReference()
@@ -57,7 +72,6 @@ class UserService extends UserServiceInterface {
           {
             UserFirestoreFieldKeys.anonymouseUserID:
                 auth.FirebaseAuth.instance.currentUser.uid,
-            UserFirestoreFieldKeys.migratedFlutter: true,
           },
           SetOptions(merge: true),
         )

--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -57,6 +57,7 @@ class UserService extends UserServiceInterface {
           {
             UserFirestoreFieldKeys.anonymouseUserID:
                 auth.FirebaseAuth.instance.currentUser.uid,
+            UserFirestoreFieldKeys.migratedFlutter: true,
           },
           SetOptions(merge: true),
         )

--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -11,7 +11,6 @@ abstract class UserServiceInterface {
   Future<User> fetch();
   Future<User> subscribe();
   Future<void> deleteSettings();
-  Future<void> setFlutterMigrationFlag();
   Future<void> registerRemoteNotificationToken(String token);
 }
 
@@ -56,13 +55,6 @@ class UserService extends UserServiceInterface {
     return _database
         .userReference()
         .update({UserFirestoreFieldKeys.settings: FieldValue.delete()});
-  }
-
-  Future<void> setFlutterMigrationFlag() {
-    return _database.userReference().set(
-      {UserFirestoreFieldKeys.migratedFlutter: true},
-      SetOptions(merge: true),
-    );
   }
 
   Future<void> _create() {

--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -11,6 +11,7 @@ abstract class UserServiceInterface {
   Future<User> fetch();
   Future<User> subscribe();
   Future<void> deleteSettings();
+  Future<void> setFlutterMigrationFlag();
   Future<void> registerRemoteNotificationToken(String token);
 }
 
@@ -55,6 +56,13 @@ class UserService extends UserServiceInterface {
     return _database
         .userReference()
         .update({UserFirestoreFieldKeys.settings: FieldValue.delete()});
+  }
+
+  Future<void> setFlutterMigrationFlag() {
+    return _database.userReference().set(
+      {UserFirestoreFieldKeys.migratedFlutter: true},
+      SetOptions(merge: true),
+    );
   }
 
   Future<void> _create() {


### PR DESCRIPTION
## What
Swiftにリリースされているプロジェクトで設定のkey:valueの組み合わせがおかしかったりするものがいくつか存在する。
それを一度消すためのロジックを追加。

## Why
法人化とか考えると データ一度消得てもやむを得ないよね。ってことになった。下記の対応をする代わりにuser.settingsを初回起動のときに消す処理を入れる


 - pillSheetTypeRawPath が間違ったままでSwiftの方リリースされているから移行スクリプト書く必要ある
 - beginingMenstruationFromAfterFakePeriod→ fromMenstruation これも移行する必要がある
 - 通知時刻reminderTime -> reminderTimes と配列に入れるようにする