### PR TITLE
Add quick record function for iOS

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -65,6 +65,7 @@ extension AppDelegate {
             switch response.actionIdentifier {
             case "RECORD_PILL":
                 // NOTE: call flutter record function
+                print(response.actionIdentifier)
                 break
             default:
                 break

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,4 +1,5 @@
 import UIKit
+import ObjectiveC
 import Flutter
 
 @UIApplicationMain
@@ -7,11 +8,78 @@ import Flutter
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    swizzleNotificationCenterDelegateMethod()
+    configureNotificationActionableButtons()
     UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: ["repeat_notification_for_taken_pill", "remind_notification_for_taken_pill"])
     UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["repeat_notification_for_taken_pill", "remind_notification_for_taken_pill"])
-    UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
+    UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }
 
+
+// MARK: - Notification
+extension AppDelegate {
+    private func swizzleNotificationCenterDelegateMethod() {
+        guard let fromMethod = class_getInstanceMethod(type(of: self), #selector(AppDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:))) else {
+            fatalError()
+        }
+        guard let toMethod = class_getInstanceMethod(type(of: self), #selector(AppDelegate.userNotificationCenter_methodSwizzling(_:didReceive:withCompletionHandler:))) else {
+            fatalError()
+        }
+        
+        method_exchangeImplementations(fromMethod, toMethod)
+    }
+
+    private func configureNotificationActionableButtons() {
+        let recordAction = UNNotificationAction(identifier: "RECORD_PILL",
+                                                title: "飲んだ",
+                                                options: UNNotificationActionOptions(rawValue: 0))
+        let category =
+            UNNotificationCategory(identifier: Category.pillReminder.rawValue,
+                                   actions: [recordAction],
+                                   intentIdentifiers: [],
+                                   hiddenPreviewsBodyPlaceholder: "",
+                                   options: .customDismissAction)
+        let notificationCenter = UNUserNotificationCenter.current()
+        notificationCenter.setNotificationCategories([category])
+    }
+
+    @objc func userNotificationCenter_methodSwizzling(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        defer {
+            var isCompleted: Bool = false
+            let completionHandlerWrapper = {
+                isCompleted = true
+                completionHandler()
+            }
+            userNotificationCenter_methodSwizzling(center, didReceive: response, withCompletionHandler: completionHandlerWrapper)
+            if !isCompleted {
+                completionHandler()
+            }
+        }
+        switch extractCategory(userInfo: response.notification.request.content.userInfo) {
+        case nil:
+            return
+        case .pillReminder:
+            switch response.actionIdentifier {
+            case "RECORD_PILL":
+                // NOTE: call flutter record function
+                break
+            default:
+                break
+            }
+        }
+    }
+   
+    enum Category: String {
+        case pillReminder = "PILL_REMINDER"
+    }
+
+    private func extractCategory(userInfo: [AnyHashable: Any]) -> Category? {
+        guard let apns = userInfo["apns"] as? [String: Any], let category = apns["category"] as? String else {
+            return nil
+        }
+        return Category(rawValue: category)
+    }
+}

--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -5,6 +5,7 @@ import 'package:Pilll/analytics.dart';
 import 'package:Pilll/components/atoms/color.dart';
 import 'package:Pilll/entity/user_error.dart';
 import 'package:Pilll/error/universal_error_page.dart';
+import 'package:Pilll/global_method_channel.dart';
 import 'package:Pilll/router/router.dart';
 import 'package:Pilll/service/push_notification.dart';
 import 'package:Pilll/util/environment.dart';
@@ -35,6 +36,7 @@ Future<void> entrypoint() async {
   };
   FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
   listenNotificationEvents();
+  definedChannel();
   runZonedGuarded(() {
     runApp(ProviderScope(child: App()));
   }, (error, stack) => FirebaseCrashlytics.instance.recordError(error, stack));

--- a/lib/global_method_channel.dart
+++ b/lib/global_method_channel.dart
@@ -1,0 +1,25 @@
+import 'package:Pilll/database/database.dart';
+import 'package:Pilll/service/pill_sheet.dart';
+import 'package:Pilll/util/datetime/day.dart';
+import 'package:flutter/services.dart';
+
+import 'auth/auth.dart';
+
+final _channel = MethodChannel("method.channel.MizukiOhashi.Pilll");
+definedChannel() {
+  _channel.setMethodCallHandler((MethodCall call) async {
+    switch (call.method) {
+      case 'recordPill':
+        return recordPill();
+      default:
+        break;
+    }
+  });
+}
+
+Future<void> recordPill() async {
+  final authInfo = await auth();
+  final service = PillSheetService(DatabaseConnection(authInfo.uid));
+  final entity = await service.fetchLast();
+  await service.update(entity.copyWith(lastTakenDate: now()));
+}


### PR DESCRIPTION
## What
iOS側の実装でQuickRecord用の通知が来たらそれに対応できるようにした

## How
Swift,Dart両方編集する必要があった
- SwiftではAppDelegateに通知を受け取ったときに `AppDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)` が実行される。が、Flutterの場合AppDelegateのsuperclassがすでに定義されていた。なのでmethod_swizzleを使ってメソッドを入れ替えてFlutterの処理の前に処理を挟み込む形式にした。なお、Flutter的にはFlutterDelegateを消してコピペすればオッケ。と書いてはあったが現状もmasterの方で5days agoに変更があったので現実的じゃないと判断。メソッド入れ替えるほうが楽
- Dart側では特定のChannel経由でメソッドが呼ばれたら既存のDartに用意されている部品を利用して、最後に飲んだ日付を今日に上書きする処理を入れる

## TODO
- Androidの実装