### PR TITLE
:bug: bugfix showing cell pill sheet is not invalid

### DIFF
--- a/lib/components/organisms/setting/setting_menstruation_page.dart
+++ b/lib/components/organisms/setting/setting_menstruation_page.dart
@@ -2,7 +2,6 @@ import 'package:Pilll/components/atoms/buttons.dart';
 import 'package:Pilll/components/atoms/color.dart';
 import 'package:Pilll/components/atoms/font.dart';
 import 'package:Pilll/components/atoms/text_color.dart';
-import 'package:Pilll/entity/pill_sheet_type.dart';
 import 'package:Pilll/util/toolbar/picker_toolbar.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -14,12 +13,10 @@ abstract class SettingMenstruationPageConstants {
 }
 
 class SettingMenstruationPageModel {
-  final PillSheetType pillSheetType;
   int selectedFromMenstruation;
   int selectedDurationMenstruation;
 
   SettingMenstruationPageModel({
-    @required this.pillSheetType,
     @required this.selectedFromMenstruation,
     @required this.selectedDurationMenstruation,
   });

--- a/lib/domain/initial_setting/initial_setting_3_page.dart
+++ b/lib/domain/initial_setting/initial_setting_3_page.dart
@@ -20,7 +20,6 @@ class InitialSetting3Page extends HookWidget {
       },
       pillSheetTotalCount: state.entity.pillSheetType.totalCount,
       model: SettingMenstruationPageModel(
-        pillSheetType: state.entity.pillSheetType,
         selectedFromMenstruation: state.entity.fromMenstruation,
         selectedDurationMenstruation: state.entity.durationMenstruation,
       ),

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -248,7 +248,8 @@ class SettingsPage extends HookWidget {
               Navigator.of(context).push(ReminderTimesPageRoute.route());
             },
           ),
-          if (!pillSheetState.entity.pillSheetType.isNotExistsNotTakenDuration)
+          if (!pillSheetState.isInvalid &&
+              !pillSheetState.entity.pillSheetType.isNotExistsNotTakenDuration)
             SettingsListSwitchRowModel(
               title: "${pillSheetState.entity.pillSheetType.notTakenWord}期間の通知",
               subtitle:

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -291,7 +291,6 @@ class SettingsPage extends HookWidget {
                   pillSheetTotalCount:
                       settingState.entity.pillSheetType.totalCount,
                   model: SettingMenstruationPageModel(
-                    pillSheetType: pillSheetState.entity.pillSheetType,
                     selectedFromMenstruation:
                         settingState.entity.pillNumberForFromMenstruation,
                     selectedDurationMenstruation:


### PR DESCRIPTION
## What
ピルシートが過去に一度も作られていない時に例外が発生していた。内容はnull pointer exceptionと同義。
影響範囲は設定画面の一部のセルが出なくなっていた。一応新しいピルシートを画面から作れば解決することなのと、一度もピルシートを作ったことないユーザーが設定画面に用事があることも多くはないので影響はそんなにないと思っている