### PR TITLE
implementation android quick record

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,5 +47,13 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <service
+            android:name=".PilllFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -48,6 +48,13 @@
             android:name="flutterEmbedding"
             android:value="2" />
 
+        <receiver android:name=".BroadCastActionReceiver"  android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.INPUT_METHOD_CHANGED" />
+            </intent-filter>
+        </receiver>
+
         <service
             android:name=".PilllFirebaseMessagingService"
             android:exported="false">

--- a/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import androidx.core.app.NotificationManagerCompat
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.dart.DartExecutor
 import io.flutter.plugin.common.MethodChannel
@@ -12,12 +13,11 @@ import io.flutter.plugin.common.MethodChannel
 public class BroadCastActionReceiver: BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         Log.d("android message: ", "onReceive")
-        callRecordPill(context)
-    }
-    private fun methodChannel(context: Context?): MethodChannel? {
-        if (context == null) {
-            return null;
+        if (context != null) {
+            callRecordPill(context)
         }
+    }
+    private fun methodChannel(context: Context): MethodChannel {
         val flutterEngine = FlutterEngine(context)
         flutterEngine
                 .dartExecutor
@@ -26,7 +26,10 @@ public class BroadCastActionReceiver: BroadcastReceiver() {
                 )
         return MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "method.channel.MizukiOhashi.Pilll")
     }
-    private fun callRecordPill(context: Context?) {
-        methodChannel(context)?.invokeMethod("recordPill", "")
+    private fun callRecordPill(context: Context) {
+        methodChannel(context).invokeMethod("recordPill", "")
+        with(NotificationManagerCompat.from(context)) {
+            cancel(PilllFirebaseMessagingService.pillReminderID)
+        }
     }
 }

--- a/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
@@ -14,8 +14,11 @@ public class BroadCastActionReceiver: BroadcastReceiver() {
         Log.d("android message: ", "onReceive")
         callRecordPill(context)
     }
-    private fun methodChannel(context: Context?): MethodChannel {
-        val flutterEngine = FlutterEngine(context!!)
+    private fun methodChannel(context: Context?): MethodChannel? {
+        if (context == null) {
+            return null;
+        }
+        val flutterEngine = FlutterEngine(context)
         flutterEngine
                 .dartExecutor
                 .executeDartEntrypoint(
@@ -24,6 +27,6 @@ public class BroadCastActionReceiver: BroadcastReceiver() {
         return MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "method.channel.MizukiOhashi.Pilll")
     }
     private fun callRecordPill(context: Context?) {
-        methodChannel(context).invokeMethod("recordPill", "")
+        methodChannel(context)?.invokeMethod("recordPill", "")
     }
 }

--- a/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
@@ -1,0 +1,29 @@
+package com.mizuki.Ohashi.Pilll
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.dart.DartExecutor
+import io.flutter.plugin.common.MethodChannel
+
+
+public class BroadCastActionReceiver: BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        Log.d("android message: ", "onReceive")
+        callRecordPill(context)
+    }
+    private fun methodChannel(context: Context?): MethodChannel {
+        val flutterEngine = FlutterEngine(context!!)
+        flutterEngine
+                .dartExecutor
+                .executeDartEntrypoint(
+                        DartExecutor.DartEntrypoint.createDefault()
+                )
+        return MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "method.channel.MizukiOhashi.Pilll")
+    }
+    private fun callRecordPill(context: Context?) {
+        methodChannel(context).invokeMethod("recordPill", "")
+    }
+}

--- a/android/app/src/main/kotlin/com/example/Pilll/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/MainActivity.kt
@@ -26,7 +26,6 @@ class MainActivity: FlutterActivity() {
         super.onStart()
         Log.d("android message: ", "onStart")
         createNotificationChannel();
-        register()
     }
     private fun createNotificationChannel() {
         // Create the NotificationChannel, but only on API 26+ because
@@ -41,29 +40,5 @@ class MainActivity: FlutterActivity() {
                     getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             notificationManager.createNotificationChannel(channel)
         }
-    }
-    private fun register() {
-//        this.registerReceiver(BroadCastActionReceiver(), IntentFilter("PILL_REMINDER"))
-        this.registerReceiver(broadcastReceiver, IntentFilter("PILL_REMINDER"))
-    }
-
-    var broadcastReceiver: BroadcastReceiver = object: BroadcastReceiver() {
-        override fun onReceive(p0: Context?, p1: Intent?) {
-            Log.d("android message:", "BroadcastReceiver.onReceive")
-            callRecordPill()
-        }
-    }
-
-    private fun methodChannel(): MethodChannel {
-        val flutterEngine = FlutterEngine(this)
-        flutterEngine
-                .dartExecutor
-                .executeDartEntrypoint(
-                        DartExecutor.DartEntrypoint.createDefault()
-                )
-        return MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "method.channel.MizukiOhashi.Pilll")
-    }
-    private fun callRecordPill() {
-        methodChannel().invokeMethod("recordPill", "")
     }
 }

--- a/android/app/src/main/kotlin/com/example/Pilll/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/MainActivity.kt
@@ -1,6 +1,59 @@
 package com.mizuki.Ohashi.Pilll
 
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.graphics.BitmapFactory
+import android.os.Bundle
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodChannel
 
 class MainActivity: FlutterActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState);
+    }
+
+}
+
+public class PilllFirebaseMessagingService: FirebaseMessagingService() {
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        super.onMessageReceived(remoteMessage)
+        val notification = remoteMessage.notification
+        if (notification != null) {
+            send(notification, remoteMessage.data)
+        }
+    }
+
+    fun send(notification: RemoteMessage.Notification, data: Map<String, String>) {
+        // Create an explicit intent for an Activity in your app
+        val snoozeIntent = Intent(this, ActionReceiver::class.java).apply {
+            action = "PILL_REMINDER"
+        }
+        val snoozePendingIntent: PendingIntent =
+                PendingIntent.getBroadcast(this, 0, snoozeIntent, 0)
+
+        val builder = NotificationCompat.Builder(this, "PILL_REMINDER")
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentTitle("My notification")
+                .setContentText(data.toString())
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .addAction(R.drawable.common_google_signin_btn_icon_dark, "ORE NO ACTION",
+                        snoozePendingIntent)
+                .setAutoCancel(true)
+        with(NotificationManagerCompat.from(this)) {
+            // notificationId is a unique int for each notification that you must define
+            notify(1, builder.build())
+        }
+    }
+}
+public class ActionReceiver: BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        MethodChannel(BinaryMessenger())
+    }
 }

--- a/android/app/src/main/kotlin/com/example/Pilll/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/MainActivity.kt
@@ -1,59 +1,22 @@
 package com.mizuki.Ohashi.Pilll
 
-import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.graphics.BitmapFactory
+import android.content.IntentFilter
 import android.os.Bundle
-import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
-import com.google.firebase.messaging.FirebaseMessagingService
-import com.google.firebase.messaging.RemoteMessage
+import android.util.Log
 import io.flutter.embedding.android.FlutterActivity
-import io.flutter.plugin.common.BinaryMessenger
-import io.flutter.plugin.common.MethodChannel
 
 class MainActivity: FlutterActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState);
-    }
-
-}
-
-public class PilllFirebaseMessagingService: FirebaseMessagingService() {
-    override fun onMessageReceived(remoteMessage: RemoteMessage) {
-        super.onMessageReceived(remoteMessage)
-        val notification = remoteMessage.notification
-        if (notification != null) {
-            send(notification, remoteMessage.data)
-        }
-    }
-
-    fun send(notification: RemoteMessage.Notification, data: Map<String, String>) {
-        // Create an explicit intent for an Activity in your app
-        val snoozeIntent = Intent(this, ActionReceiver::class.java).apply {
-            action = "PILL_REMINDER"
-        }
-        val snoozePendingIntent: PendingIntent =
-                PendingIntent.getBroadcast(this, 0, snoozeIntent, 0)
-
-        val builder = NotificationCompat.Builder(this, "PILL_REMINDER")
-                .setSmallIcon(R.mipmap.ic_launcher)
-                .setContentTitle("My notification")
-                .setContentText(data.toString())
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                .addAction(R.drawable.common_google_signin_btn_icon_dark, "ORE NO ACTION",
-                        snoozePendingIntent)
-                .setAutoCancel(true)
-        with(NotificationManagerCompat.from(this)) {
-            // notificationId is a unique int for each notification that you must define
-            notify(1, builder.build())
-        }
+        Log.d("android message: ", "onCreate")
     }
 }
+
 public class ActionReceiver: BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
-        MethodChannel(BinaryMessenger())
+        Log.d("android message:", "onReceive")
     }
 }

--- a/android/app/src/main/kotlin/com/example/Pilll/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/MainActivity.kt
@@ -1,22 +1,69 @@
 package com.mizuki.Ohashi.Pilll
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.dart.DartExecutor
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugins.GeneratedPluginRegistrant
 
 class MainActivity: FlutterActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState);
         Log.d("android message: ", "onCreate")
     }
-}
 
-public class ActionReceiver: BroadcastReceiver() {
-    override fun onReceive(context: Context?, intent: Intent?) {
-        Log.d("android message:", "onReceive")
+    override fun onStart() {
+        super.onStart()
+        Log.d("android message: ", "onStart")
+        createNotificationChannel();
+        register()
+    }
+    private fun createNotificationChannel() {
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel("PILL_REMINDER", "method.channel.MizukiOhashi.Pilll", importance).apply {
+                description = "method.channel.MizukiOhashi.Pilll.description"
+            }
+            // Register the channel with the system
+            val notificationManager: NotificationManager =
+                    getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+    private fun register() {
+//        this.registerReceiver(BroadCastActionReceiver(), IntentFilter("PILL_REMINDER"))
+        this.registerReceiver(broadcastReceiver, IntentFilter("PILL_REMINDER"))
+    }
+
+    var broadcastReceiver: BroadcastReceiver = object: BroadcastReceiver() {
+        override fun onReceive(p0: Context?, p1: Intent?) {
+            Log.d("android message:", "BroadcastReceiver.onReceive")
+            callRecordPill()
+        }
+    }
+
+    private fun methodChannel(): MethodChannel {
+        val flutterEngine = FlutterEngine(this)
+        flutterEngine
+                .dartExecutor
+                .executeDartEntrypoint(
+                        DartExecutor.DartEntrypoint.createDefault()
+                )
+        return MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "method.channel.MizukiOhashi.Pilll")
+    }
+    private fun callRecordPill() {
+        methodChannel().invokeMethod("recordPill", "")
     }
 }

--- a/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
@@ -1,30 +1,29 @@
 package com.mizuki.Ohashi.Pilll
 
+import android.app.NotificationManager
 import android.app.PendingIntent
+import android.content.Context
 import android.content.Intent
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import com.mizuki.Ohashi.Pilll.ActionReceiver
 import com.mizuki.Ohashi.Pilll.R
 
 public class PilllFirebaseMessagingService: FirebaseMessagingService() {
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         super.onMessageReceived(remoteMessage)
         Log.d("android message: ", "onMessageReceived")
-        val notification = remoteMessage.notification
-        if (notification != null) {
-            send(notification, remoteMessage.data)
-        }
+        send(remoteMessage.data)
     }
 
-    fun send(notification: RemoteMessage.Notification, data: Map<String, String>) {
+    fun send( data: Map<String, String>) {
+        Log.d("android message: ", "send")
+
         // Create an explicit intent for an Activity in your app
-        val snoozeIntent = Intent(this, ActionReceiver::class.java).apply {
+        val snoozeIntent = Intent().apply {
             action = "PILL_REMINDER"
-            putExtra("TESTPUTEXTRA", "TESTPUTEXTRAVALUE")
         }
         val snoozePendingIntent: PendingIntent =
                 PendingIntent.getBroadcast(this, 0, snoozeIntent, 0)
@@ -33,13 +32,12 @@ public class PilllFirebaseMessagingService: FirebaseMessagingService() {
                 .setSmallIcon(R.mipmap.ic_launcher)
                 .setContentTitle("My notification")
                 .setContentText(data.toString())
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .addAction(R.drawable.common_google_signin_btn_icon_dark, "ORE NO ACTION",
                         snoozePendingIntent)
-                .setAutoCancel(true)
         with(NotificationManagerCompat.from(this)) {
             // notificationId is a unique int for each notification that you must define
-            notify(1, builder.build())
+            notify(0, builder.build())
         }
     }
 }

--- a/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
@@ -28,13 +28,16 @@ public class PilllFirebaseMessagingService: FirebaseMessagingService() {
         val snoozePendingIntent: PendingIntent =
                 PendingIntent.getBroadcast(this, 0, snoozeIntent, 0)
 
+        val title = data["title"]
+        val body = data["body"]
         val builder = NotificationCompat.Builder(this, "PILL_REMINDER")
                 .setSmallIcon(R.mipmap.ic_launcher)
-                .setContentTitle("My notification")
-                .setContentText(data.toString())
-                .setPriority(NotificationCompat.PRIORITY_HIGH)
-                .addAction(R.drawable.common_google_signin_btn_icon_dark, "ORE NO ACTION",
-                        snoozePendingIntent)
+                .setContentTitle(title)
+                .setContentText(body)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .addAction(0, "飲んだ",
+                        snoozePendingIntent
+                )
         with(NotificationManagerCompat.from(this)) {
             // notificationId is a unique int for each notification that you must define
             notify(0, builder.build())

--- a/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
@@ -41,6 +41,7 @@ public class PilllFirebaseMessagingService: FirebaseMessagingService() {
                 .addAction(0, "飲んだ",
                         snoozePendingIntent
                 )
+                .setAutoCancel(true)
         with(NotificationManagerCompat.from(this)) {
             // notificationId is a unique int for each notification that you must define
             notify(pillReminderID, builder.build())

--- a/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
@@ -12,6 +12,9 @@ import com.google.firebase.messaging.RemoteMessage
 import com.mizuki.Ohashi.Pilll.R
 
 public class PilllFirebaseMessagingService: FirebaseMessagingService() {
+    companion object {
+        val pillReminderID = 1
+    }
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         super.onMessageReceived(remoteMessage)
         Log.d("android message: ", "onMessageReceived")
@@ -40,7 +43,7 @@ public class PilllFirebaseMessagingService: FirebaseMessagingService() {
                 )
         with(NotificationManagerCompat.from(this)) {
             // notificationId is a unique int for each notification that you must define
-            notify(0, builder.build())
+            notify(pillReminderID, builder.build())
         }
     }
 }

--- a/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
@@ -1,0 +1,45 @@
+package com.mizuki.Ohashi.Pilll
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.mizuki.Ohashi.Pilll.ActionReceiver
+import com.mizuki.Ohashi.Pilll.R
+
+public class PilllFirebaseMessagingService: FirebaseMessagingService() {
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        super.onMessageReceived(remoteMessage)
+        Log.d("android message: ", "onMessageReceived")
+        val notification = remoteMessage.notification
+        if (notification != null) {
+            send(notification, remoteMessage.data)
+        }
+    }
+
+    fun send(notification: RemoteMessage.Notification, data: Map<String, String>) {
+        // Create an explicit intent for an Activity in your app
+        val snoozeIntent = Intent(this, ActionReceiver::class.java).apply {
+            action = "PILL_REMINDER"
+            putExtra("TESTPUTEXTRA", "TESTPUTEXTRAVALUE")
+        }
+        val snoozePendingIntent: PendingIntent =
+                PendingIntent.getBroadcast(this, 0, snoozeIntent, 0)
+
+        val builder = NotificationCompat.Builder(this, "PILL_REMINDER")
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentTitle("My notification")
+                .setContentText(data.toString())
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .addAction(R.drawable.common_google_signin_btn_icon_dark, "ORE NO ACTION",
+                        snoozePendingIntent)
+                .setAutoCancel(true)
+        with(NotificationManagerCompat.from(this)) {
+            // notificationId is a unique int for each notification that you must define
+            notify(1, builder.build())
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
@@ -22,7 +22,7 @@ public class PilllFirebaseMessagingService: FirebaseMessagingService() {
         Log.d("android message: ", "send")
 
         // Create an explicit intent for an Activity in your app
-        val snoozeIntent = Intent().apply {
+        val snoozeIntent = Intent(this, BroadCastActionReceiver::class.java).apply {
             action = "PILL_REMINDER"
         }
         val snoozePendingIntent: PendingIntent =

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,7 @@
+import 'package:Pilll/entrypoint.dart';
+import 'package:Pilll/util/environment.dart';
+
+Future<void> main() async {
+  Environment.flavor = Flavor.DEVELOP;
+  await entrypoint();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,0 @@
-import 'package:Pilll/entrypoint.dart';
-import 'package:Pilll/util/environment.dart';
-
-Future<void> main() async {
-  Environment.flavor = Flavor.DEVELOP;
-  await entrypoint();
-}


### PR DESCRIPTION
## What
WIP
- Andriod用のQuickRecord作成

## Links
参考: https://developer.android.com/training/notify-user/build-notification?hl=ja
https://www.raywenderlich.com/9227276-firebase-cloud-messaging-for-android-sending-push-notifications
https://medium.com/@info_67212/firebase-push-notification-with-action-button-in-flutter-a841da348097

## TODO
- [x] main.dart 消す

## Checked
- [x] foregroundの状態で通知を受け取れる
- [x] foregroundの状態で飲んだが押せる
- [x] backgroundの状態で通知を受け取れる
- [x] backgroundの状態で飲んだが押せる
- [x] killedの状態で通知を受け取れる
- [x] killedの状態で飲んだが押せる