### PR TITLE
:recycle: add delegate for notification handler

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -9,6 +9,7 @@ import Flutter
   ) -> Bool {
     UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: ["repeat_notification_for_taken_pill", "remind_notification_for_taken_pill"])
     UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["repeat_notification_for_taken_pill", "remind_notification_for_taken_pill"])
+    UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }


### PR DESCRIPTION
## What
Firebase Cloud MessagingにおいてiOS側で処理をハンドリングするコードの入れ忘れがあったので対応。もしかしたらAndroidもあるかも。後で調査する

ref: https://pub.dev/packages/firebase_messaging#ios-integration