### PR TITLE
Fix timing about listen to push notification after requset notification auth

### DIFF
--- a/lib/domain/home/home_page.dart
+++ b/lib/domain/home/home_page.dart
@@ -6,6 +6,7 @@ import 'package:Pilll/domain/record/record_page.dart';
 import 'package:Pilll/domain/settings/settings_page.dart';
 import 'package:Pilll/components/atoms/color.dart';
 import 'package:Pilll/components/atoms/text_color.dart';
+import 'package:Pilll/service/push_notification.dart';
 import 'package:Pilll/service/setting.dart';
 import 'package:Pilll/util/datetime/day.dart';
 import 'package:Pilll/util/formatter/date_time_formatter.dart';
@@ -31,6 +32,7 @@ class _HomePageState extends State<HomePage>
         TabController(length: 3, vsync: this, initialIndex: _selectedIndex);
     _tabController.addListener(_handleTabSelection);
     auth().then((auth) {
+      requestNotificationPermissions();
       SettingService(DatabaseConnection(auth.uid)).fetch().then((setting) {
         if (setting.isOnReminder) {
           analytics.logEvent(name: "user_allowed_notification");

--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -6,10 +6,8 @@ import 'package:Pilll/entity/user_error.dart';
 import 'package:Pilll/components/molecules/indicator.dart';
 import 'package:Pilll/error/template.dart';
 import 'package:Pilll/error/universal_error_page.dart';
-import 'package:Pilll/service/push_notification.dart';
 import 'package:Pilll/service/user.dart';
 import 'package:Pilll/util/shared_preference/keys.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/all.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -127,9 +125,6 @@ class RootState extends State<Root> {
     auth().then((authInfo) {
       final userService = UserService(DatabaseConnection(authInfo.uid));
       return userService.prepare().then((_) async {
-        final token = await FirebaseMessaging().getToken();
-        await userService.registerRemoteNotificationToken(token);
-        listenNotificationEvents();
         userService.saveLaunchInfo();
         userService.saveStats();
         final user = await userService.fetch();

--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -6,6 +6,7 @@ import 'package:Pilll/entity/user_error.dart';
 import 'package:Pilll/components/molecules/indicator.dart';
 import 'package:Pilll/error/template.dart';
 import 'package:Pilll/error/universal_error_page.dart';
+import 'package:Pilll/service/push_notification.dart';
 import 'package:Pilll/service/user.dart';
 import 'package:Pilll/util/shared_preference/keys.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -128,6 +129,7 @@ class RootState extends State<Root> {
       return userService.prepare().then((_) async {
         final token = await FirebaseMessaging().getToken();
         await userService.registerRemoteNotificationToken(token);
+        listenNotificationEvents();
         userService.saveLaunchInfo();
         userService.saveStats();
         final user = await userService.fetch();

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -1,4 +1,3 @@
-import 'package:Pilll/entity/pill_sheet.dart';
 import 'package:Pilll/entity/setting.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';

--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -35,7 +35,6 @@ Future<void> entrypoint() async {
     );
   };
   FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
-  listenNotificationEvents();
   definedChannel();
   runZonedGuarded(() {
     runApp(ProviderScope(child: App()));

--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -7,7 +7,6 @@ import 'package:Pilll/entity/user_error.dart';
 import 'package:Pilll/error/universal_error_page.dart';
 import 'package:Pilll/global_method_channel.dart';
 import 'package:Pilll/router/router.dart';
-import 'package:Pilll/service/push_notification.dart';
 import 'package:Pilll/util/environment.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_analytics/observer.dart';

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -23,6 +23,7 @@ class AppRouter {
     SharedPreferences.getInstance().then((storage) {
       storage.setBool(BoolKey.didEndInitialSetting, true);
       requestNotificationPermissions().then((value) {
+        listenNotificationEvents();
         Navigator.popUntil(context, (router) => router.isFirst);
         Navigator.pushReplacementNamed(context, Routes.main);
       });

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -22,10 +22,9 @@ class AppRouter {
   static void endInitialSetting(BuildContext context) {
     SharedPreferences.getInstance().then((storage) {
       storage.setBool(BoolKey.didEndInitialSetting, true);
-      requestNotificationPermissions().then((value) {
-        Navigator.popUntil(context, (router) => router.isFirst);
-        Navigator.pushReplacementNamed(context, Routes.main);
-      });
+      requestNotificationPermissions();
+      Navigator.popUntil(context, (router) => router.isFirst);
+      Navigator.pushReplacementNamed(context, Routes.main);
     });
   }
 }

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -22,9 +22,10 @@ class AppRouter {
   static void endInitialSetting(BuildContext context) {
     SharedPreferences.getInstance().then((storage) {
       storage.setBool(BoolKey.didEndInitialSetting, true);
-      requestNotificationPermissions();
-      Navigator.popUntil(context, (router) => router.isFirst);
-      Navigator.pushReplacementNamed(context, Routes.main);
+      requestNotificationPermissions().then((value) {
+        Navigator.popUntil(context, (router) => router.isFirst);
+        Navigator.pushReplacementNamed(context, Routes.main);
+      });
     });
   }
 }

--- a/lib/service/push_notification.dart
+++ b/lib/service/push_notification.dart
@@ -4,11 +4,11 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 
 Future<void> requestNotificationPermissions() async {
   await FirebaseMessaging().requestNotificationPermissions();
-  return listenNotificationEvents();
+  return Future.value();
 }
 
 Future<void> listenNotificationEvents() async {
-  return FirebaseMessaging()
+  FirebaseMessaging()
     ..configure(
       onMessage: (Map<String, dynamic> message) async {
         print('onMessage: $message');

--- a/lib/service/push_notification.dart
+++ b/lib/service/push_notification.dart
@@ -7,7 +7,7 @@ Future<void> requestNotificationPermissions() async {
   return Future.value();
 }
 
-Future<void> listenNotificationEvents() async {
+void listenNotificationEvents() {
   FirebaseMessaging()
     ..configure(
       onMessage: (Map<String, dynamic> message) async {

--- a/lib/service/push_notification.dart
+++ b/lib/service/push_notification.dart
@@ -3,8 +3,9 @@ import 'dart:io';
 import 'package:firebase_messaging/firebase_messaging.dart';
 
 Future<void> requestNotificationPermissions() async {
-  await FirebaseMessaging().requestNotificationPermissions();
-  return listenNotificationEvents();
+  return FirebaseMessaging()
+    ..requestNotificationPermissions()
+    ..onIosSettingsRegistered.listen((IosNotificationSettings settings) {});
 }
 
 Future<void> listenNotificationEvents() async {

--- a/lib/service/push_notification.dart
+++ b/lib/service/push_notification.dart
@@ -3,9 +3,8 @@ import 'dart:io';
 import 'package:firebase_messaging/firebase_messaging.dart';
 
 Future<void> requestNotificationPermissions() async {
-  return FirebaseMessaging()
-    ..requestNotificationPermissions()
-    ..onIosSettingsRegistered.listen((IosNotificationSettings settings) {});
+  await FirebaseMessaging().requestNotificationPermissions();
+  return listenNotificationEvents();
 }
 
 Future<void> listenNotificationEvents() async {


### PR DESCRIPTION
## What
- ~iOSで通知の許可を得たらFirebaseMessagingでListenをすぐ始める~
- FirebaseMessage.getTokenのあとにlistenNotificationEventsを呼ぶ

## Why
~FirebaseMessage.configureを呼ぶことによりプッシュ通知のリッスンが始まるが、 通知の許可をとった後にやらないと意味がない。アプリを起動した後にリッスンの処理を通すように~

途中から違うことに気づいた。この場合だとアップデート前に通知の許可をすでに取れているユーザーの説明にならない
- おそらくgetTokenを読んだときにTokenが作られ、Firemessage.configureでtokenベースの通知を受け取る場合はその後に呼ぶ必要があると推測

## 再現手順
- 1.3.2でユーザーを作る。通知を許可
- 2.0.0以降のバイナリを落とす。初期設定を通過
- アプリをバックグラウンド or kill
- そのあとに通知を送る。来ない(個々までが再現
- アプリをkillして、再度起動する
- アプリをバックグラウンド or kill
- 通知を送る。受け取れる