### PR TITLE
Disable top safearea for RecordPage

### DIFF
--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -28,7 +28,7 @@ class RecordPage extends HookWidget {
       backgroundColor: PilllColors.background,
       appBar: null,
       extendBodyBehindAppBar: true,
-      body: SafeArea(child: _body(context)),
+      body: SafeArea(top: false, child: _body(context)),
     );
   }
 


### PR DESCRIPTION
## What
RecordPageの上に余白が空いたのでSafeAreaを無効化する

## Checked
ローカルのiOS Simulator立ち上がるの遅いので配布してから確認する。たぶんだいじょうぶ