### PR TITLE
Fix functions for those affected by adding pill sheet type

### DIFF
--- a/lib/components/organisms/setting/setting_menstruation_page.dart
+++ b/lib/components/organisms/setting/setting_menstruation_page.dart
@@ -9,8 +9,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 abstract class SettingMenstruationPageConstants {
-  static final List<String> fromList =
-      List<String>.generate(8, (index) => index.toString());
   static final List<String> durationList =
       List<String>.generate(7, (index) => (index + 1).toString());
 }
@@ -32,6 +30,7 @@ class SettingMenstruationPage extends StatefulWidget {
   // NOTE: If done and skip is null, button is hidden
   final String doneText;
   final VoidCallback done;
+  final int pillSheetTotalCount;
   final SettingMenstruationPageModel model;
   final void Function(int from) fromMenstructionDidDecide;
   final void Function(int duration) durationMenstructionDidDecide;
@@ -41,6 +40,7 @@ class SettingMenstruationPage extends StatefulWidget {
     @required this.title,
     @required this.doneText,
     @required this.done,
+    @required this.pillSheetTotalCount,
     @required this.model,
     @required this.fromMenstructionDidDecide,
     @required this.durationMenstructionDidDecide,
@@ -177,7 +177,7 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
 
   void _showFromModalSheet(BuildContext context) {
     int keepSelectedFromMenstruation =
-        this.widget.model.selectedFromMenstruation ?? 0;
+        this.widget.model.selectedFromMenstruation ?? 1;
     showModalBottomSheet(
       context: context,
       builder: (BuildContext context) {
@@ -208,14 +208,16 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
                 },
                 child: CupertinoPicker(
                   itemExtent: 40,
-                  children: SettingMenstruationPageConstants.fromList
+                  children: List.generate(
+                          this.widget.pillSheetTotalCount, (index) => index + 1)
+                      .map((number) => number.toString())
                       .map(_pickerItem)
                       .toList(),
                   onSelectedItemChanged: (index) {
-                    keepSelectedFromMenstruation = index;
+                    keepSelectedFromMenstruation = index + 1;
                   },
                   scrollController: FixedExtentScrollController(
-                      initialItem: keepSelectedFromMenstruation),
+                      initialItem: keepSelectedFromMenstruation - 1),
                 ),
               ),
             ),
@@ -289,6 +291,7 @@ extension SettingMenstruationPageRoute on SettingMenstruationPage {
     @required String title,
     @required String doneText,
     @required VoidCallback done,
+    @required int pillSheetTotalCount,
     @required SettingMenstruationPageModel model,
     @required void Function(int from) fromMenstructionDidDecide,
     @required void Function(int duration) durationMenstructionDidDecide,
@@ -299,6 +302,7 @@ extension SettingMenstruationPageRoute on SettingMenstruationPage {
         title: title,
         doneText: doneText,
         done: done,
+        pillSheetTotalCount: pillSheetTotalCount,
         model: model,
         fromMenstructionDidDecide: fromMenstructionDidDecide,
         durationMenstructionDidDecide: durationMenstructionDidDecide,

--- a/lib/components/organisms/setting/setting_menstruation_page.dart
+++ b/lib/components/organisms/setting/setting_menstruation_page.dart
@@ -90,8 +90,7 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: <Widget>[
-                          Text(
-                              "${this.widget.model.pillSheetType.notTakenWord}期間に入って ",
+                          Text("ピル番号 ",
                               style: FontType.assisting
                                   .merge(TextColorStyle.main)),
                           GestureDetector(

--- a/lib/domain/calendar/calendar_card.dart
+++ b/lib/domain/calendar/calendar_card.dart
@@ -7,6 +7,7 @@ import 'package:Pilll/domain/calendar/calendar_help.dart';
 import 'package:Pilll/domain/calendar/calendar_list_page.dart';
 import 'package:Pilll/entity/pill_sheet.dart';
 import 'package:Pilll/entity/setting.dart';
+import 'package:Pilll/entity/pill_sheet_type.dart';
 import 'package:Pilll/store/pill_sheet.dart';
 import 'package:Pilll/store/setting.dart';
 import 'package:Pilll/components/atoms/buttons.dart';
@@ -35,17 +36,8 @@ class CalendarCard extends HookWidget {
           _header(context),
           Calendar(
             calculator: Calculator(date),
-            bandModels: [
-              if (currentPillSheetState.entity != null) ...[
-                menstruationDateRange(
-                        currentPillSheetState.entity, settingState.entity, 0)
-                    .map((range) =>
-                        CalendarMenstruationBandModel(range.begin, range.end)),
-                nextPillSheetDateRange(currentPillSheetState.entity, 0).map(
-                    (range) =>
-                        CalendarNextPillSheetBandModel(range.begin, range.end)),
-              ]
-            ],
+            bandModels: buildBandModels(
+                currentPillSheetState.entity, settingState.entity, 0),
             horizontalPadding: 16,
           ),
           _more(context, settingState.entity, currentPillSheetState.entity),
@@ -103,28 +95,14 @@ class CalendarCard extends HookWidget {
                         []);
                     return previous;
                   });
-                  CalendarListPageModel current =
-                      CalendarListPageModel(Calculator(now), [
-                    if (latestPillSheet != null) ...[
-                      menstruationDateRange(latestPillSheet, setting, 0).map(
-                          (range) => CalendarMenstruationBandModel(
-                              range.begin, range.end)),
-                      nextPillSheetDateRange(latestPillSheet, 0).map((range) =>
-                          CalendarNextPillSheetBandModel(
-                              range.begin, range.end)),
-                    ]
-                  ]);
+                  CalendarListPageModel current = CalendarListPageModel(
+                    Calculator(now),
+                    buildBandModels(latestPillSheet, setting, 0),
+                  );
                   List<CalendarBandModel> satisfyNextMonthDateRanges = [];
                   if (latestPillSheet != null) {
                     satisfyNextMonthDateRanges = List.generate(12, (index) {
-                      return [
-                        menstruationDateRange(latestPillSheet, setting, index)
-                            .map((range) => CalendarMenstruationBandModel(
-                                range.begin, range.end)),
-                        nextPillSheetDateRange(latestPillSheet, index).map(
-                            (range) => CalendarNextPillSheetBandModel(
-                                range.begin, range.end)),
-                      ];
+                      return buildBandModels(latestPillSheet, setting, index);
                     }).expand((element) => element).toList();
                   }
                   final nextCalendars = List.generate(

--- a/lib/domain/calendar/calendar_card.dart
+++ b/lib/domain/calendar/calendar_card.dart
@@ -7,7 +7,6 @@ import 'package:Pilll/domain/calendar/calendar_help.dart';
 import 'package:Pilll/domain/calendar/calendar_list_page.dart';
 import 'package:Pilll/entity/pill_sheet.dart';
 import 'package:Pilll/entity/setting.dart';
-import 'package:Pilll/entity/pill_sheet_type.dart';
 import 'package:Pilll/store/pill_sheet.dart';
 import 'package:Pilll/store/setting.dart';
 import 'package:Pilll/components/atoms/buttons.dart';

--- a/lib/domain/calendar/utility.dart
+++ b/lib/domain/calendar/utility.dart
@@ -14,10 +14,8 @@ DateRange menstruationDateRange(
     return null;
   }
   var offset = page * pillSheet.pillSheetType.totalCount;
-  var begin = pillSheet.beginingDate.add(Duration(
-      days: (pillSheet.pillSheetType.dosingPeriod - 1) +
-          setting.fromMenstruation +
-          offset));
+  var begin = pillSheet.beginingDate.add(
+      Duration(days: (setting.pillNumberForFromMenstruation - 1) + offset));
   var end = begin.add(Duration(days: (setting.durationMenstruation - 1)));
   return DateRange(begin, end);
 }

--- a/lib/domain/calendar/utility.dart
+++ b/lib/domain/calendar/utility.dart
@@ -1,3 +1,4 @@
+import 'package:Pilll/domain/calendar/calendar_band_model.dart';
 import 'package:Pilll/domain/calendar/date_range.dart';
 import 'package:Pilll/entity/pill_sheet.dart';
 import 'package:Pilll/entity/pill_sheet_type.dart';
@@ -29,4 +30,23 @@ DateRange nextPillSheetDateRange(
       .add(Duration(days: pillSheet.pillSheetType.totalCount * (page + 1)));
   var end = begin.add(Duration(days: Weekday.values.length - 1));
   return DateRange(begin, end);
+}
+
+List<CalendarBandModel> buildBandModels(
+  PillSheetModel pillSheet,
+  Setting setting,
+  int page,
+) {
+  if (pillSheet == null) {
+    return [];
+  }
+  List<CalendarBandModel> bandModels = [];
+  final menstruation = menstruationDateRange(pillSheet, setting, 0);
+  if (menstruation != null) {
+    bandModels.add(menstruation
+        .map((range) => CalendarMenstruationBandModel(range.begin, range.end)));
+  }
+  bandModels.add(nextPillSheetDateRange(pillSheet, 0)
+      .map((range) => CalendarNextPillSheetBandModel(range.begin, range.end)));
+  return bandModels;
 }

--- a/lib/domain/calendar/utility.dart
+++ b/lib/domain/calendar/utility.dart
@@ -9,6 +9,9 @@ DateRange menstruationDateRange(
   Setting setting,
   int page,
 ) {
+  if (pillSheet.pillSheetType.isNotExistsNotTakenDuration) {
+    return null;
+  }
   var offset = page * pillSheet.pillSheetType.totalCount;
   var begin = pillSheet.beginingDate.add(Duration(
       days: (pillSheet.pillSheetType.dosingPeriod - 1) +

--- a/lib/domain/calendar/utility.dart
+++ b/lib/domain/calendar/utility.dart
@@ -10,9 +10,6 @@ DateRange menstruationDateRange(
   Setting setting,
   int page,
 ) {
-  if (pillSheet.pillSheetType.isNotExistsNotTakenDuration) {
-    return null;
-  }
   var offset = page * pillSheet.pillSheetType.totalCount;
   var begin = pillSheet.beginingDate.add(
       Duration(days: (setting.pillNumberForFromMenstruation - 1) + offset));

--- a/lib/domain/calendar/utility.dart
+++ b/lib/domain/calendar/utility.dart
@@ -35,13 +35,10 @@ List<CalendarBandModel> buildBandModels(
   if (pillSheet == null) {
     return [];
   }
-  List<CalendarBandModel> bandModels = [];
-  final menstruation = menstruationDateRange(pillSheet, setting, 0);
-  if (menstruation != null) {
-    bandModels.add(menstruation
-        .map((range) => CalendarMenstruationBandModel(range.begin, range.end)));
-  }
-  bandModels.add(nextPillSheetDateRange(pillSheet, 0)
-      .map((range) => CalendarNextPillSheetBandModel(range.begin, range.end)));
-  return bandModels;
+  return [
+    menstruationDateRange(pillSheet, setting, page)
+        .map((range) => CalendarMenstruationBandModel(range.begin, range.end)),
+    nextPillSheetDateRange(pillSheet, page)
+        .map((range) => CalendarNextPillSheetBandModel(range.begin, range.end))
+  ];
 }

--- a/lib/domain/initial_setting/initial_setting_3_page.dart
+++ b/lib/domain/initial_setting/initial_setting_3_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/all.dart';
+import 'package:Pilll/entity/pill_sheet_type.dart';
 
 class InitialSetting3Page extends HookWidget {
   @override
@@ -17,6 +18,7 @@ class InitialSetting3Page extends HookWidget {
       done: () {
         Navigator.of(context).push(InitialSetting4PageRoute.route());
       },
+      pillSheetTotalCount: state.entity.pillSheetType.totalCount,
       model: SettingMenstruationPageModel(
         pillSheetType: state.entity.pillSheetType,
         selectedFromMenstruation: state.entity.fromMenstruation,

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -286,6 +286,8 @@ class SettingsPage extends HookWidget {
                   done: null,
                   doneText: null,
                   title: "生理について",
+                  pillSheetTotalCount:
+                      settingState.entity.pillSheetType.totalCount,
                   model: SettingMenstruationPageModel(
                     pillSheetType: pillSheetState.entity.pillSheetType,
                     selectedFromMenstruation:

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -248,32 +248,31 @@ class SettingsPage extends HookWidget {
               Navigator.of(context).push(ReminderTimesPageRoute.route());
             },
           ),
-          if (!pillSheetState.entity.pillSheetType.isNotExistsNotTakenDuration)
-            SettingsListSwitchRowModel(
-              title: "${pillSheetState.entity.pillSheetType.notTakenWord}期間の通知",
-              subtitle:
-                  "通知オフの場合は、${pillSheetState.entity.pillSheetType.notTakenWord}期間の服用記録も自動で付けられます",
-              value: settingState.entity.isOnNotifyInNotTakenDuration,
-              onTap: () {
-                analytics.logEvent(
-                  name: "toggle_notify_not_taken_duration",
-                );
-                Scaffold.of(context).hideCurrentSnackBar();
-                settingStore
-                    .modifyIsOnNotifyInNotTakenDuration(
-                        !settingState.entity.isOnNotifyInNotTakenDuration)
-                    .then((state) {
-                  Scaffold.of(context).showSnackBar(
-                    SnackBar(
-                      duration: Duration(seconds: 1),
-                      content: Text(
-                        "${pillSheetState.entity.pillSheetType.notTakenWord}期間の通知を${state.entity.isOnNotifyInNotTakenDuration ? "ON" : "OFF"}にしました",
-                      ),
+          SettingsListSwitchRowModel(
+            title: "${pillSheetState.entity.pillSheetType.notTakenWord}期間の通知",
+            subtitle:
+                "通知オフの場合は、${pillSheetState.entity.pillSheetType.notTakenWord}期間の服用記録も自動で付けられます",
+            value: settingState.entity.isOnNotifyInNotTakenDuration,
+            onTap: () {
+              analytics.logEvent(
+                name: "toggle_notify_not_taken_duration",
+              );
+              Scaffold.of(context).hideCurrentSnackBar();
+              settingStore
+                  .modifyIsOnNotifyInNotTakenDuration(
+                      !settingState.entity.isOnNotifyInNotTakenDuration)
+                  .then((state) {
+                Scaffold.of(context).showSnackBar(
+                  SnackBar(
+                    duration: Duration(seconds: 1),
+                    content: Text(
+                      "${pillSheetState.entity.pillSheetType.notTakenWord}期間の通知を${state.entity.isOnNotifyInNotTakenDuration ? "ON" : "OFF"}にしました",
                     ),
-                  );
-                });
-              },
-            ),
+                  ),
+                );
+              });
+            },
+          ),
         ];
       case SettingSection.menstruation:
         return [

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -290,7 +290,7 @@ class SettingsPage extends HookWidget {
                   model: SettingMenstruationPageModel(
                     pillSheetType: pillSheetState.entity.pillSheetType,
                     selectedFromMenstruation:
-                        settingState.entity.fromMenstruation,
+                        settingState.entity.pillNumberForFromMenstruation,
                     selectedDurationMenstruation:
                         settingState.entity.durationMenstruation,
                   ),

--- a/lib/entity/initial_setting.dart
+++ b/lib/entity/initial_setting.dart
@@ -11,7 +11,7 @@ part 'initial_setting.freezed.dart';
 abstract class InitialSettingModel implements _$InitialSettingModel {
   InitialSettingModel._();
   factory InitialSettingModel.initial({
-    @Default(2)
+    @Default(23)
         int fromMenstruation,
     @Default(4)
         int durationMenstruation,
@@ -27,7 +27,7 @@ abstract class InitialSettingModel implements _$InitialSettingModel {
   }) = _InitialSettingModel;
 
   Setting buildSetting() => Setting(
-        fromMenstruation: fromMenstruation,
+        pillNumberForFromMenstruation: fromMenstruation,
         durationMenstruation: durationMenstruation,
         pillSheetTypeRawPath: pillSheetType.rawPath,
         reminderTimes: reminderTimes,

--- a/lib/entity/initial_setting.freezed.dart
+++ b/lib/entity/initial_setting.freezed.dart
@@ -15,7 +15,7 @@ class _$InitialSettingModelTearOff {
 
 // ignore: unused_element
   _InitialSettingModel initial(
-      {int fromMenstruation = 2,
+      {int fromMenstruation = 23,
       int durationMenstruation = 4,
       List<ReminderTime> reminderTimes = const [
         const ReminderTime(hour: 21, minute: 0),
@@ -198,7 +198,7 @@ class __$InitialSettingModelCopyWithImpl<$Res>
 /// @nodoc
 class _$_InitialSettingModel extends _InitialSettingModel {
   _$_InitialSettingModel(
-      {this.fromMenstruation = 2,
+      {this.fromMenstruation = 23,
       this.durationMenstruation = 4,
       this.reminderTimes = const [
         const ReminderTime(hour: 21, minute: 0),
@@ -213,7 +213,7 @@ class _$_InitialSettingModel extends _InitialSettingModel {
         assert(isOnReminder != null),
         super._();
 
-  @JsonKey(defaultValue: 2)
+  @JsonKey(defaultValue: 23)
   @override
   final int fromMenstruation;
   @JsonKey(defaultValue: 4)

--- a/lib/entity/initial_setting.freezed.dart
+++ b/lib/entity/initial_setting.freezed.dart
@@ -18,8 +18,8 @@ class _$InitialSettingModelTearOff {
       {int fromMenstruation = 2,
       int durationMenstruation = 4,
       List<ReminderTime> reminderTimes = const [
-        ReminderTime(hour: 21, minute: 0),
-        ReminderTime(hour: 22, minute: 0)
+        const ReminderTime(hour: 21, minute: 0),
+        const ReminderTime(hour: 22, minute: 0)
       ],
       bool isOnReminder = false,
       int todayPillNumber,
@@ -201,8 +201,8 @@ class _$_InitialSettingModel extends _InitialSettingModel {
       {this.fromMenstruation = 2,
       this.durationMenstruation = 4,
       this.reminderTimes = const [
-        ReminderTime(hour: 21, minute: 0),
-        ReminderTime(hour: 22, minute: 0)
+        const ReminderTime(hour: 21, minute: 0),
+        const ReminderTime(hour: 22, minute: 0)
       ],
       this.isOnReminder = false,
       this.todayPillNumber,
@@ -220,8 +220,8 @@ class _$_InitialSettingModel extends _InitialSettingModel {
   @override
   final int durationMenstruation;
   @JsonKey(defaultValue: const [
-    ReminderTime(hour: 21, minute: 0),
-    ReminderTime(hour: 22, minute: 0)
+    const ReminderTime(hour: 21, minute: 0),
+    const ReminderTime(hour: 22, minute: 0)
   ])
   @override
   final List<ReminderTime> reminderTimes;

--- a/lib/entity/setting.dart
+++ b/lib/entity/setting.dart
@@ -35,7 +35,6 @@ abstract class Setting implements _$Setting {
   @JsonSerializable(explicitToJson: true)
   factory Setting({
     @required String pillSheetTypeRawPath,
-    @deprecated int fromMenstruation,
     @required int pillNumberForFromMenstruation,
     @required int durationMenstruation,
     @required List<ReminderTime> reminderTimes,

--- a/lib/entity/setting.dart
+++ b/lib/entity/setting.dart
@@ -35,7 +35,8 @@ abstract class Setting implements _$Setting {
   @JsonSerializable(explicitToJson: true)
   factory Setting({
     @required String pillSheetTypeRawPath,
-    @required int fromMenstruation,
+    @deprecated int fromMenstruation,
+    @required int pillNumberForFromMenstruation,
     @required int durationMenstruation,
     @required List<ReminderTime> reminderTimes,
     @required @JsonSerializable(explicitToJson: true) bool isOnReminder,

--- a/lib/entity/setting.freezed.dart
+++ b/lib/entity/setting.freezed.dart
@@ -187,7 +187,6 @@ class _$SettingTearOff {
 // ignore: unused_element
   _Setting call(
       {@required String pillSheetTypeRawPath,
-      @deprecated int fromMenstruation,
       @required int pillNumberForFromMenstruation,
       @required int durationMenstruation,
       @required List<ReminderTime> reminderTimes,
@@ -195,7 +194,6 @@ class _$SettingTearOff {
       bool isOnNotifyInNotTakenDuration = false}) {
     return _Setting(
       pillSheetTypeRawPath: pillSheetTypeRawPath,
-      fromMenstruation: fromMenstruation,
       pillNumberForFromMenstruation: pillNumberForFromMenstruation,
       durationMenstruation: durationMenstruation,
       reminderTimes: reminderTimes,
@@ -217,8 +215,6 @@ const $Setting = _$SettingTearOff();
 /// @nodoc
 mixin _$Setting {
   String get pillSheetTypeRawPath;
-  @deprecated
-  int get fromMenstruation;
   int get pillNumberForFromMenstruation;
   int get durationMenstruation;
   List<ReminderTime> get reminderTimes;
@@ -236,7 +232,6 @@ abstract class $SettingCopyWith<$Res> {
       _$SettingCopyWithImpl<$Res>;
   $Res call(
       {String pillSheetTypeRawPath,
-      @deprecated int fromMenstruation,
       int pillNumberForFromMenstruation,
       int durationMenstruation,
       List<ReminderTime> reminderTimes,
@@ -255,7 +250,6 @@ class _$SettingCopyWithImpl<$Res> implements $SettingCopyWith<$Res> {
   @override
   $Res call({
     Object pillSheetTypeRawPath = freezed,
-    Object fromMenstruation = freezed,
     Object pillNumberForFromMenstruation = freezed,
     Object durationMenstruation = freezed,
     Object reminderTimes = freezed,
@@ -266,9 +260,6 @@ class _$SettingCopyWithImpl<$Res> implements $SettingCopyWith<$Res> {
       pillSheetTypeRawPath: pillSheetTypeRawPath == freezed
           ? _value.pillSheetTypeRawPath
           : pillSheetTypeRawPath as String,
-      fromMenstruation: fromMenstruation == freezed
-          ? _value.fromMenstruation
-          : fromMenstruation as int,
       pillNumberForFromMenstruation: pillNumberForFromMenstruation == freezed
           ? _value.pillNumberForFromMenstruation
           : pillNumberForFromMenstruation as int,
@@ -294,7 +285,6 @@ abstract class _$SettingCopyWith<$Res> implements $SettingCopyWith<$Res> {
   @override
   $Res call(
       {String pillSheetTypeRawPath,
-      @deprecated int fromMenstruation,
       int pillNumberForFromMenstruation,
       int durationMenstruation,
       List<ReminderTime> reminderTimes,
@@ -314,7 +304,6 @@ class __$SettingCopyWithImpl<$Res> extends _$SettingCopyWithImpl<$Res>
   @override
   $Res call({
     Object pillSheetTypeRawPath = freezed,
-    Object fromMenstruation = freezed,
     Object pillNumberForFromMenstruation = freezed,
     Object durationMenstruation = freezed,
     Object reminderTimes = freezed,
@@ -325,9 +314,6 @@ class __$SettingCopyWithImpl<$Res> extends _$SettingCopyWithImpl<$Res>
       pillSheetTypeRawPath: pillSheetTypeRawPath == freezed
           ? _value.pillSheetTypeRawPath
           : pillSheetTypeRawPath as String,
-      fromMenstruation: fromMenstruation == freezed
-          ? _value.fromMenstruation
-          : fromMenstruation as int,
       pillNumberForFromMenstruation: pillNumberForFromMenstruation == freezed
           ? _value.pillNumberForFromMenstruation
           : pillNumberForFromMenstruation as int,
@@ -352,7 +338,6 @@ class __$SettingCopyWithImpl<$Res> extends _$SettingCopyWithImpl<$Res>
 class _$_Setting extends _Setting with DiagnosticableTreeMixin {
   _$_Setting(
       {@required this.pillSheetTypeRawPath,
-      @deprecated this.fromMenstruation,
       @required this.pillNumberForFromMenstruation,
       @required this.durationMenstruation,
       @required this.reminderTimes,
@@ -372,9 +357,6 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
   @override
   final String pillSheetTypeRawPath;
   @override
-  @deprecated
-  final int fromMenstruation;
-  @override
   final int pillNumberForFromMenstruation;
   @override
   final int durationMenstruation;
@@ -389,7 +371,7 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'Setting(pillSheetTypeRawPath: $pillSheetTypeRawPath, fromMenstruation: $fromMenstruation, pillNumberForFromMenstruation: $pillNumberForFromMenstruation, durationMenstruation: $durationMenstruation, reminderTimes: $reminderTimes, isOnReminder: $isOnReminder, isOnNotifyInNotTakenDuration: $isOnNotifyInNotTakenDuration)';
+    return 'Setting(pillSheetTypeRawPath: $pillSheetTypeRawPath, pillNumberForFromMenstruation: $pillNumberForFromMenstruation, durationMenstruation: $durationMenstruation, reminderTimes: $reminderTimes, isOnReminder: $isOnReminder, isOnNotifyInNotTakenDuration: $isOnNotifyInNotTakenDuration)';
   }
 
   @override
@@ -398,7 +380,6 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
     properties
       ..add(DiagnosticsProperty('type', 'Setting'))
       ..add(DiagnosticsProperty('pillSheetTypeRawPath', pillSheetTypeRawPath))
-      ..add(DiagnosticsProperty('fromMenstruation', fromMenstruation))
       ..add(DiagnosticsProperty(
           'pillNumberForFromMenstruation', pillNumberForFromMenstruation))
       ..add(DiagnosticsProperty('durationMenstruation', durationMenstruation))
@@ -415,9 +396,6 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
             (identical(other.pillSheetTypeRawPath, pillSheetTypeRawPath) ||
                 const DeepCollectionEquality().equals(
                     other.pillSheetTypeRawPath, pillSheetTypeRawPath)) &&
-            (identical(other.fromMenstruation, fromMenstruation) ||
-                const DeepCollectionEquality()
-                    .equals(other.fromMenstruation, fromMenstruation)) &&
             (identical(other.pillNumberForFromMenstruation,
                     pillNumberForFromMenstruation) ||
                 const DeepCollectionEquality().equals(
@@ -443,7 +421,6 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
   int get hashCode =>
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(pillSheetTypeRawPath) ^
-      const DeepCollectionEquality().hash(fromMenstruation) ^
       const DeepCollectionEquality().hash(pillNumberForFromMenstruation) ^
       const DeepCollectionEquality().hash(durationMenstruation) ^
       const DeepCollectionEquality().hash(reminderTimes) ^
@@ -464,7 +441,6 @@ abstract class _Setting extends Setting {
   _Setting._() : super._();
   factory _Setting(
       {@required String pillSheetTypeRawPath,
-      @deprecated int fromMenstruation,
       @required int pillNumberForFromMenstruation,
       @required int durationMenstruation,
       @required List<ReminderTime> reminderTimes,
@@ -475,9 +451,6 @@ abstract class _Setting extends Setting {
 
   @override
   String get pillSheetTypeRawPath;
-  @override
-  @deprecated
-  int get fromMenstruation;
   @override
   int get pillNumberForFromMenstruation;
   @override

--- a/lib/entity/setting.freezed.dart
+++ b/lib/entity/setting.freezed.dart
@@ -187,7 +187,8 @@ class _$SettingTearOff {
 // ignore: unused_element
   _Setting call(
       {@required String pillSheetTypeRawPath,
-      @required int fromMenstruation,
+      @deprecated int fromMenstruation,
+      @required int pillNumberForFromMenstruation,
       @required int durationMenstruation,
       @required List<ReminderTime> reminderTimes,
       @required @JsonSerializable(explicitToJson: true) bool isOnReminder,
@@ -195,6 +196,7 @@ class _$SettingTearOff {
     return _Setting(
       pillSheetTypeRawPath: pillSheetTypeRawPath,
       fromMenstruation: fromMenstruation,
+      pillNumberForFromMenstruation: pillNumberForFromMenstruation,
       durationMenstruation: durationMenstruation,
       reminderTimes: reminderTimes,
       isOnReminder: isOnReminder,
@@ -215,7 +217,9 @@ const $Setting = _$SettingTearOff();
 /// @nodoc
 mixin _$Setting {
   String get pillSheetTypeRawPath;
+  @deprecated
   int get fromMenstruation;
+  int get pillNumberForFromMenstruation;
   int get durationMenstruation;
   List<ReminderTime> get reminderTimes;
   @JsonSerializable(explicitToJson: true)
@@ -232,7 +236,8 @@ abstract class $SettingCopyWith<$Res> {
       _$SettingCopyWithImpl<$Res>;
   $Res call(
       {String pillSheetTypeRawPath,
-      int fromMenstruation,
+      @deprecated int fromMenstruation,
+      int pillNumberForFromMenstruation,
       int durationMenstruation,
       List<ReminderTime> reminderTimes,
       @JsonSerializable(explicitToJson: true) bool isOnReminder,
@@ -251,6 +256,7 @@ class _$SettingCopyWithImpl<$Res> implements $SettingCopyWith<$Res> {
   $Res call({
     Object pillSheetTypeRawPath = freezed,
     Object fromMenstruation = freezed,
+    Object pillNumberForFromMenstruation = freezed,
     Object durationMenstruation = freezed,
     Object reminderTimes = freezed,
     Object isOnReminder = freezed,
@@ -263,6 +269,9 @@ class _$SettingCopyWithImpl<$Res> implements $SettingCopyWith<$Res> {
       fromMenstruation: fromMenstruation == freezed
           ? _value.fromMenstruation
           : fromMenstruation as int,
+      pillNumberForFromMenstruation: pillNumberForFromMenstruation == freezed
+          ? _value.pillNumberForFromMenstruation
+          : pillNumberForFromMenstruation as int,
       durationMenstruation: durationMenstruation == freezed
           ? _value.durationMenstruation
           : durationMenstruation as int,
@@ -285,7 +294,8 @@ abstract class _$SettingCopyWith<$Res> implements $SettingCopyWith<$Res> {
   @override
   $Res call(
       {String pillSheetTypeRawPath,
-      int fromMenstruation,
+      @deprecated int fromMenstruation,
+      int pillNumberForFromMenstruation,
       int durationMenstruation,
       List<ReminderTime> reminderTimes,
       @JsonSerializable(explicitToJson: true) bool isOnReminder,
@@ -305,6 +315,7 @@ class __$SettingCopyWithImpl<$Res> extends _$SettingCopyWithImpl<$Res>
   $Res call({
     Object pillSheetTypeRawPath = freezed,
     Object fromMenstruation = freezed,
+    Object pillNumberForFromMenstruation = freezed,
     Object durationMenstruation = freezed,
     Object reminderTimes = freezed,
     Object isOnReminder = freezed,
@@ -317,6 +328,9 @@ class __$SettingCopyWithImpl<$Res> extends _$SettingCopyWithImpl<$Res>
       fromMenstruation: fromMenstruation == freezed
           ? _value.fromMenstruation
           : fromMenstruation as int,
+      pillNumberForFromMenstruation: pillNumberForFromMenstruation == freezed
+          ? _value.pillNumberForFromMenstruation
+          : pillNumberForFromMenstruation as int,
       durationMenstruation: durationMenstruation == freezed
           ? _value.durationMenstruation
           : durationMenstruation as int,
@@ -338,13 +352,14 @@ class __$SettingCopyWithImpl<$Res> extends _$SettingCopyWithImpl<$Res>
 class _$_Setting extends _Setting with DiagnosticableTreeMixin {
   _$_Setting(
       {@required this.pillSheetTypeRawPath,
-      @required this.fromMenstruation,
+      @deprecated this.fromMenstruation,
+      @required this.pillNumberForFromMenstruation,
       @required this.durationMenstruation,
       @required this.reminderTimes,
       @required @JsonSerializable(explicitToJson: true) this.isOnReminder,
       this.isOnNotifyInNotTakenDuration = false})
       : assert(pillSheetTypeRawPath != null),
-        assert(fromMenstruation != null),
+        assert(pillNumberForFromMenstruation != null),
         assert(durationMenstruation != null),
         assert(reminderTimes != null),
         assert(isOnReminder != null),
@@ -357,7 +372,10 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
   @override
   final String pillSheetTypeRawPath;
   @override
+  @deprecated
   final int fromMenstruation;
+  @override
+  final int pillNumberForFromMenstruation;
   @override
   final int durationMenstruation;
   @override
@@ -371,7 +389,7 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'Setting(pillSheetTypeRawPath: $pillSheetTypeRawPath, fromMenstruation: $fromMenstruation, durationMenstruation: $durationMenstruation, reminderTimes: $reminderTimes, isOnReminder: $isOnReminder, isOnNotifyInNotTakenDuration: $isOnNotifyInNotTakenDuration)';
+    return 'Setting(pillSheetTypeRawPath: $pillSheetTypeRawPath, fromMenstruation: $fromMenstruation, pillNumberForFromMenstruation: $pillNumberForFromMenstruation, durationMenstruation: $durationMenstruation, reminderTimes: $reminderTimes, isOnReminder: $isOnReminder, isOnNotifyInNotTakenDuration: $isOnNotifyInNotTakenDuration)';
   }
 
   @override
@@ -381,6 +399,8 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
       ..add(DiagnosticsProperty('type', 'Setting'))
       ..add(DiagnosticsProperty('pillSheetTypeRawPath', pillSheetTypeRawPath))
       ..add(DiagnosticsProperty('fromMenstruation', fromMenstruation))
+      ..add(DiagnosticsProperty(
+          'pillNumberForFromMenstruation', pillNumberForFromMenstruation))
       ..add(DiagnosticsProperty('durationMenstruation', durationMenstruation))
       ..add(DiagnosticsProperty('reminderTimes', reminderTimes))
       ..add(DiagnosticsProperty('isOnReminder', isOnReminder))
@@ -398,6 +418,11 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
             (identical(other.fromMenstruation, fromMenstruation) ||
                 const DeepCollectionEquality()
                     .equals(other.fromMenstruation, fromMenstruation)) &&
+            (identical(other.pillNumberForFromMenstruation,
+                    pillNumberForFromMenstruation) ||
+                const DeepCollectionEquality().equals(
+                    other.pillNumberForFromMenstruation,
+                    pillNumberForFromMenstruation)) &&
             (identical(other.durationMenstruation, durationMenstruation) ||
                 const DeepCollectionEquality().equals(
                     other.durationMenstruation, durationMenstruation)) &&
@@ -419,6 +444,7 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(pillSheetTypeRawPath) ^
       const DeepCollectionEquality().hash(fromMenstruation) ^
+      const DeepCollectionEquality().hash(pillNumberForFromMenstruation) ^
       const DeepCollectionEquality().hash(durationMenstruation) ^
       const DeepCollectionEquality().hash(reminderTimes) ^
       const DeepCollectionEquality().hash(isOnReminder) ^
@@ -438,7 +464,8 @@ abstract class _Setting extends Setting {
   _Setting._() : super._();
   factory _Setting(
       {@required String pillSheetTypeRawPath,
-      @required int fromMenstruation,
+      @deprecated int fromMenstruation,
+      @required int pillNumberForFromMenstruation,
       @required int durationMenstruation,
       @required List<ReminderTime> reminderTimes,
       @required @JsonSerializable(explicitToJson: true) bool isOnReminder,
@@ -449,7 +476,10 @@ abstract class _Setting extends Setting {
   @override
   String get pillSheetTypeRawPath;
   @override
+  @deprecated
   int get fromMenstruation;
+  @override
+  int get pillNumberForFromMenstruation;
   @override
   int get durationMenstruation;
   @override

--- a/lib/entity/setting.g.dart
+++ b/lib/entity/setting.g.dart
@@ -23,6 +23,7 @@ _$_Setting _$_$_SettingFromJson(Map<String, dynamic> json) {
   return _$_Setting(
     pillSheetTypeRawPath: json['pillSheetTypeRawPath'] as String,
     fromMenstruation: json['fromMenstruation'] as int,
+    pillNumberForFromMenstruation: json['pillNumberForFromMenstruation'] as int,
     durationMenstruation: json['durationMenstruation'] as int,
     reminderTimes: (json['reminderTimes'] as List)
         ?.map((e) =>
@@ -38,6 +39,7 @@ Map<String, dynamic> _$_$_SettingToJson(_$_Setting instance) =>
     <String, dynamic>{
       'pillSheetTypeRawPath': instance.pillSheetTypeRawPath,
       'fromMenstruation': instance.fromMenstruation,
+      'pillNumberForFromMenstruation': instance.pillNumberForFromMenstruation,
       'durationMenstruation': instance.durationMenstruation,
       'reminderTimes':
           instance.reminderTimes?.map((e) => e?.toJson())?.toList(),

--- a/lib/entity/setting.g.dart
+++ b/lib/entity/setting.g.dart
@@ -22,7 +22,6 @@ Map<String, dynamic> _$_$_ReminderTimeToJson(_$_ReminderTime instance) =>
 _$_Setting _$_$_SettingFromJson(Map<String, dynamic> json) {
   return _$_Setting(
     pillSheetTypeRawPath: json['pillSheetTypeRawPath'] as String,
-    fromMenstruation: json['fromMenstruation'] as int,
     pillNumberForFromMenstruation: json['pillNumberForFromMenstruation'] as int,
     durationMenstruation: json['durationMenstruation'] as int,
     reminderTimes: (json['reminderTimes'] as List)
@@ -38,7 +37,6 @@ _$_Setting _$_$_SettingFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$_$_SettingToJson(_$_Setting instance) =>
     <String, dynamic>{
       'pillSheetTypeRawPath': instance.pillSheetTypeRawPath,
-      'fromMenstruation': instance.fromMenstruation,
       'pillNumberForFromMenstruation': instance.pillNumberForFromMenstruation,
       'durationMenstruation': instance.durationMenstruation,
       'reminderTimes':

--- a/lib/store/setting.dart
+++ b/lib/store/setting.dart
@@ -98,7 +98,8 @@ class SettingStateStore extends StateNotifier<SettingState> {
 
   Future<void> modifyFromMenstruation(int fromMenstruation) {
     return _service
-        .update(state.entity.copyWith(fromMenstruation: fromMenstruation))
+        .update(state.entity
+            .copyWith(pillNumberForFromMenstruation: fromMenstruation))
         .then((entity) => state = state.copyWith(entity: entity));
   }
 

--- a/test/domain/calendar/util_test.dart
+++ b/test/domain/calendar/util_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
   group("#menstruationDateRange", () {
     test(
-      "First page with pillSheetType: pillsheet_28_7, beginingDate: 2020-09-01, fromMenstruation: 2, durationMenstruation: 3",
+      "First page with pillSheetType: pillsheet_28_7, beginingDate: 2020-09-01, fromMenstruation: 23, durationMenstruation: 3",
       () {
         /*
         A = Start
@@ -33,7 +33,7 @@ void main() {
     */
         var pillSheetType = PillSheetType.pillsheet_28_7;
         var beginingDate = DateTime.parse("2020-09-01");
-        var fromMenstruation = 2;
+        var fromMenstruation = 23;
         var durationMenstruation = 3;
         var model = PillSheetModel(
           typeInfo: pillSheetType.typeInfo,
@@ -42,7 +42,7 @@ void main() {
         );
         var setting = Setting(
           pillSheetTypeRawPath: pillSheetType.rawPath,
-          fromMenstruation: fromMenstruation,
+          pillNumberForFromMenstruation: fromMenstruation,
           durationMenstruation: durationMenstruation,
           isOnReminder: false,
           reminderTimes: [ReminderTime(hour: 1, minute: 1)],
@@ -59,11 +59,11 @@ void main() {
       },
     );
     test(
-      "Second page with pillSheetType: pillsheet_28_7, beginingDate: 2020-09-01, fromMenstruation: 2, durationMenstruation: 3",
+      "Second page with pillSheetType: pillsheet_28_7, beginingDate: 2020-09-01, fromMenstruation: 23, durationMenstruation: 3",
       () {
         var pillSheetType = PillSheetType.pillsheet_28_7;
         var beginingDate = DateTime.parse("2020-09-01");
-        var fromMenstruation = 2;
+        var fromMenstruation = 23;
         var durationMenstruation = 3;
         var model = PillSheetModel(
           typeInfo: pillSheetType.typeInfo,
@@ -72,7 +72,7 @@ void main() {
         );
         var setting = Setting(
           pillSheetTypeRawPath: pillSheetType.rawPath,
-          fromMenstruation: fromMenstruation,
+          pillNumberForFromMenstruation: fromMenstruation,
           durationMenstruation: durationMenstruation,
           isOnReminder: false,
           reminderTimes: [ReminderTime(hour: 1, minute: 1)],
@@ -89,11 +89,11 @@ void main() {
       },
     );
     test(
-      "Third page with pillSheetType: pillsheet_28_7, beginingDate: 2020-09-01, fromMenstruation: 2, durationMenstruation: 3",
+      "Third page with pillSheetType: pillsheet_28_7, beginingDate: 2020-09-01, fromMenstruation: 23, durationMenstruation: 3",
       () {
         var pillSheetType = PillSheetType.pillsheet_28_7;
         var beginingDate = DateTime.parse("2020-09-01");
-        var fromMenstruation = 2;
+        var fromMenstruation = 23;
         var durationMenstruation = 3;
         var model = PillSheetModel(
           typeInfo: pillSheetType.typeInfo,
@@ -102,7 +102,7 @@ void main() {
         );
         var setting = Setting(
           pillSheetTypeRawPath: pillSheetType.rawPath,
-          fromMenstruation: fromMenstruation,
+          pillNumberForFromMenstruation: fromMenstruation,
           durationMenstruation: durationMenstruation,
           isOnReminder: false,
           reminderTimes: [ReminderTime(hour: 1, minute: 1)],
@@ -119,7 +119,7 @@ void main() {
       },
     );
     test(
-      "First page with pillSheetType: pillsheet_28_0(that means pill sheet is not exists not taken duration and totalCount == dosingPerod), beginingDate: 2020-09-01, fromMenstruation: 2, durationMenstruation: 3",
+      "First page with pillSheetType: pillsheet_28_0(that means pill sheet is not exists not taken duration and totalCount == dosingPerod), beginingDate: 2020-09-01, fromMenstruation: 23, durationMenstruation: 3",
       () {
         /*
         A = Start
@@ -139,7 +139,7 @@ void main() {
     */
         var pillSheetType = PillSheetType.pillsheet_28_0;
         var beginingDate = DateTime.parse("2020-09-01");
-        var fromMenstruation = 2;
+        var fromMenstruation = 23;
         var durationMenstruation = 3;
         var model = PillSheetModel(
           typeInfo: pillSheetType.typeInfo,
@@ -148,7 +148,7 @@ void main() {
         );
         var setting = Setting(
           pillSheetTypeRawPath: pillSheetType.rawPath,
-          fromMenstruation: fromMenstruation,
+          pillNumberForFromMenstruation: fromMenstruation,
           durationMenstruation: durationMenstruation,
           isOnReminder: false,
           reminderTimes: [ReminderTime(hour: 1, minute: 1)],

--- a/test/domain/calendar/util_test.dart
+++ b/test/domain/calendar/util_test.dart
@@ -237,5 +237,41 @@ void main() {
         );
       },
     );
+    test(
+      "First page with pillSheetType: pillsheet_28_0(that means pill sheet is not exists not taken duration and totalCount == dosingPerod), beginingDate: 2020-09-01",
+      () {
+        /*
+        A = Current Pill Sheett Start
+        B = Next Pill Sheet Start
+        C = End of Next Pill Sheet Band
+  30   31   1   2   3   4   5  
+            A==>
+   6    7   8   9  10  11  12  
+
+  13   14  15  16  17  18  19  
+
+  20   21  22  23  24  25  26  
+       
+  27   28  29  30   1   2   3
+           B==>
+   4    5   6   7   8   9  10
+        C  
+    */
+        var pillSheetType = PillSheetType.pillsheet_28_0;
+        var beginingDate = DateTime.parse("2020-09-01");
+        var model = PillSheetModel(
+          typeInfo: pillSheetType.typeInfo,
+          beginingDate: beginingDate,
+          lastTakenDate: null,
+        );
+        expect(
+          nextPillSheetDateRange(model, 0),
+          DateRange(
+            DateTime.parse("2020-09-29"),
+            DateTime.parse("2020-10-05"),
+          ),
+        );
+      },
+    );
   });
 }

--- a/test/domain/calendar/util_test.dart
+++ b/test/domain/calendar/util_test.dart
@@ -237,41 +237,5 @@ void main() {
         );
       },
     );
-    test(
-      "First page with pillSheetType: pillsheet_28_0(that means pill sheet is not exists not taken duration and totalCount == dosingPerod), beginingDate: 2020-09-01",
-      () {
-        /*
-        A = Current Pill Sheett Start
-        B = Next Pill Sheet Start
-        C = End of Next Pill Sheet Band
-  30   31   1   2   3   4   5  
-            A==>
-   6    7   8   9  10  11  12  
-
-  13   14  15  16  17  18  19  
-
-  20   21  22  23  24  25  26  
-       
-  27   28  29  30   1   2   3
-           B==>
-   4    5   6   7   8   9  10
-        C  
-    */
-        var pillSheetType = PillSheetType.pillsheet_28_0;
-        var beginingDate = DateTime.parse("2020-09-01");
-        var model = PillSheetModel(
-          typeInfo: pillSheetType.typeInfo,
-          beginingDate: beginingDate,
-          lastTakenDate: null,
-        );
-        expect(
-          nextPillSheetDateRange(model, 0),
-          DateRange(
-            DateTime.parse("2020-09-29"),
-            DateTime.parse("2020-10-05"),
-          ),
-        );
-      },
-    );
   });
 }

--- a/test/domain/calendar/util_test.dart
+++ b/test/domain/calendar/util_test.dart
@@ -118,49 +118,6 @@ void main() {
         );
       },
     );
-    test(
-      "First page with pillSheetType: pillsheet_28_0(that means pill sheet is not exists not taken duration and totalCount == dosingPerod), beginingDate: 2020-09-01, fromMenstruation: 23, durationMenstruation: 3",
-      () {
-        /*
-        A = Start
-        B = A with dosingPeriod
-        C = B with fromMenstruation
-        D = C with durationMenstruation
-  30   31   1   2   3   4   5  
-            A==>
-   6    7   8   9  10  11  12  
-
-  13   14  15  16  17  18  19  
-
-  20   21  22  23  24  25  26  
-       B       C,D
-  27   28  29  30
-       
-    */
-        var pillSheetType = PillSheetType.pillsheet_28_0;
-        var beginingDate = DateTime.parse("2020-09-01");
-        var fromMenstruation = 23;
-        var durationMenstruation = 3;
-        var model = PillSheetModel(
-          typeInfo: pillSheetType.typeInfo,
-          beginingDate: beginingDate,
-          lastTakenDate: null,
-        );
-        var setting = Setting(
-          pillSheetTypeRawPath: pillSheetType.rawPath,
-          pillNumberForFromMenstruation: fromMenstruation,
-          durationMenstruation: durationMenstruation,
-          isOnReminder: false,
-          reminderTimes: [ReminderTime(hour: 1, minute: 1)],
-        );
-        assert(pillSheetType.dosingPeriod == 28,
-            "menstruationDateRange adding value with dosingPeriod when it will create DateRange. pillsheet_28_0 type has 28 dosingPeriod");
-        expect(
-          menstruationDateRange(model, setting, 0),
-          null,
-        );
-      },
-    );
   });
   group("#nextPillSheetDateRange", () {
     test(

--- a/test/domain/calendar/util_test.dart
+++ b/test/domain/calendar/util_test.dart
@@ -118,6 +118,49 @@ void main() {
         );
       },
     );
+    test(
+      "First page with pillSheetType: pillsheet_28_0(that means pill sheet is not exists not taken duration and totalCount == dosingPerod), beginingDate: 2020-09-01, fromMenstruation: 2, durationMenstruation: 3",
+      () {
+        /*
+        A = Start
+        B = A with dosingPeriod
+        C = B with fromMenstruation
+        D = C with durationMenstruation
+  30   31   1   2   3   4   5  
+            A==>
+   6    7   8   9  10  11  12  
+
+  13   14  15  16  17  18  19  
+
+  20   21  22  23  24  25  26  
+       B       C,D
+  27   28  29  30
+       
+    */
+        var pillSheetType = PillSheetType.pillsheet_28_0;
+        var beginingDate = DateTime.parse("2020-09-01");
+        var fromMenstruation = 2;
+        var durationMenstruation = 3;
+        var model = PillSheetModel(
+          typeInfo: pillSheetType.typeInfo,
+          beginingDate: beginingDate,
+          lastTakenDate: null,
+        );
+        var setting = Setting(
+          pillSheetTypeRawPath: pillSheetType.rawPath,
+          fromMenstruation: fromMenstruation,
+          durationMenstruation: durationMenstruation,
+          isOnReminder: false,
+          reminderTimes: [ReminderTime(hour: 1, minute: 1)],
+        );
+        assert(pillSheetType.dosingPeriod == 28,
+            "menstruationDateRange adding value with dosingPeriod when it will create DateRange. pillsheet_28_0 type has 28 dosingPeriod");
+        expect(
+          menstruationDateRange(model, setting, 0),
+          null,
+        );
+      },
+    );
   });
   group("#nextPillSheetDateRange", () {
     test(

--- a/test/domain/record/record_page_tapped_pill_mark_test.dart
+++ b/test/domain/record/record_page_tapped_pill_mark_test.dart
@@ -18,7 +18,7 @@ import '../../helper/mock.dart';
 
 void main() {
   Setting _anySetting() => Setting(
-        fromMenstruation: 1,
+        pillNumberForFromMenstruation: 22,
         durationMenstruation: 2,
         isOnReminder: false,
         pillSheetTypeRawPath: PillSheetType.pillsheet_21.rawPath,

--- a/test/domain/settings/reminder_times_widget_test.dart
+++ b/test/domain/settings/reminder_times_widget_test.dart
@@ -28,7 +28,7 @@ void main() {
 
       final service = MockSettingService();
       final entity = Setting(
-        fromMenstruation: 1,
+        pillNumberForFromMenstruation: 22,
         durationMenstruation: 2,
         isOnReminder: false,
         pillSheetTypeRawPath: PillSheetType.pillsheet_21.rawPath,
@@ -66,7 +66,7 @@ void main() {
 
       final service = MockSettingService();
       final entity = Setting(
-        fromMenstruation: 1,
+        pillNumberForFromMenstruation: 22,
         durationMenstruation: 2,
         isOnReminder: false,
         pillSheetTypeRawPath: PillSheetType.pillsheet_21.rawPath,

--- a/test/domain/settings/store_test.dart
+++ b/test/domain/settings/store_test.dart
@@ -29,7 +29,7 @@ void main() {
           ReminderTime(hour: 2, minute: 0),
         ],
         durationMenstruation: 1,
-        fromMenstruation: 1,
+        pillNumberForFromMenstruation: 22,
         isOnReminder: false,
         pillSheetTypeRawPath: PillSheetType.pillsheet_28_4.rawPath,
       );
@@ -87,7 +87,7 @@ void main() {
           ReminderTime(hour: 2, minute: 0),
         ],
         durationMenstruation: 1,
-        fromMenstruation: 1,
+        pillNumberForFromMenstruation: 22,
         isOnReminder: false,
         pillSheetTypeRawPath: PillSheetType.pillsheet_28_4.rawPath,
       );


### PR DESCRIPTION
## What
pillsheet_28_0を追加した時による影響がある場所を修正
これの続き: https://github.com/bannzai/Pilll/pull/157

## Checked
- [x] 28_0の場合はカレンダーの帯も隠す
- [ ] ~設定から休薬期間のあるピルシートに変えた場合は~  つねにピル番号を変更できるようにすれば良い
  - [ ] ~設定画面のセルもでる~
  - [ ] ~カレンダーの帯もでる~
  - [ ] ~このときに使われる値は初期設定で裏側で埋めていたデフォの値~
- [ ] ~28_0の場合は初期設定の生理日の設定はスキップする~ スキップせずにピル番号を入力させるフォームに変える
  - [x] ただ裏側でデフォ値で埋める

途中から方針変えた。生理の開始位置を具体的なピル番号を入力させる
<img width="320px" src="https://user-images.githubusercontent.com/10897361/107868943-277fc200-6ecc-11eb-83b3-62a1eb36adba.png" />

なのでチェック項目を更新
#### pillsheet_28_0
- [x] カレンダーの帯が出る
- [x] 生理の設定画面のセルが出る
#### Any pill sheet
- [x] 生理の設定画面のUIが変わる
- [x] 生理の開始のデフォルト値を23とする
- [x] DBに保存ができているかチェック