### PR TITLE
:art: update record page before subscribe result

### DIFF
--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -50,7 +50,11 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   }
 
   void take(DateTime takenDate) {
-    _service.update(state.entity.copyWith(lastTakenDate: takenDate));
+    // NOTE: updated ui immediately after request is success. Because firebase fucntions => firestore connection is slow ready that means user.latestPillSheet does not update immediately.
+    final updated = state.entity.copyWith(lastTakenDate: takenDate);
+    _service
+        .update(updated)
+        .then((value) => state = state.copyWith(entity: updated));
   }
 
   DateTime calcBeginingDateFromNextTodayPillNumber(int pillNumber) {


### PR DESCRIPTION
## What
DBのuser.latestPillSheetが更新された通知が来る前にUIをアップデートしてしまう

## Why
Firebase FunctionsのCold StartによりFirestoreにデータの反映が遅れる場合が発生するため