### PR TITLE
enhancement/experience/middle_issues

### DIFF
--- a/lib/components/atoms/button.dart
+++ b/lib/components/atoms/button.dart
@@ -3,6 +3,12 @@ import 'package:Pilll/components/atoms/font.dart';
 import 'package:flutter/material.dart';
 
 abstract class ButtonTextStyle {
+  static final TextStyle main = TextStyle(
+    fontFamily: FontFamily.japanese,
+    fontWeight: FontWeight.w700,
+    fontSize: FontSize.sLarge,
+    color: PilllColors.white,
+  );
   static final TextStyle alert = TextStyle(
     fontFamily: FontFamily.japanese,
     fontWeight: FontWeight.w600,

--- a/lib/components/atoms/buttons.dart
+++ b/lib/components/atoms/buttons.dart
@@ -18,7 +18,7 @@ class PrimaryButton extends StatelessWidget {
       width: 180,
       height: 44,
       child: RaisedButton(
-        child: Text(text),
+        child: Text(text, style: ButtonTextStyle.main),
         onPressed: onPressed,
       ),
     );

--- a/lib/components/atoms/font.dart
+++ b/lib/components/atoms/font.dart
@@ -83,6 +83,12 @@ class FontType {
     fontWeight: FontWeight.w300,
     fontSize: FontSize.sLarge,
   );
+  static final TextStyle gridElement = TextStyle(
+    fontFamily: FontFamily.japanese,
+    fontWeight: FontWeight.w600,
+    fontSize: FontSize.sLarge,
+  );
+
   static final TextStyle row = TextStyle(
     fontFamily: FontFamily.roboto,
     fontWeight: FontWeight.w300,

--- a/lib/components/atoms/font.dart
+++ b/lib/components/atoms/font.dart
@@ -19,7 +19,6 @@ class FontSize {
   static final double normal = 14;
   static final double small = 12;
   static final double sSmall = 10;
-  static final double mini = 8;
 }
 
 class FontType {
@@ -119,9 +118,9 @@ class FontType {
     fontWeight: FontWeight.w600,
     fontSize: FontSize.sSmall,
   );
-  static final TextStyle mini = TextStyle(
+  static final TextStyle sSmallSentence = TextStyle(
     fontFamily: FontFamily.japanese,
     fontWeight: FontWeight.w300,
-    fontSize: FontSize.mini,
+    fontSize: FontSize.sSmall,
   );
 }

--- a/lib/domain/calendar/calendar.dart
+++ b/lib/domain/calendar/calendar.dart
@@ -255,7 +255,7 @@ class CalendarDayTile extends StatelessWidget {
                               .weekdayColor()
                               .withAlpha((255 * 0.4).floor())
                           : weekday.weekdayColor(),
-                    ).merge(FontType.componentTitle),
+                    ).merge(FontType.gridElement),
                   ),
                 ),
               ),

--- a/lib/domain/initial_setting/initial_setting_4_page.dart
+++ b/lib/domain/initial_setting/initial_setting_4_page.dart
@@ -138,7 +138,8 @@ class InitialSetting4Page extends HookWidget {
                       children: [
                         TextSpan(
                           text: "プライバシーポリシー",
-                          style: FontType.mini.merge(TextColorStyle.link),
+                          style: FontType.sSmallSentence
+                              .merge(TextColorStyle.link),
                           recognizer: TapGestureRecognizer()
                             ..onTap = () {
                               launch(
@@ -148,11 +149,13 @@ class InitialSetting4Page extends HookWidget {
                         ),
                         TextSpan(
                           text: "と",
-                          style: FontType.mini.merge(TextColorStyle.gray),
+                          style: FontType.sSmallSentence
+                              .merge(TextColorStyle.gray),
                         ),
                         TextSpan(
                           text: "利用規約",
-                          style: FontType.mini.merge(TextColorStyle.link),
+                          style: FontType.sSmallSentence
+                              .merge(TextColorStyle.link),
                           recognizer: TapGestureRecognizer()
                             ..onTap = () {
                               launch("https://bannzai.github.io/Pilll/Terms",
@@ -160,8 +163,9 @@ class InitialSetting4Page extends HookWidget {
                             },
                         ),
                         TextSpan(
-                          text: "を読んで、利用をはじめてください",
-                          style: FontType.mini.merge(TextColorStyle.gray),
+                          text: "\nを読んで、利用をはじめてください",
+                          style: FontType.sSmallSentence
+                              .merge(TextColorStyle.gray),
                         ),
                       ],
                     ),

--- a/lib/domain/initial_setting/initial_setting_4_page.dart
+++ b/lib/domain/initial_setting/initial_setting_4_page.dart
@@ -134,6 +134,7 @@ class InitialSetting4Page extends HookWidget {
               Column(
                 children: [
                   RichText(
+                    textAlign: TextAlign.center,
                     text: TextSpan(
                       children: [
                         TextSpan(
@@ -163,7 +164,7 @@ class InitialSetting4Page extends HookWidget {
                             },
                         ),
                         TextSpan(
-                          text: "\nを読んで、利用をはじめてください",
+                          text: "を読んで\n利用をはじめてください",
                           style: FontType.sSmallSentence
                               .merge(TextColorStyle.gray),
                         ),

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -105,16 +105,17 @@ class RecordPage extends HookWidget {
                 ),
             ],
           ),
+          SizedBox(height: 97),
           if (currentPillSheet == null)
             _empty(store, settingState.entity.pillSheetType),
           if (currentPillSheet != null) ...[
             _pillSheet(context, currentPillSheet, store),
-            SizedBox(height: 24),
+            SizedBox(height: 40),
             currentPillSheet.allTaken
                 ? _cancelTakeButton(currentPillSheet, store)
                 : _takenButton(context, currentPillSheet, store),
           ],
-          SizedBox(height: 8),
+          Spacer(),
         ],
       ),
     );

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -111,9 +111,14 @@ class RecordPage extends HookWidget {
           if (currentPillSheet != null) ...[
             _pillSheet(context, currentPillSheet, store),
             SizedBox(height: 40),
-            currentPillSheet.allTaken
-                ? _cancelTakeButton(currentPillSheet, store)
-                : _takenButton(context, currentPillSheet, store),
+            if (currentPillSheet.inNotTakenDuration)
+              _notTakenButton(context, currentPillSheet, store),
+            if (!currentPillSheet.inNotTakenDuration &&
+                currentPillSheet.allTaken)
+              _cancelTakeButton(currentPillSheet, store),
+            if (!currentPillSheet.allTaken &&
+                !currentPillSheet.inNotTakenDuration)
+              _takenButton(context, currentPillSheet, store),
           ],
           Spacer(),
         ],
@@ -206,6 +211,17 @@ class RecordPage extends HookWidget {
     return TertiaryButton(
       text: "飲んでない",
       onPressed: () => _cancelTake(pillSheet, store),
+    );
+  }
+
+  Widget _notTakenButton(
+    BuildContext context,
+    PillSheetModel pillSheet,
+    PillSheetStateStore store,
+  ) {
+    return TertiaryButton(
+      text: _notificationString(pillSheet),
+      onPressed: () {},
     );
   }
 

--- a/lib/domain/settings/reminder_times_page.dart
+++ b/lib/domain/settings/reminder_times_page.dart
@@ -71,12 +71,29 @@ class ReminderTimesPage extends HookWidget {
     }
     return Dismissible(
       key: UniqueKey(),
+      direction: DismissDirection.endToStart,
       onDismissed: state.entity.reminderTimes.length == 1
           ? null
           : (direction) {
               store.deleteReminderTimes(number - 1);
             },
-      background: Container(color: Colors.red),
+      background: Container(
+        color: Colors.red,
+        child: Container(
+          width: 40,
+          child: Padding(
+            padding: const EdgeInsets.all(20.0),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                "削除",
+                style: FontType.assistingBold.merge(TextColorStyle.white),
+                textAlign: TextAlign.right,
+              ),
+            ),
+          ),
+        ),
+      ),
       child: body,
     );
   }


### PR DESCRIPTION
## What
- [x] カレンダーの日付を太字(Medium)に
- [x] 今日の日付をBoldに
- [x] 「飲んだ」を太字に。フォントサイズ:16pxに 
- [x] デバイスが大きくなっていている事と、女性の手の大きさでも片手でタップできるようにしたい
- [x] 休薬期間中は「飲んだ」を押さなくてもよいデザインに 写真参考→
- [x] 横スワイプで、削除というテキストがでてきて、タップで消える方が親切かな。削除は危険行為だから、なるべく丁寧にしてあげたい
- [x] https://github.com/bannzai/_Pilll/issues/255#issuecomment-751471299