### PR TITLE
Fix quick record end timing

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -68,7 +68,7 @@ extension AppDelegate {
     }
 
     @objc func userNotificationCenter_methodSwizzling(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        defer {
+        func end(delay: TimeInterval = 0) {
             var isCompleted: Bool = false
             let completionHandlerWrapper = {
                 isCompleted = true
@@ -79,7 +79,7 @@ extension AppDelegate {
             // ちなみにリミットは30秒以内にcompletionを呼ぶ:  https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app
             // なおバッジはすぐに消しても良いと判断して消した
             UIApplication.shared.applicationIconBadgeNumber = 0
-            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
                 self.userNotificationCenter_methodSwizzling(center, didReceive: response, withCompletionHandler: completionHandlerWrapper)
                 if !isCompleted {
                     completionHandlerWrapper()
@@ -93,9 +93,9 @@ extension AppDelegate {
             switch response.actionIdentifier {
             case "RECORD_PILL":
                 call(method: "recordPill", arguments: nil)
-                break
+                end(delay: 10)
             default:
-                break
+                end()
             }
         }
     }


### PR DESCRIPTION
## What
やったことはQuick Recordのアクション時に
- 「完了」とシステムに伝える時に10秒のdelayを挟む
- メインスレッドで呼ぶ

## Why
- Quick Recordをしたが記録がうまくいかない
- 再度通知が来てしまう
- 通知からアプリを開くと記録ができている状態になっている

という現象が発生した。`(AppDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:))`のcompletionHandlerはあFlutterに存在しているQuick Recordの関数をすぐに呼び出した後にcompletionしていた。 だが、通信環境等によってはFlutterのfirestoreに書き込む処理が終わっていない場合もありえるのでこの場合はQuick Recordはうまくいかない

アプリを再度開くと記録されている状態になっているのはおそらく Firestoreが途中までのリクエストを保持していたため、アプリが起動した時にリクエストの続きがされた。という可能性がじゃっかんある。試しに10秒のdelayを入れて様子を見る