### PR TITLE
:art: :up: margin to -30

### DIFF
--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -115,7 +115,7 @@ class RecordPage extends HookWidget {
                 ),
               ),
             ),
-          SizedBox(height: 97),
+          SizedBox(height: 67),
           if (state.isInvalid)
             Align(
                 child:


### PR DESCRIPTION
## What
RecordPageの上部マージンを-30にした

## Why
iPhone SE (2nd)端末で微妙にきれてしまうため

## Memo
Centerにしようとしたけど、それでもiPhone SE(1st)ではおさまらないのでスクローラブルにする必要がありそうだったため、とりあえずマージンを上に持っていくようにした