### PR TITLE
LatestPillSheet get from user.latestPillSheet

### DIFF
--- a/lib/domain/calendar/calendar_card.dart
+++ b/lib/domain/calendar/calendar_card.dart
@@ -82,7 +82,7 @@ class CalendarCard extends HookWidget {
   }
 
   Widget _more(
-      BuildContext context, Setting setting, PillSheetModel currentPillSheet) {
+      BuildContext context, Setting setting, PillSheetModel latestPillSheet) {
     return ConstrainedBox(
       constraints: BoxConstraints.expand(height: 60),
       child: Row(
@@ -98,23 +98,23 @@ class CalendarCard extends HookWidget {
                       Calculator(DateTime(now.year, now.month - 1, 1)), []);
                   CalendarListPageModel current =
                       CalendarListPageModel(Calculator(now), [
-                    if (currentPillSheet != null) ...[
-                      menstruationDateRange(currentPillSheet, setting, 0).map(
+                    if (latestPillSheet != null) ...[
+                      menstruationDateRange(latestPillSheet, setting, 0).map(
                           (range) => CalendarMenstruationBandModel(
                               range.begin, range.end)),
-                      nextPillSheetDateRange(currentPillSheet, 0).map((range) =>
+                      nextPillSheetDateRange(latestPillSheet, 0).map((range) =>
                           CalendarNextPillSheetBandModel(
                               range.begin, range.end)),
                     ]
                   ]);
                   List<CalendarBandModel> satisfyNextMonthDateRanges = [];
-                  if (currentPillSheet != null) {
+                  if (latestPillSheet != null) {
                     satisfyNextMonthDateRanges = List.generate(12, (index) {
                       return [
-                        menstruationDateRange(currentPillSheet, setting, index)
+                        menstruationDateRange(latestPillSheet, setting, index)
                             .map((range) => CalendarMenstruationBandModel(
                                 range.begin, range.end)),
-                        nextPillSheetDateRange(currentPillSheet, index).map(
+                        nextPillSheetDateRange(latestPillSheet, index).map(
                             (range) => CalendarNextPillSheetBandModel(
                                 range.begin, range.end)),
                       ];
@@ -127,7 +127,7 @@ class CalendarCard extends HookWidget {
                           Calculator(
                               DateTime(now.year, now.month + index + 1, 1)),
                           [
-                            if (currentPillSheet != null)
+                            if (latestPillSheet != null)
                               ...satisfyNextMonthDateRanges
                           ]);
                     },

--- a/lib/domain/calendar/calendar_page.dart
+++ b/lib/domain/calendar/calendar_page.dart
@@ -106,13 +106,21 @@ class MenstruationCard extends HookWidget {
                   style: TextColorStyle.noshime.merge(FontType.assisting)),
             ],
           ),
-          Text(
-              pillSheetState.entity != null
-                  ? DateTimeFormatter.monthAndWeekday(menstruationDateRange(
-                          pillSheetState.entity, settingState.entity, 0)
-                      .begin)
-                  : "",
-              style: TextColorStyle.gray.merge(FontType.xBigTitle)),
+          Text(() {
+            if (pillSheetState.entity == null) {
+              return "";
+            }
+
+            for (int i = 0; i < 12; i += 1) {
+              final begin = menstruationDateRange(
+                      pillSheetState.entity, settingState.entity, i)
+                  .begin;
+              if (begin.isAfter(utility.today())) {
+                return DateTimeFormatter.monthAndWeekday(begin);
+              }
+            }
+            return "";
+          }(), style: TextColorStyle.gray.merge(FontType.xBigTitle)),
         ],
       ),
     );

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -110,7 +110,7 @@ class RecordPage extends HookWidget {
           SizedBox(height: 97),
           if (currentPillSheet == null)
             _empty(store, settingState.entity.pillSheetType),
-          if (currentPillSheet != null) ...[
+          if (!state.isHidden) ...[
             _pillSheet(context, currentPillSheet, store),
             SizedBox(height: 40),
             if (currentPillSheet.inNotTakenDuration)

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -4,6 +4,7 @@ import 'package:Pilll/domain/record/record_taken_information.dart';
 import 'package:Pilll/entity/pill_sheet.dart';
 import 'package:Pilll/entity/pill_sheet_type.dart';
 import 'package:Pilll/entity/weekday.dart';
+import 'package:Pilll/state/pill_sheet.dart';
 import 'package:Pilll/store/pill_sheet.dart';
 import 'package:Pilll/store/setting.dart';
 import 'package:Pilll/components/atoms/buttons.dart';
@@ -30,7 +31,8 @@ class RecordPage extends HookWidget {
   }
 
   Widget _body(BuildContext context) {
-    final currentPillSheet = useProvider(pillSheetStoreProvider.state).entity;
+    final state = useProvider(pillSheetStoreProvider.state);
+    final currentPillSheet = state.entity;
     final store = useProvider(pillSheetStoreProvider);
     final settingState = useProvider(settingStoreProvider.state);
     if (settingState.entity == null || !store.firstLoadIsEnded) {
@@ -44,7 +46,7 @@ class RecordPage extends HookWidget {
             children: [
               RecordTakenInformation(
                 today: DateTime.now(),
-                pillSheetModel: currentPillSheet,
+                state: state,
                 onPressed: () {
                   showModalBottomSheet(
                     context: context,
@@ -90,14 +92,14 @@ class RecordPage extends HookWidget {
                   );
                 },
               ),
-              if (_notificationString(currentPillSheet).isNotEmpty)
+              if (_notificationString(state).isNotEmpty)
                 ConstrainedBox(
                   constraints: BoxConstraints.expand(height: 26),
                   child: Container(
                     height: 26,
                     color: PilllColors.secondary,
                     child: Center(
-                      child: Text(_notificationString(currentPillSheet),
+                      child: Text(_notificationString(state),
                           style:
                               FontType.assisting.merge(TextColorStyle.white)),
                     ),
@@ -112,7 +114,7 @@ class RecordPage extends HookWidget {
             _pillSheet(context, currentPillSheet, store),
             SizedBox(height: 40),
             if (currentPillSheet.inNotTakenDuration)
-              _notTakenButton(context, currentPillSheet, store),
+              _notTakenButton(context, state, store),
             if (!currentPillSheet.inNotTakenDuration &&
                 currentPillSheet.allTaken)
               _cancelTakeButton(currentPillSheet, store),
@@ -167,13 +169,16 @@ class RecordPage extends HookWidget {
         });
   }
 
-  String _notificationString(PillSheetModel currentPillSheet) {
-    if (currentPillSheet == null) {
+  String _notificationString(PillSheetState state) {
+    if (state.isHidden) {
       return "";
     }
-    if (currentPillSheet.typeInfo.dosingPeriod <
-        currentPillSheet.todayPillNumber) {
-      switch (currentPillSheet.pillSheetType) {
+    final pillSheet = state.entity;
+    if (pillSheet == null) {
+      return "";
+    }
+    if (pillSheet.typeInfo.dosingPeriod < pillSheet.todayPillNumber) {
+      switch (pillSheet.pillSheetType) {
         case PillSheetType.pillsheet_21:
           return "休薬期間中";
         case PillSheetType.pillsheet_28_4:
@@ -184,11 +189,10 @@ class RecordPage extends HookWidget {
     }
 
     final threshold = 4;
-    if (currentPillSheet.typeInfo.dosingPeriod - threshold + 1 <
-        currentPillSheet.todayPillNumber) {
-      final diff = currentPillSheet.typeInfo.dosingPeriod -
-          currentPillSheet.todayPillNumber +
-          1;
+    if (pillSheet.typeInfo.dosingPeriod - threshold + 1 <
+        pillSheet.todayPillNumber) {
+      final diff =
+          pillSheet.typeInfo.dosingPeriod - pillSheet.todayPillNumber + 1;
       return "あと$diff日で偽薬期間です";
     }
 
@@ -216,11 +220,11 @@ class RecordPage extends HookWidget {
 
   Widget _notTakenButton(
     BuildContext context,
-    PillSheetModel pillSheet,
+    PillSheetState state,
     PillSheetStateStore store,
   ) {
     return TertiaryButton(
-      text: _notificationString(pillSheet),
+      text: _notificationString(state),
       onPressed: () {},
     );
   }

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -110,7 +110,7 @@ class RecordPage extends HookWidget {
           SizedBox(height: 97),
           if (currentPillSheet == null)
             _empty(store, settingState.entity.pillSheetType),
-          if (!state.isHidden) ...[
+          if (!state.isInvalid) ...[
             _pillSheet(context, currentPillSheet, store),
             SizedBox(height: 40),
             if (currentPillSheet.inNotTakenDuration)
@@ -170,7 +170,7 @@ class RecordPage extends HookWidget {
   }
 
   String _notificationString(PillSheetState state) {
-    if (state.isHidden) {
+    if (state.isInvalid) {
       return "";
     }
     final pillSheet = state.entity;

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -108,8 +108,7 @@ class RecordPage extends HookWidget {
             ],
           ),
           SizedBox(height: 97),
-          if (currentPillSheet == null)
-            _empty(store, settingState.entity.pillSheetType),
+          if (state.isInvalid) _empty(store, settingState.entity.pillSheetType),
           if (!state.isInvalid) ...[
             _pillSheet(context, currentPillSheet, store),
             SizedBox(height: 40),

--- a/lib/domain/record/record_taken_information.dart
+++ b/lib/domain/record/record_taken_information.dart
@@ -23,7 +23,7 @@ class RecordTakenInformation extends StatelessWidget {
   String _formattedToday() => DateTimeFormatter.monthAndDay(this.today);
 
   String _todayWeekday() => DateTimeFormatter.weekday(this.today);
-  bool get pillSheetIsHidden => pillSheetModel != null || state.isHidden;
+  bool get pillSheetIsValid => pillSheetModel != null || !state.isHidden;
 
   @override
   Widget build(BuildContext context) {
@@ -72,14 +72,14 @@ class RecordTakenInformation extends StatelessWidget {
             "💊 今日飲むピル",
             style: FontType.assisting.merge(TextColorStyle.noshime),
           ),
-          if (pillSheetIsHidden) SizedBox(height: 10),
-          if (!pillSheetIsHidden) SizedBox(height: 12),
+          if (pillSheetIsValid) SizedBox(height: 10),
+          if (!pillSheetIsValid) SizedBox(height: 12),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.baseline,
             textBaseline: TextBaseline.ideographic,
             children: <Widget>[
-              if (pillSheetIsHidden) ...[
+              if (pillSheetIsValid) ...[
                 if (!pillSheetModel.inNotTakenDuration) ...[
                   Text("${pillSheetModel.todayPillNumber}",
                       style: FontType.xHugeNumber.merge(TextColorStyle.main)),
@@ -94,7 +94,7 @@ class RecordTakenInformation extends StatelessWidget {
                   ),
                 ],
               ],
-              if (!pillSheetIsHidden) ...[
+              if (!pillSheetIsValid) ...[
                 Text("-",
                     style: FontType.assisting.merge(TextColorStyle.noshime)),
               ],
@@ -103,7 +103,7 @@ class RecordTakenInformation extends StatelessWidget {
         ],
       ),
       onTap: () {
-        if (!pillSheetIsHidden) {
+        if (!pillSheetIsValid) {
           return;
         }
         this.onPressed();

--- a/lib/domain/record/record_taken_information.dart
+++ b/lib/domain/record/record_taken_information.dart
@@ -23,7 +23,7 @@ class RecordTakenInformation extends StatelessWidget {
   String _formattedToday() => DateTimeFormatter.monthAndDay(this.today);
 
   String _todayWeekday() => DateTimeFormatter.weekday(this.today);
-  bool get pillSheetIsValid => pillSheetModel != null || !state.isHidden;
+  bool get pillSheetIsValid => pillSheetModel != null && !state.isHidden;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/domain/record/record_taken_information.dart
+++ b/lib/domain/record/record_taken_information.dart
@@ -23,7 +23,7 @@ class RecordTakenInformation extends StatelessWidget {
   String _formattedToday() => DateTimeFormatter.monthAndDay(this.today);
 
   String _todayWeekday() => DateTimeFormatter.weekday(this.today);
-  bool get pillSheetIsValid => pillSheetModel != null && !state.isHidden;
+  bool get pillSheetIsValid => pillSheetModel != null && !state.isInvalid;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/domain/record/record_taken_information.dart
+++ b/lib/domain/record/record_taken_information.dart
@@ -3,17 +3,19 @@ import 'package:Pilll/components/atoms/color.dart';
 import 'package:Pilll/components/atoms/font.dart';
 import 'package:Pilll/components/atoms/text_color.dart';
 import 'package:Pilll/entity/pill_sheet_type.dart';
+import 'package:Pilll/state/pill_sheet.dart';
 import 'package:Pilll/util/formatter/date_time_formatter.dart';
 import 'package:flutter/material.dart';
 
 class RecordTakenInformation extends StatelessWidget {
   final DateTime today;
-  final PillSheetModel pillSheetModel;
+  final PillSheetState state;
+  PillSheetModel get pillSheetModel => state.entity;
   final VoidCallback onPressed;
   const RecordTakenInformation({
     Key key,
     @required this.today,
-    @required this.pillSheetModel,
+    @required this.state,
     @required this.onPressed,
   })  : assert(today != null),
         super(key: key);
@@ -21,7 +23,7 @@ class RecordTakenInformation extends StatelessWidget {
   String _formattedToday() => DateTimeFormatter.monthAndDay(this.today);
 
   String _todayWeekday() => DateTimeFormatter.weekday(this.today);
-  bool get isExistsPillSheet => pillSheetModel != null;
+  bool get pillSheetIsHidden => pillSheetModel != null || state.isHidden;
 
   @override
   Widget build(BuildContext context) {
@@ -70,14 +72,14 @@ class RecordTakenInformation extends StatelessWidget {
             "💊 今日飲むピル",
             style: FontType.assisting.merge(TextColorStyle.noshime),
           ),
-          if (isExistsPillSheet) SizedBox(height: 10),
-          if (!isExistsPillSheet) SizedBox(height: 12),
+          if (pillSheetIsHidden) SizedBox(height: 10),
+          if (!pillSheetIsHidden) SizedBox(height: 12),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.baseline,
             textBaseline: TextBaseline.ideographic,
             children: <Widget>[
-              if (isExistsPillSheet) ...[
+              if (pillSheetIsHidden) ...[
                 if (!pillSheetModel.inNotTakenDuration) ...[
                   Text("${pillSheetModel.todayPillNumber}",
                       style: FontType.xHugeNumber.merge(TextColorStyle.main)),
@@ -92,7 +94,7 @@ class RecordTakenInformation extends StatelessWidget {
                   ),
                 ],
               ],
-              if (!isExistsPillSheet) ...[
+              if (!pillSheetIsHidden) ...[
                 Text("-",
                     style: FontType.assisting.merge(TextColorStyle.noshime)),
               ],
@@ -101,7 +103,7 @@ class RecordTakenInformation extends StatelessWidget {
         ],
       ),
       onTap: () {
-        if (!isExistsPillSheet) {
+        if (!pillSheetIsHidden) {
           return;
         }
         this.onPressed();

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -172,7 +172,7 @@ class SettingsPage extends HookWidget {
                     title: "種類",
                     backButtonIsHidden: false,
                     selected: (type) {
-                      if (pillSheetState.entity != null)
+                      if (!pillSheetState.isHidden)
                         transactionModifier.modifyPillSheetType(type);
                       else
                         settingStore.modifyType(type);

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -172,7 +172,7 @@ class SettingsPage extends HookWidget {
                     title: "種類",
                     backButtonIsHidden: false,
                     selected: (type) {
-                      if (!pillSheetState.isHidden)
+                      if (!pillSheetState.isInvalid)
                         transactionModifier.modifyPillSheetType(type);
                       else
                         settingStore.modifyType(type);
@@ -186,7 +186,7 @@ class SettingsPage extends HookWidget {
               },
             );
           }(),
-          if (!pillSheetState.isHidden) ...[
+          if (!pillSheetState.isInvalid) ...[
             SettingListTitleRowModel(
                 title: "今日飲むピル番号の変更",
                 onTap: () {

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -186,7 +186,7 @@ class SettingsPage extends HookWidget {
               },
             );
           }(),
-          if (pillSheetState.entity != null) ...[
+          if (!pillSheetState.isHidden) ...[
             SettingListTitleRowModel(
                 title: "今日飲むピル番号の変更",
                 onTap: () {

--- a/lib/entity/pill_sheet.dart
+++ b/lib/entity/pill_sheet.dart
@@ -96,5 +96,6 @@ abstract class PillSheetModel implements _$PillSheetModel {
   bool get isEnded =>
       today().difference(beginingDate.date()).inDays + 1 >
       pillSheetType.totalCount;
+  bool get isDeleted => deletedAt != null;
   bool get inNotTakenDuration => todayPillNumber > typeInfo.dosingPeriod;
 }

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -1,3 +1,4 @@
+import 'package:Pilll/entity/pill_sheet.dart';
 import 'package:Pilll/entity/setting.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -48,6 +49,7 @@ abstract class User implements _$User {
   factory User({
     @required String anonymouseUserID,
     @JsonKey(name: "settings") Setting setting,
+    PillSheetModel latestPillSheet,
     @Default(false) bool migratedFlutter,
   }) = _User;
 

--- a/lib/entity/user.freezed.dart
+++ b/lib/entity/user.freezed.dart
@@ -162,10 +162,12 @@ class _$UserTearOff {
   _User call(
       {@required String anonymouseUserID,
       @JsonKey(name: "settings") Setting setting,
+      PillSheetModel latestPillSheet,
       bool migratedFlutter = false}) {
     return _User(
       anonymouseUserID: anonymouseUserID,
       setting: setting,
+      latestPillSheet: latestPillSheet,
       migratedFlutter: migratedFlutter,
     );
   }
@@ -185,6 +187,7 @@ mixin _$User {
   String get anonymouseUserID;
   @JsonKey(name: "settings")
   Setting get setting;
+  PillSheetModel get latestPillSheet;
   bool get migratedFlutter;
 
   Map<String, dynamic> toJson();
@@ -198,9 +201,11 @@ abstract class $UserCopyWith<$Res> {
   $Res call(
       {String anonymouseUserID,
       @JsonKey(name: "settings") Setting setting,
+      PillSheetModel latestPillSheet,
       bool migratedFlutter});
 
   $SettingCopyWith<$Res> get setting;
+  $PillSheetModelCopyWith<$Res> get latestPillSheet;
 }
 
 /// @nodoc
@@ -215,6 +220,7 @@ class _$UserCopyWithImpl<$Res> implements $UserCopyWith<$Res> {
   $Res call({
     Object anonymouseUserID = freezed,
     Object setting = freezed,
+    Object latestPillSheet = freezed,
     Object migratedFlutter = freezed,
   }) {
     return _then(_value.copyWith(
@@ -222,6 +228,9 @@ class _$UserCopyWithImpl<$Res> implements $UserCopyWith<$Res> {
           ? _value.anonymouseUserID
           : anonymouseUserID as String,
       setting: setting == freezed ? _value.setting : setting as Setting,
+      latestPillSheet: latestPillSheet == freezed
+          ? _value.latestPillSheet
+          : latestPillSheet as PillSheetModel,
       migratedFlutter: migratedFlutter == freezed
           ? _value.migratedFlutter
           : migratedFlutter as bool,
@@ -237,6 +246,16 @@ class _$UserCopyWithImpl<$Res> implements $UserCopyWith<$Res> {
       return _then(_value.copyWith(setting: value));
     });
   }
+
+  @override
+  $PillSheetModelCopyWith<$Res> get latestPillSheet {
+    if (_value.latestPillSheet == null) {
+      return null;
+    }
+    return $PillSheetModelCopyWith<$Res>(_value.latestPillSheet, (value) {
+      return _then(_value.copyWith(latestPillSheet: value));
+    });
+  }
 }
 
 /// @nodoc
@@ -247,10 +266,13 @@ abstract class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
   $Res call(
       {String anonymouseUserID,
       @JsonKey(name: "settings") Setting setting,
+      PillSheetModel latestPillSheet,
       bool migratedFlutter});
 
   @override
   $SettingCopyWith<$Res> get setting;
+  @override
+  $PillSheetModelCopyWith<$Res> get latestPillSheet;
 }
 
 /// @nodoc
@@ -266,6 +288,7 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
   $Res call({
     Object anonymouseUserID = freezed,
     Object setting = freezed,
+    Object latestPillSheet = freezed,
     Object migratedFlutter = freezed,
   }) {
     return _then(_User(
@@ -273,6 +296,9 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
           ? _value.anonymouseUserID
           : anonymouseUserID as String,
       setting: setting == freezed ? _value.setting : setting as Setting,
+      latestPillSheet: latestPillSheet == freezed
+          ? _value.latestPillSheet
+          : latestPillSheet as PillSheetModel,
       migratedFlutter: migratedFlutter == freezed
           ? _value.migratedFlutter
           : migratedFlutter as bool,
@@ -287,6 +313,7 @@ class _$_User extends _User {
   _$_User(
       {@required this.anonymouseUserID,
       @JsonKey(name: "settings") this.setting,
+      this.latestPillSheet,
       this.migratedFlutter = false})
       : assert(anonymouseUserID != null),
         assert(migratedFlutter != null),
@@ -300,13 +327,15 @@ class _$_User extends _User {
   @override
   @JsonKey(name: "settings")
   final Setting setting;
+  @override
+  final PillSheetModel latestPillSheet;
   @JsonKey(defaultValue: false)
   @override
   final bool migratedFlutter;
 
   @override
   String toString() {
-    return 'User(anonymouseUserID: $anonymouseUserID, setting: $setting, migratedFlutter: $migratedFlutter)';
+    return 'User(anonymouseUserID: $anonymouseUserID, setting: $setting, latestPillSheet: $latestPillSheet, migratedFlutter: $migratedFlutter)';
   }
 
   @override
@@ -319,6 +348,9 @@ class _$_User extends _User {
             (identical(other.setting, setting) ||
                 const DeepCollectionEquality()
                     .equals(other.setting, setting)) &&
+            (identical(other.latestPillSheet, latestPillSheet) ||
+                const DeepCollectionEquality()
+                    .equals(other.latestPillSheet, latestPillSheet)) &&
             (identical(other.migratedFlutter, migratedFlutter) ||
                 const DeepCollectionEquality()
                     .equals(other.migratedFlutter, migratedFlutter)));
@@ -329,6 +361,7 @@ class _$_User extends _User {
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(anonymouseUserID) ^
       const DeepCollectionEquality().hash(setting) ^
+      const DeepCollectionEquality().hash(latestPillSheet) ^
       const DeepCollectionEquality().hash(migratedFlutter);
 
   @override
@@ -346,6 +379,7 @@ abstract class _User extends User {
   factory _User(
       {@required String anonymouseUserID,
       @JsonKey(name: "settings") Setting setting,
+      PillSheetModel latestPillSheet,
       bool migratedFlutter}) = _$_User;
 
   factory _User.fromJson(Map<String, dynamic> json) = _$_User.fromJson;
@@ -355,6 +389,8 @@ abstract class _User extends User {
   @override
   @JsonKey(name: "settings")
   Setting get setting;
+  @override
+  PillSheetModel get latestPillSheet;
   @override
   bool get migratedFlutter;
   @override

--- a/lib/entity/user.g.dart
+++ b/lib/entity/user.g.dart
@@ -23,6 +23,10 @@ _$_User _$_$_UserFromJson(Map<String, dynamic> json) {
     setting: json['settings'] == null
         ? null
         : Setting.fromJson(json['settings'] as Map<String, dynamic>),
+    latestPillSheet: json['latestPillSheet'] == null
+        ? null
+        : PillSheetModel.fromJson(
+            json['latestPillSheet'] as Map<String, dynamic>),
     migratedFlutter: json['migratedFlutter'] as bool ?? false,
   );
 }
@@ -30,5 +34,6 @@ _$_User _$_$_UserFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$_$_UserToJson(_$_User instance) => <String, dynamic>{
       'anonymouseUserID': instance.anonymouseUserID,
       'settings': instance.setting,
+      'latestPillSheet': instance.latestPillSheet,
       'migratedFlutter': instance.migratedFlutter,
     };

--- a/lib/service/pill_sheet.dart
+++ b/lib/service/pill_sheet.dart
@@ -1,8 +1,8 @@
 import 'package:Pilll/database/database.dart';
 import 'package:Pilll/entity/firestore_timestamp_converter.dart';
 import 'package:Pilll/entity/pill_sheet.dart';
+import 'package:Pilll/entity/user.dart';
 import 'package:Pilll/entity/user_error.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:riverpod/all.dart';
 
 abstract class PillSheetServiceInterface {
@@ -20,33 +20,13 @@ class PillSheetService extends PillSheetServiceInterface {
   final DatabaseConnection _database;
 
   PillSheetService(this._database);
-
-  PillSheetModel _filterForLatestPillSheet(QuerySnapshot snapshot) {
-    if (snapshot.docs.isEmpty) return null;
-    if (!snapshot.docs.last.exists) return null;
-    var document = snapshot.docs.last;
-
-    var data = document.data();
-    data["id"] = document.id;
-    var pillSheetModel = PillSheetModel.fromJson(data);
-
-    if (pillSheetModel.deletedAt != null) return null;
-    if (pillSheetModel.isEnded) return null;
-    return pillSheetModel;
-  }
-
-  Query _queryOfFetchLastPillSheet() {
-    return _database
-        .pillSheetsReference()
-        .orderBy(PillSheetFirestoreKey.createdAt)
-        .limitToLast(1);
-  }
-
   @override
   Future<PillSheetModel> fetchLast() {
-    return _queryOfFetchLastPillSheet()
+    return _database
+        .userReference()
         .get()
-        .then((event) => _filterForLatestPillSheet(event));
+        .then((value) => User.fromJson(value.data()))
+        .then((user) => user.latestPillSheet);
   }
 
   @override
@@ -84,9 +64,10 @@ class PillSheetService extends PillSheetServiceInterface {
   }
 
   Stream<PillSheetModel> subscribeForLatestPillSheet() {
-    return _queryOfFetchLastPillSheet()
+    return _database
+        .userReference()
         .snapshots()
-        .map((event) => _filterForLatestPillSheet(event));
+        .map((event) => User.fromJson(event.data()).latestPillSheet);
   }
 }
 

--- a/lib/state/pill_sheet.dart
+++ b/lib/state/pill_sheet.dart
@@ -8,5 +8,5 @@ abstract class PillSheetState implements _$PillSheetState {
   PillSheetState._();
   factory PillSheetState({PillSheetModel entity}) = _PillSheetState;
 
-  bool get isHidden => entity == null || entity.isDeleted || entity.isEnded;
+  bool get isInvalid => entity == null || entity.isDeleted || entity.isEnded;
 }

--- a/lib/state/pill_sheet.dart
+++ b/lib/state/pill_sheet.dart
@@ -7,4 +7,6 @@ part 'pill_sheet.freezed.dart';
 abstract class PillSheetState implements _$PillSheetState {
   PillSheetState._();
   factory PillSheetState({PillSheetModel entity}) = _PillSheetState;
+
+  bool get isHidden => entity == null || entity.isDeleted || entity.isEnded;
 }


### PR DESCRIPTION
## What
ユーザーが登録した最後のピルシートのデータの取得方法。及びアプリの扱い方を変更する

## Why
今までは下記の条件を満たしているピルシートのデータのみをアプリで扱うように一括でフィルタリングしていたが、カレンダー画面でピルシート起点で生理予定日を計算した結果を表示する場合において表示できなくなったので条件等を見直す

#### 今まで
- ピルシートがデータとして存在する
- ピルシートが飲み始めてから29日移譲経過していない
- ピルシートが削除されていない

#### これから
- ピルシートがデータとして存在する

というふうに変えた。ピルシートが存在していればアプリ上でも扱う。UIの細かな条件(例えばレコード画面の場合は終わっているピルシートや削除されているピルシートは表示しない。あたかも存在していないようにする)は個々のWidgetのclass起点で行う

## How
- Functionsの方でuser.latestPillSheetを書き込む
- service/pill_sheetに存在していた今までのフィルターを削除。そしてuser.latestPillSheetを見るようにする
- pillSheetの書き込みは今まで通り `users/{userID}/pill_sheets` に書き込み
- record_page, settings_pageでは pillSheet != null の場所を !pillSheetState.isInvalid に置き換える
- 生理予定日のロジックを latestPillSheet から計算して、かつ今日よりもあとの日付を表示するように書き換えた
  * ユーザーがアプリを放置していて、3ヶ月あとに開いたときに2ヶ月前の日付が生理予定日として表示されているってこともありそうだから
  * 適当に12ヶ月分までは保証。あとは知らない

## Checked
- [x] 初期設定でピルシートが作成されることを確認
- [x] 設定画面からピル番号変更できる
- [x] 設定画面からピルシートの種類変更ができる
- [x] ピルシートを破棄できる
  - [x] レコード画面にはピルシートが出ていない
  - [x] カレンダー画面には生理予定日等が出ている
  - [x] 設定画面にピル番号変更が出ていない
  - [x] 設定画面にピルシートの破棄が出ていない
  - [x] ピルシートの種類を変更してもuser.latestPillSheetが変わらない

## Likns
resolved: https://github.com/bannzai/_Pilll/issues/254