### PR TITLE
:art: fix record page design

### DIFF
--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -24,11 +24,65 @@ import 'package:hooks_riverpod/all.dart';
 class RecordPage extends HookWidget {
   @override
   Widget build(BuildContext context) {
+    final state = useProvider(pillSheetStoreProvider.state);
+    final store = useProvider(pillSheetStoreProvider);
+    final currentPillSheet = state.entity;
     return Scaffold(
       backgroundColor: PilllColors.background,
-      appBar: null,
+      appBar: AppBar(
+        titleSpacing: 0,
+        backgroundColor: PilllColors.white,
+        toolbarHeight: 130,
+        title: RecordTakenInformation(
+          today: DateTime.now(),
+          state: state,
+          onPressed: () {
+            showModalBottomSheet(
+              context: context,
+              builder: (BuildContext context) {
+                var selectedTodayPillNumber = currentPillSheet.todayPillNumber;
+                return Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    PickerToolbar(
+                      done: (() {
+                        store.modifyBeginingDate(selectedTodayPillNumber);
+                        Navigator.pop(context);
+                      }),
+                      cancel: (() {
+                        Navigator.pop(context);
+                      }),
+                    ),
+                    Container(
+                      height: 200,
+                      child: GestureDetector(
+                        onTap: () {
+                          Navigator.pop(context);
+                        },
+                        child: CupertinoPicker(
+                          itemExtent: 40,
+                          children: List.generate(
+                              currentPillSheet.typeInfo.totalCount,
+                              (index) => Text("${index + 1}")),
+                          onSelectedItemChanged: (index) {
+                            selectedTodayPillNumber = index + 1;
+                          },
+                          scrollController: FixedExtentScrollController(
+                            initialItem: selectedTodayPillNumber - 1,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                );
+              },
+            );
+          },
+        ),
+      ),
       extendBodyBehindAppBar: true,
-      body: SafeArea(top: false, child: _body(context)),
+      body: _body(context),
     );
   }
 
@@ -44,54 +98,6 @@ class RecordPage extends HookWidget {
     return Center(
       child: ListView(
         children: [
-          RecordTakenInformation(
-            today: DateTime.now(),
-            state: state,
-            onPressed: () {
-              showModalBottomSheet(
-                context: context,
-                builder: (BuildContext context) {
-                  var selectedTodayPillNumber =
-                      currentPillSheet.todayPillNumber;
-                  return Column(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      PickerToolbar(
-                        done: (() {
-                          store.modifyBeginingDate(selectedTodayPillNumber);
-                          Navigator.pop(context);
-                        }),
-                        cancel: (() {
-                          Navigator.pop(context);
-                        }),
-                      ),
-                      Container(
-                        height: 200,
-                        child: GestureDetector(
-                          onTap: () {
-                            Navigator.pop(context);
-                          },
-                          child: CupertinoPicker(
-                            itemExtent: 40,
-                            children: List.generate(
-                                currentPillSheet.typeInfo.totalCount,
-                                (index) => Text("${index + 1}")),
-                            onSelectedItemChanged: (index) {
-                              selectedTodayPillNumber = index + 1;
-                            },
-                            scrollController: FixedExtentScrollController(
-                              initialItem: selectedTodayPillNumber - 1,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  );
-                },
-              );
-            },
-          ),
           if (_notificationString(state).isNotEmpty)
             ConstrainedBox(
               constraints: BoxConstraints.expand(height: 26),

--- a/lib/domain/record/record_taken_information.dart
+++ b/lib/domain/record/record_taken_information.dart
@@ -28,7 +28,7 @@ class RecordTakenInformation extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: 150,
+      height: 130,
       decoration: BoxDecoration(
         color: Colors.white,
         boxShadow: [
@@ -41,7 +41,7 @@ class RecordTakenInformation extends StatelessWidget {
       ),
       child: Column(
         children: <Widget>[
-          SizedBox(height: 54),
+          SizedBox(height: 34),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[


### PR DESCRIPTION
## What
レコードページのデザイン調整
status bar 文の余白をなくす

## How
- SafeArea箱のページに要らないので削除
- AppBarにRecordInfomationを置くように調整。高さを150pxから130pxにした

## Why
[このPR](https://github.com/bannzai/Pilll/pull/103)でSafeAreaが原因だと思ってカジュアルに直したけど違った)
[こっちのPR](https://github.com/bannzai/Pilll/pull/99)でListViewに変えちゃったのがおそらく要因だろう