### PR TITLE
LatestPillSheet get from users/{id}/pill_sheets

### DIFF
--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -88,7 +88,6 @@ class RecordPage extends HookWidget {
   }
 
   Widget _body(BuildContext context) {
-    hideIndicator();
     final state = useProvider(pillSheetStoreProvider.state);
     final currentPillSheet = state.entity;
     final store = useProvider(pillSheetStoreProvider);

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -49,7 +49,6 @@ abstract class User implements _$User {
   factory User({
     @required String anonymouseUserID,
     @JsonKey(name: "settings") Setting setting,
-    PillSheetModel latestPillSheet,
     @Default(false) bool migratedFlutter,
   }) = _User;
 

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -52,7 +52,11 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
 
   void take(DateTime takenDate) {
     showIndicator();
-    _service.update(state.entity.copyWith(lastTakenDate: takenDate));
+    final updated = state.entity.copyWith(lastTakenDate: takenDate);
+    _service.update(updated).then((value) {
+      hideIndicator();
+      state = state.copyWith(entity: updated);
+    });
   }
 
   DateTime calcBeginingDateFromNextTodayPillNumber(int pillNumber) {


### PR DESCRIPTION
## What
[このPR]でuser.latestPillSheetからUserが最後に作ったピルシートを取得しようとしたが以前のロジックに戻して `users/{id}/pill_sheets` の中でcreated_atが一番新しいものを取得するようにする

## Why
Cloud Functions経由でuser.latestPillSheetを埋めていて、アプリ側ではその変更を検知しようとしていた。が、Cold Startなどでレスポンスが遅い状態が発生しがちなので処理内容を以前の流れに戻す。以前と違うところは削除されたピルシート等でもフィルタリングせずにアプリに返すことにより当初の目的は達成している。

## Checked

- [x] 初期設定でピルシートが作成されることを確認
- [x] 設定画面からピル番号変更できる
- [x] 設定画面からピルシートの種類変更ができる
- [x] ピルシートを破棄できる
  - [x] レコード画面にはピルシートが出ていない
  - [x] カレンダー画面には生理予定日等が出ている
  - [x] 設定画面にピル番号変更が出ていない
  - [x] 設定画面にピルシートの破棄が出ていない
  - [x] ピルシートの種類を変更してもuser.latestPillSheetが変わらない