### PR TITLE
Fix high priority issues

### DIFF
--- a/lib/components/organisms/pill/pill_mark.dart
+++ b/lib/components/organisms/pill/pill_mark.dart
@@ -8,13 +8,11 @@ import 'package:flutter/widgets.dart';
 class PillMark extends StatefulWidget {
   final PillMarkType type;
   final bool isDone;
-  final VoidCallback tapped;
   final bool hasRippleAnimation;
   const PillMark({
     Key key,
     this.hasRippleAnimation = false,
     @required this.type,
-    @required this.tapped,
     @required this.isDone,
   }) : super(key: key);
 
@@ -48,29 +46,27 @@ class _PillMarkState extends State<PillMark> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-        child: Stack(
-          overflow: Overflow.visible,
-          children: [
-            PillMarkTypeFunctions.create(widget.isDone, widget.type),
-            if (widget.hasRippleAnimation)
-              // NOTE: pill mark size is 20px. Ripple view final size is 80px.
-              // Positined ripple animation equal to (80px - 20px) / 2(to center) = 28;
-              Positioned(
-                left: -30,
-                top: -30,
-                child: Container(
-                  child: CustomPaint(
-                    size: Size(80, 80),
-                    painter: Ripple(
-                      _controller,
-                      color: PilllColors.primary,
-                    ),
-                  ),
+    return Stack(
+      overflow: Overflow.visible,
+      children: [
+        PillMarkTypeFunctions.create(widget.isDone, widget.type),
+        if (widget.hasRippleAnimation)
+          // NOTE: pill mark size is 20px. Ripple view final size is 80px.
+          // Positined ripple animation equal to (80px - 20px) / 2(to center) = 28;
+          Positioned(
+            left: -30,
+            top: -30,
+            child: Container(
+              child: CustomPaint(
+                size: Size(80, 80),
+                painter: Ripple(
+                  _controller,
+                  color: PilllColors.primary,
                 ),
               ),
-          ],
-        ),
-        onTap: widget.tapped);
+            ),
+          ),
+      ],
+    );
   }
 }

--- a/lib/components/organisms/pill/pill_sheet.dart
+++ b/lib/components/organisms/pill/pill_sheet.dart
@@ -47,20 +47,23 @@ class PillSheet extends StatelessWidget {
 
   Widget _pillMarkWithNumber(int number) {
     var type = pillMarkTypeBuilder(number);
-    return Column(
-      children: <Widget>[
-        Text("$number", style: TextStyle(color: PilllColors.weekday)),
-        PillMark(
+    return GestureDetector(
+      onTap: () {
+        markSelected(number);
+      },
+      child: Column(
+        children: <Widget>[
+          Text("$number", style: TextStyle(color: PilllColors.weekday)),
+          PillMark(
             key: Key("PillMarkWidget_$number"),
             hasRippleAnimation: enabledMarkAnimation == null
                 ? false
                 : enabledMarkAnimation(number),
             isDone: doneStateBuilder(number),
             type: type,
-            tapped: () {
-              markSelected(number);
-            }),
-      ],
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/domain/calendar/calendar.dart
+++ b/lib/domain/calendar/calendar.dart
@@ -230,8 +230,8 @@ class CalendarDayTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Expanded(
-      child: GestureDetector(
-        onTap: onTap,
+      child: RawMaterialButton(
+        onPressed: onTap,
         child: Container(
           height: CalendarConstants.tileHeight,
           child: Stack(

--- a/lib/domain/diary/confirm_diary_sheet.dart
+++ b/lib/domain/diary/confirm_diary_sheet.dart
@@ -45,7 +45,7 @@ class ConfirmDiarySheet extends HookWidget {
             ...[
               if (state.hasPhysicalConditionStatus()) _physicalCondition(),
               _physicalConditionDetails(),
-              _sex(),
+              if (state.entity.hasSex) _sex(),
               _memo(),
             ].map((e) => _withContentSpacer(e)),
           ]),
@@ -138,18 +138,13 @@ class ConfirmDiarySheet extends HookWidget {
   }
 
   Widget _sex() {
-    final diary = useProvider(_confirmDiaryProvider(date).state).entity;
     return Container(
       padding: EdgeInsets.all(4),
       width: 32,
       height: 32,
       decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          color: diary.hasSex
-              ? PilllColors.thinSecondary
-              : PilllColors.disabledSheet),
-      child: SvgPicture.asset("images/heart.svg",
-          color: diary.hasSex ? PilllColors.secondary : TextColor.darkGray),
+          shape: BoxShape.circle, color: PilllColors.thinSecondary),
+      child: SvgPicture.asset("images/heart.svg", color: PilllColors.secondary),
     );
   }
 


### PR DESCRIPTION
## What
- 初期設定、設定、レコード(ピル)画面のピルのタップ領域を広く。→写真参考
- カレンダーの日付のタップ領域が狭くて押しづらい
- Sexの記録してないのに、日記参照画面にハートマークが表示されている。記録してない場合は出さない