### PR TITLE
App use list of pillsheet instead of latest one pillsheet

### DIFF
--- a/lib/domain/calendar/calendar_card.dart
+++ b/lib/domain/calendar/calendar_card.dart
@@ -7,6 +7,7 @@ import 'package:Pilll/domain/calendar/calendar_help.dart';
 import 'package:Pilll/domain/calendar/calendar_list_page.dart';
 import 'package:Pilll/entity/pill_sheet.dart';
 import 'package:Pilll/entity/setting.dart';
+import 'package:Pilll/service/pill_sheet.dart';
 import 'package:Pilll/store/pill_sheet.dart';
 import 'package:Pilll/store/setting.dart';
 import 'package:Pilll/components/atoms/buttons.dart';
@@ -86,7 +87,7 @@ class CalendarCard extends HookWidget {
               Navigator.of(context).push(
                 () {
                   var now = today();
-                  final latestPillSheet = pillSheets.first;
+                  final latestPillSheet = extractLatestPillSheet(pillSheets);
                   final previousBands = List.generate(6, (index) => index + 1)
                       .reversed
                       .map((number) {

--- a/lib/domain/calendar/calendar_card.dart
+++ b/lib/domain/calendar/calendar_card.dart
@@ -36,10 +36,10 @@ class CalendarCard extends HookWidget {
           Calendar(
             calculator: Calculator(date),
             bandModels: buildBandModels(
-                currentPillSheetState.entity, settingState.entity, 0),
+                currentPillSheetState.latestPillSheet, settingState.entity, 0),
             horizontalPadding: 16,
           ),
-          _more(context, settingState.entity, currentPillSheetState.entity),
+          _more(context, settingState.entity, currentPillSheetState.latestPillSheet),
         ],
       ),
     );

--- a/lib/domain/calendar/calendar_card.dart
+++ b/lib/domain/calendar/calendar_card.dart
@@ -39,7 +39,7 @@ class CalendarCard extends HookWidget {
                 currentPillSheetState.latestPillSheet, settingState.entity, 0),
             horizontalPadding: 16,
           ),
-          _more(context, settingState.entity, currentPillSheetState.latestPillSheet),
+          _more(context, settingState.entity, currentPillSheetState.entities),
         ],
       ),
     );
@@ -74,7 +74,7 @@ class CalendarCard extends HookWidget {
   }
 
   Widget _more(
-      BuildContext context, Setting setting, PillSheetModel latestPillSheet) {
+      BuildContext context, Setting setting, List<PillSheetModel> pillSheets) {
     return ConstrainedBox(
       constraints: BoxConstraints.expand(height: 60),
       child: Row(
@@ -86,7 +86,8 @@ class CalendarCard extends HookWidget {
               Navigator.of(context).push(
                 () {
                   var now = today();
-                  final previouses = List.generate(6, (index) => index + 1)
+                  final latestPillSheet = pillSheets.first;
+                  final previousBands = List.generate(6, (index) => index + 1)
                       .reversed
                       .map((number) {
                     CalendarListPageModel previous = CalendarListPageModel(
@@ -94,17 +95,18 @@ class CalendarCard extends HookWidget {
                         []);
                     return previous;
                   });
-                  CalendarListPageModel current = CalendarListPageModel(
-                    Calculator(now),
-                    buildBandModels(latestPillSheet, setting, 0),
-                  );
+                  final currentBands =
+                      pillSheets.map((e) => CalendarListPageModel(
+                            Calculator(now),
+                            buildBandModels(e, setting, 0),
+                          ));
                   List<CalendarBandModel> satisfyNextMonthDateRanges = [];
                   if (latestPillSheet != null) {
                     satisfyNextMonthDateRanges = List.generate(12, (index) {
                       return buildBandModels(latestPillSheet, setting, index);
                     }).expand((element) => element).toList();
                   }
-                  final nextCalendars = List.generate(
+                  final nextBands = List.generate(
                     6,
                     (index) {
                       return CalendarListPageModel(
@@ -117,9 +119,9 @@ class CalendarCard extends HookWidget {
                     },
                   );
                   return CalendarListPageRoute.route([
-                    ...previouses,
-                    current,
-                    ...nextCalendars,
+                    ...previousBands,
+                    ...currentBands,
+                    ...nextBands,
                   ]);
                 }(),
               );

--- a/lib/domain/calendar/calendar_page.dart
+++ b/lib/domain/calendar/calendar_page.dart
@@ -116,13 +116,13 @@ class MenstruationCard extends HookWidget {
             ],
           ),
           Text(() {
-            if (pillSheetState.entity == null) {
+            if (pillSheetState.latestPillSheet == null) {
               return "";
             }
 
             for (int i = 0; i < 12; i += 1) {
               final begin = menstruationDateRange(
-                      pillSheetState.entity, settingState.entity, i)
+                      pillSheetState.latestPillSheet, settingState.entity, i)
                   .begin;
               if (begin.isAfter(utility.today())) {
                 return DateTimeFormatter.monthAndWeekday(begin);

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -157,11 +157,11 @@ class RecordPage extends HookWidget {
               ),
             ),
           SizedBox(height: 67),
-          if (state.isInvalid)
+          if (state.latestIsInvalid)
             Align(
                 child:
                     _empty(context, store, settingState.entity.pillSheetType)),
-          if (!state.isInvalid) ...[
+          if (!state.latestIsInvalid) ...[
             Align(child: _pillSheet(context, currentPillSheet, store)),
             SizedBox(height: 40),
             if (currentPillSheet.allTaken)
@@ -176,7 +176,7 @@ class RecordPage extends HookWidget {
   }
 
   String _notificationString(PillSheetState state) {
-    if (state.isInvalid) {
+    if (state.latestIsInvalid) {
       return "";
     }
     final pillSheet = state.latestPillSheet;

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -36,7 +36,7 @@ class RecordPage extends HookWidget {
   Widget build(BuildContext context) {
     final state = useProvider(pillSheetStoreProvider.state);
     final store = useProvider(pillSheetStoreProvider);
-    final currentPillSheet = state.entity;
+    final currentPillSheet = state.latestPillSheet;
     if (!isAlreadyShowModal) {
       isAlreadyShowModal = true;
       Future.delayed(Duration(seconds: 1)).then((_) {
@@ -134,7 +134,7 @@ class RecordPage extends HookWidget {
 
   Widget _body(BuildContext context) {
     final state = useProvider(pillSheetStoreProvider.state);
-    final currentPillSheet = state.entity;
+    final currentPillSheet = state.latestPillSheet;
     final store = useProvider(pillSheetStoreProvider);
     final settingState = useProvider(settingStoreProvider.state);
     if (settingState.entity == null || !store.firstLoadIsEnded) {
@@ -179,7 +179,7 @@ class RecordPage extends HookWidget {
     if (state.isInvalid) {
       return "";
     }
-    final pillSheet = state.entity;
+    final pillSheet = state.latestPillSheet;
     if (pillSheet == null) {
       return "";
     }

--- a/lib/domain/record/record_taken_information.dart
+++ b/lib/domain/record/record_taken_information.dart
@@ -10,7 +10,7 @@ import 'package:flutter/material.dart';
 class RecordTakenInformation extends StatelessWidget {
   final DateTime today;
   final PillSheetState state;
-  PillSheetModel get pillSheetModel => state.entity;
+  PillSheetModel get pillSheetModel => state.latestPillSheet;
   final VoidCallback onPressed;
   const RecordTakenInformation({
     Key key,

--- a/lib/domain/record/record_taken_information.dart
+++ b/lib/domain/record/record_taken_information.dart
@@ -23,7 +23,7 @@ class RecordTakenInformation extends StatelessWidget {
   String _formattedToday() => DateTimeFormatter.monthAndDay(this.today);
 
   String _todayWeekday() => DateTimeFormatter.weekday(this.today);
-  bool get pillSheetIsValid => pillSheetModel != null && !state.isInvalid;
+  bool get pillSheetIsValid => pillSheetModel != null && !state.latestIsInvalid;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -44,10 +44,10 @@ class _TransactionModifier {
     final settingStore = reader(settingStoreProvider);
     final pillSheetState = reader(pillSheetStoreProvider.state);
     final settingState = reader(settingStoreProvider.state);
-    assert(pillSheetState.entity.documentID != null);
+    assert(pillSheetState.latestPillSheet.documentID != null);
     return _database.transaction((transaction) {
       transaction.update(
-          _database.pillSheetReference(pillSheetState.entity.documentID), {
+          _database.pillSheetReference(pillSheetState.latestPillSheet.documentID), {
         PillSheetFirestoreKey.typeInfo: type.typeInfo.toJson(),
       });
       transaction.update(_database.userReference(), {
@@ -58,7 +58,7 @@ class _TransactionModifier {
       return;
     }).then((_) {
       pillSheetStore
-          .update(pillSheetState.entity.copyWith(typeInfo: type.typeInfo));
+          .update(pillSheetState.latestPillSheet.copyWith(typeInfo: type.typeInfo));
       settingStore.update(
           settingState.entity.copyWith(pillSheetTypeRawPath: type.rawPath));
     });
@@ -249,11 +249,11 @@ class SettingsPage extends HookWidget {
             },
           ),
           if (!pillSheetState.isInvalid &&
-              !pillSheetState.entity.pillSheetType.isNotExistsNotTakenDuration)
+              !pillSheetState.latestPillSheet.pillSheetType.isNotExistsNotTakenDuration)
             SettingsListSwitchRowModel(
-              title: "${pillSheetState.entity.pillSheetType.notTakenWord}期間の通知",
+              title: "${pillSheetState.latestPillSheet.pillSheetType.notTakenWord}期間の通知",
               subtitle:
-                  "通知オフの場合は、${pillSheetState.entity.pillSheetType.notTakenWord}期間の服用記録も自動で付けられます",
+                  "通知オフの場合は、${pillSheetState.latestPillSheet.pillSheetType.notTakenWord}期間の服用記録も自動で付けられます",
               value: settingState.entity.isOnNotifyInNotTakenDuration,
               onTap: () {
                 analytics.logEvent(
@@ -268,7 +268,7 @@ class SettingsPage extends HookWidget {
                     SnackBar(
                       duration: Duration(seconds: 1),
                       content: Text(
-                        "${pillSheetState.entity.pillSheetType.notTakenWord}期間の通知を${state.entity.isOnNotifyInNotTakenDuration ? "ON" : "OFF"}にしました",
+                        "${pillSheetState.latestPillSheet.pillSheetType.notTakenWord}期間の通知を${state.entity.isOnNotifyInNotTakenDuration ? "ON" : "OFF"}にしました",
                       ),
                     ),
                   );

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -160,7 +160,7 @@ class SettingsPage extends HookWidget {
                     title: "種類",
                     backButtonIsHidden: false,
                     selected: (type) {
-                      if (!pillSheetState.isInvalid)
+                      if (!pillSheetState.latestIsInvalid)
                         transactionModifier.modifyPillSheetType(type);
                       else
                         settingStore.modifyType(type);
@@ -174,7 +174,7 @@ class SettingsPage extends HookWidget {
               },
             );
           }(),
-          if (!pillSheetState.isInvalid) ...[
+          if (!pillSheetState.latestIsInvalid) ...[
             SettingListTitleRowModel(
                 title: "今日飲むピル番号の変更",
                 onTap: () {
@@ -248,7 +248,7 @@ class SettingsPage extends HookWidget {
               Navigator.of(context).push(ReminderTimesPageRoute.route());
             },
           ),
-          if (!pillSheetState.isInvalid &&
+          if (!pillSheetState.latestIsInvalid &&
               !pillSheetState.latestPillSheet.pillSheetType.isNotExistsNotTakenDuration)
             SettingsListSwitchRowModel(
               title: "${pillSheetState.latestPillSheet.pillSheetType.notTakenWord}期間の通知",

--- a/lib/entity/initial_setting.freezed.dart
+++ b/lib/entity/initial_setting.freezed.dart
@@ -18,8 +18,8 @@ class _$InitialSettingModelTearOff {
       {int fromMenstruation = 23,
       int durationMenstruation = 4,
       List<ReminderTime> reminderTimes = const [
-        ReminderTime(hour: 21, minute: 0),
-        ReminderTime(hour: 22, minute: 0)
+        const ReminderTime(hour: 21, minute: 0),
+        const ReminderTime(hour: 22, minute: 0)
       ],
       bool isOnReminder = false,
       int todayPillNumber,
@@ -201,8 +201,8 @@ class _$_InitialSettingModel extends _InitialSettingModel {
       {this.fromMenstruation = 23,
       this.durationMenstruation = 4,
       this.reminderTimes = const [
-        ReminderTime(hour: 21, minute: 0),
-        ReminderTime(hour: 22, minute: 0)
+        const ReminderTime(hour: 21, minute: 0),
+        const ReminderTime(hour: 22, minute: 0)
       ],
       this.isOnReminder = false,
       this.todayPillNumber,
@@ -220,8 +220,8 @@ class _$_InitialSettingModel extends _InitialSettingModel {
   @override
   final int durationMenstruation;
   @JsonKey(defaultValue: const [
-    ReminderTime(hour: 21, minute: 0),
-    ReminderTime(hour: 22, minute: 0)
+    const ReminderTime(hour: 21, minute: 0),
+    const ReminderTime(hour: 22, minute: 0)
   ])
   @override
   final List<ReminderTime> reminderTimes;

--- a/lib/global_method_channel.dart
+++ b/lib/global_method_channel.dart
@@ -24,7 +24,7 @@ definedChannel() {
 Future<void> recordPill() async {
   final authInfo = await auth();
   final service = PillSheetService(DatabaseConnection(authInfo.uid));
-  final entity = await service.fetchLatests();
+  final entity = await service.fetchLatest();
   await service.update(entity.copyWith(lastTakenDate: now()));
 }
 

--- a/lib/global_method_channel.dart
+++ b/lib/global_method_channel.dart
@@ -24,8 +24,9 @@ definedChannel() {
 Future<void> recordPill() async {
   final authInfo = await auth();
   final service = PillSheetService(DatabaseConnection(authInfo.uid));
-  final entity = await service.fetchLatest();
-  await service.update(entity.copyWith(lastTakenDate: now()));
+  final pillSheets = await service.fetchList(1);
+  final latestPillSheet = extractLatestPillSheet(pillSheets);
+  await service.update(latestPillSheet.copyWith(lastTakenDate: now()));
 }
 
 Future<void> salvagedOldStartTakenDate(dynamic arguments) async {

--- a/lib/global_method_channel.dart
+++ b/lib/global_method_channel.dart
@@ -24,7 +24,7 @@ definedChannel() {
 Future<void> recordPill() async {
   final authInfo = await auth();
   final service = PillSheetService(DatabaseConnection(authInfo.uid));
-  final entity = await service.fetchLast();
+  final entity = await service.fetchLatests();
   await service.update(entity.copyWith(lastTakenDate: now()));
 }
 

--- a/lib/inquiry/inquiry.dart
+++ b/lib/inquiry/inquiry.dart
@@ -1,6 +1,5 @@
 import 'package:Pilll/auth/auth.dart';
 import 'package:Pilll/database/database.dart';
-import 'package:Pilll/entity/pill_sheet.dart';
 import 'package:Pilll/entity/setting.dart';
 import 'package:Pilll/service/pill_sheet.dart';
 import 'package:Pilll/service/setting.dart';
@@ -20,8 +19,8 @@ inquiry() {
 Future<String> debugInfo(String separator) async {
   String userID = (await auth()).uid;
   DatabaseConnection databaseConnection = DatabaseConnection(userID);
-  PillSheetModel pillSheet =
-      await PillSheetService(databaseConnection).fetchLatest();
+  final pillSheets = await PillSheetService(databaseConnection).fetchList(1);
+  final pillSheet = extractLatestPillSheet(pillSheets);
   Setting setting = await SettingService(databaseConnection).fetch();
   final package = await PackageInfo.fromPlatform();
   final appName = package.appName;

--- a/lib/inquiry/inquiry.dart
+++ b/lib/inquiry/inquiry.dart
@@ -21,7 +21,7 @@ Future<String> debugInfo(String separator) async {
   String userID = (await auth()).uid;
   DatabaseConnection databaseConnection = DatabaseConnection(userID);
   PillSheetModel pillSheet =
-      await PillSheetService(databaseConnection).fetchLast();
+      await PillSheetService(databaseConnection).fetchLatests();
   Setting setting = await SettingService(databaseConnection).fetch();
   final package = await PackageInfo.fromPlatform();
   final appName = package.appName;

--- a/lib/inquiry/inquiry.dart
+++ b/lib/inquiry/inquiry.dart
@@ -21,7 +21,7 @@ Future<String> debugInfo(String separator) async {
   String userID = (await auth()).uid;
   DatabaseConnection databaseConnection = DatabaseConnection(userID);
   PillSheetModel pillSheet =
-      await PillSheetService(databaseConnection).fetchLatests();
+      await PillSheetService(databaseConnection).fetchLatest();
   Setting setting = await SettingService(databaseConnection).fetch();
   final package = await PackageInfo.fromPlatform();
   final appName = package.appName;

--- a/lib/service/pill_sheet.dart
+++ b/lib/service/pill_sheet.dart
@@ -18,7 +18,7 @@ final pillSheetServiceProvider = Provider<PillSheetServiceInterface>(
 class PillSheetService extends PillSheetServiceInterface {
   final DatabaseConnection _database;
 
-  PillSheetModel _filterForLatestPillSheet(QuerySnapshot snapshot) {
+  PillSheetModel _mapPillSheet(QuerySnapshot snapshot) {
     if (snapshot.docs.isEmpty) return null;
     if (!snapshot.docs.last.exists) return null;
     var document = snapshot.docs.last;
@@ -30,19 +30,19 @@ class PillSheetService extends PillSheetServiceInterface {
     return pillSheetModel;
   }
 
-  Query _queryOfFetchLastPillSheet() {
+  Query _queryOfFetchLastPillSheet(int limit) {
     return _database
         .pillSheetsReference()
         .orderBy(PillSheetFirestoreKey.createdAt)
-        .limitToLast(1);
+        .limitToLast(limit);
   }
 
   PillSheetService(this._database);
   @override
   Future<PillSheetModel> fetchLast() {
-    return _queryOfFetchLastPillSheet()
+    return _queryOfFetchLastPillSheet(1)
         .get()
-        .then((event) => _filterForLatestPillSheet(event));
+        .then((event) => _mapPillSheet(event));
   }
 
   @override
@@ -76,9 +76,9 @@ class PillSheetService extends PillSheetServiceInterface {
   }
 
   Stream<PillSheetModel> subscribeForLatestPillSheet() {
-    return _queryOfFetchLastPillSheet()
+    return _queryOfFetchLastPillSheet(1)
         .snapshots()
-        .map((event) => _filterForLatestPillSheet(event));
+        .map((event) => _mapPillSheet(event));
   }
 }
 

--- a/lib/service/pill_sheet.dart
+++ b/lib/service/pill_sheet.dart
@@ -111,3 +111,7 @@ class PillSheetAlreadyDeleted extends Error {
     return "ピルシートはすでに削除されています。";
   }
 }
+
+PillSheetModel extractLatestPillSheet(List<PillSheetModel> pillSheets) {
+  return pillSheets.first;
+}

--- a/lib/service/pill_sheet.dart
+++ b/lib/service/pill_sheet.dart
@@ -20,7 +20,7 @@ class PillSheetService extends PillSheetServiceInterface {
   final DatabaseConnection _database;
 
   PillSheetModel _mapPillSheet(QueryDocumentSnapshot snapshot) {
-    assert(snapshot == null);
+    assert(snapshot != null);
     if (snapshot == null) {
       return null;
     }

--- a/lib/service/pill_sheet.dart
+++ b/lib/service/pill_sheet.dart
@@ -5,11 +5,12 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:riverpod/all.dart';
 
 abstract class PillSheetServiceInterface {
-  Future<List<PillSheetModel>> fetchLatests(int limit);
+  Future<PillSheetModel> fetchLatest();
+  Future<List<PillSheetModel>> fetchList(int limit);
   Future<PillSheetModel> register(PillSheetModel model);
   Future<void> delete(PillSheetModel pillSheet);
   Future<PillSheetModel> update(PillSheetModel pillSheet);
-  Stream<List<PillSheetModel>> subscribeForLatestPillSheet();
+  Stream<PillSheetModel> subscribeForLatestPillSheet();
 }
 
 final pillSheetServiceProvider = Provider<PillSheetServiceInterface>(
@@ -40,10 +41,17 @@ class PillSheetService extends PillSheetServiceInterface {
 
   PillSheetService(this._database);
   @override
-  Future<List<PillSheetModel>> fetchLatests(int limit) {
+  Future<List<PillSheetModel>> fetchList(int limit) {
     return _queryOfFetchLastPillSheet(limit)
         .get()
         .then((event) => event.docs.map((doc) => _mapPillSheet(doc)).toList());
+  }
+
+  @override
+  Future<PillSheetModel> fetchLatest() {
+    return _queryOfFetchLastPillSheet(1)
+        .get()
+        .then((event) => _mapPillSheet(event.docs.last));
   }
 
   @override
@@ -76,10 +84,10 @@ class PillSheetService extends PillSheetServiceInterface {
         .then((_) => pillSheet);
   }
 
-  Stream<List<PillSheetModel>> subscribeForLatestPillSheet() {
+  Stream<PillSheetModel> subscribeForLatestPillSheet() {
     return _queryOfFetchLastPillSheet(1)
         .snapshots()
-        .map((event) => event.docs.map((doc) => _mapPillSheet(doc)).toList());
+        .map((event) => _mapPillSheet(event.docs.last));
   }
 }
 

--- a/lib/service/pill_sheet.dart
+++ b/lib/service/pill_sheet.dart
@@ -5,7 +5,6 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:riverpod/all.dart';
 
 abstract class PillSheetServiceInterface {
-  Future<PillSheetModel> fetchLatest();
   Future<List<PillSheetModel>> fetchList(int limit);
   Future<PillSheetModel> register(PillSheetModel model);
   Future<void> delete(PillSheetModel pillSheet);
@@ -35,8 +34,8 @@ class PillSheetService extends PillSheetServiceInterface {
   Query _queryOfFetchLastPillSheet(int limit) {
     return _database
         .pillSheetsReference()
-        .orderBy(PillSheetFirestoreKey.createdAt)
-        .limitToLast(limit);
+        .orderBy(PillSheetFirestoreKey.createdAt, descending: true)
+        .limit(limit);
   }
 
   PillSheetService(this._database);
@@ -45,13 +44,6 @@ class PillSheetService extends PillSheetServiceInterface {
     return _queryOfFetchLastPillSheet(limit)
         .get()
         .then((event) => event.docs.map((doc) => _mapPillSheet(doc)).toList());
-  }
-
-  @override
-  Future<PillSheetModel> fetchLatest() {
-    return _queryOfFetchLastPillSheet(1)
-        .get()
-        .then((event) => _mapPillSheet(event.docs.last));
   }
 
   @override

--- a/lib/state/pill_sheet.dart
+++ b/lib/state/pill_sheet.dart
@@ -7,6 +7,8 @@ part 'pill_sheet.freezed.dart';
 abstract class PillSheetState implements _$PillSheetState {
   PillSheetState._();
   factory PillSheetState({List<PillSheetModel> entities}) = _PillSheetState;
+  factory PillSheetState.one({PillSheetModel latestPillSheet}) =>
+      PillSheetState(entities: [latestPillSheet]);
 
   PillSheetModel get latestPillSheet => entities.last;
 

--- a/lib/state/pill_sheet.dart
+++ b/lib/state/pill_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:Pilll/entity/pill_sheet.dart';
+import 'package:Pilll/service/pill_sheet.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'pill_sheet.freezed.dart';
@@ -9,7 +10,8 @@ abstract class PillSheetState implements _$PillSheetState {
   factory PillSheetState({@required List<PillSheetModel> entities}) =
       _PillSheetState;
 
-  PillSheetModel get latestPillSheet => entities.isEmpty ? null : entities.last;
+  PillSheetModel get latestPillSheet =>
+      entities.isEmpty ? null : extractLatestPillSheet(entities);
 
   bool get latestIsInvalid =>
       latestPillSheet == null ||

--- a/lib/state/pill_sheet.dart
+++ b/lib/state/pill_sheet.dart
@@ -14,4 +14,13 @@ abstract class PillSheetState implements _$PillSheetState {
       latestPillSheet == null ||
       latestPillSheet.isDeleted ||
       latestPillSheet.isEnded;
+
+  PillSheetState copyWithLatestPillSheet(PillSheetModel entity) {
+    if (this.entities.isEmpty) {
+      return copyWith(entities: [entity]);
+    }
+    var entities = this.entities;
+    entities[0] = entity;
+    return copyWith(entities: entities);
+  }
 }

--- a/lib/state/pill_sheet.dart
+++ b/lib/state/pill_sheet.dart
@@ -6,11 +6,13 @@ part 'pill_sheet.freezed.dart';
 @freezed
 abstract class PillSheetState implements _$PillSheetState {
   PillSheetState._();
-  factory PillSheetState({List<PillSheetModel> entities}) = _PillSheetState;
+  factory PillSheetState({@required List<PillSheetModel> entities}) =
+      _PillSheetState;
   factory PillSheetState.one({PillSheetModel latestPillSheet}) =>
-      PillSheetState(entities: [latestPillSheet]);
+      PillSheetState(
+          entities: latestPillSheet != null ? [latestPillSheet] : []);
 
-  PillSheetModel get latestPillSheet => entities.last;
+  PillSheetModel get latestPillSheet => entities.isEmpty ? null : entities.last;
 
   bool get latestIsInvalid =>
       latestPillSheet == null ||

--- a/lib/state/pill_sheet.dart
+++ b/lib/state/pill_sheet.dart
@@ -6,7 +6,12 @@ part 'pill_sheet.freezed.dart';
 @freezed
 abstract class PillSheetState implements _$PillSheetState {
   PillSheetState._();
-  factory PillSheetState({PillSheetModel entity}) = _PillSheetState;
+  factory PillSheetState({List<PillSheetModel> entities}) = _PillSheetState;
 
-  bool get isInvalid => entity == null || entity.isDeleted || entity.isEnded;
+  PillSheetModel get latestPillSheet => entities.last;
+
+  bool get latestIsInvalid =>
+      latestPillSheet == null ||
+      latestPillSheet.isDeleted ||
+      latestPillSheet.isEnded;
 }

--- a/lib/state/pill_sheet.dart
+++ b/lib/state/pill_sheet.dart
@@ -8,9 +8,6 @@ abstract class PillSheetState implements _$PillSheetState {
   PillSheetState._();
   factory PillSheetState({@required List<PillSheetModel> entities}) =
       _PillSheetState;
-  factory PillSheetState.one({PillSheetModel latestPillSheet}) =>
-      PillSheetState(
-          entities: latestPillSheet != null ? [latestPillSheet] : []);
 
   PillSheetModel get latestPillSheet => entities.isEmpty ? null : entities.last;
 

--- a/lib/state/pill_sheet.freezed.dart
+++ b/lib/state/pill_sheet.freezed.dart
@@ -14,7 +14,7 @@ class _$PillSheetStateTearOff {
   const _$PillSheetStateTearOff();
 
 // ignore: unused_element
-  _PillSheetState call({List<PillSheetModel> entities}) {
+  _PillSheetState call({@required List<PillSheetModel> entities}) {
     return _PillSheetState(
       entities: entities,
     );
@@ -96,7 +96,9 @@ class __$PillSheetStateCopyWithImpl<$Res>
 
 /// @nodoc
 class _$_PillSheetState extends _PillSheetState {
-  _$_PillSheetState({this.entities}) : super._();
+  _$_PillSheetState({@required this.entities})
+      : assert(entities != null),
+        super._();
 
   @override
   final List<PillSheetModel> entities;
@@ -126,7 +128,8 @@ class _$_PillSheetState extends _PillSheetState {
 
 abstract class _PillSheetState extends PillSheetState {
   _PillSheetState._() : super._();
-  factory _PillSheetState({List<PillSheetModel> entities}) = _$_PillSheetState;
+  factory _PillSheetState({@required List<PillSheetModel> entities}) =
+      _$_PillSheetState;
 
   @override
   List<PillSheetModel> get entities;

--- a/lib/state/pill_sheet.freezed.dart
+++ b/lib/state/pill_sheet.freezed.dart
@@ -14,9 +14,9 @@ class _$PillSheetStateTearOff {
   const _$PillSheetStateTearOff();
 
 // ignore: unused_element
-  _PillSheetState call({PillSheetModel entity}) {
+  _PillSheetState call({List<PillSheetModel> entities}) {
     return _PillSheetState(
-      entity: entity,
+      entities: entities,
     );
   }
 }
@@ -27,7 +27,7 @@ const $PillSheetState = _$PillSheetStateTearOff();
 
 /// @nodoc
 mixin _$PillSheetState {
-  PillSheetModel get entity;
+  List<PillSheetModel> get entities;
 
   $PillSheetStateCopyWith<PillSheetState> get copyWith;
 }
@@ -37,9 +37,7 @@ abstract class $PillSheetStateCopyWith<$Res> {
   factory $PillSheetStateCopyWith(
           PillSheetState value, $Res Function(PillSheetState) then) =
       _$PillSheetStateCopyWithImpl<$Res>;
-  $Res call({PillSheetModel entity});
-
-  $PillSheetModelCopyWith<$Res> get entity;
+  $Res call({List<PillSheetModel> entities});
 }
 
 /// @nodoc
@@ -53,21 +51,13 @@ class _$PillSheetStateCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object entity = freezed,
+    Object entities = freezed,
   }) {
     return _then(_value.copyWith(
-      entity: entity == freezed ? _value.entity : entity as PillSheetModel,
+      entities: entities == freezed
+          ? _value.entities
+          : entities as List<PillSheetModel>,
     ));
-  }
-
-  @override
-  $PillSheetModelCopyWith<$Res> get entity {
-    if (_value.entity == null) {
-      return null;
-    }
-    return $PillSheetModelCopyWith<$Res>(_value.entity, (value) {
-      return _then(_value.copyWith(entity: value));
-    });
   }
 }
 
@@ -78,10 +68,7 @@ abstract class _$PillSheetStateCopyWith<$Res>
           _PillSheetState value, $Res Function(_PillSheetState) then) =
       __$PillSheetStateCopyWithImpl<$Res>;
   @override
-  $Res call({PillSheetModel entity});
-
-  @override
-  $PillSheetModelCopyWith<$Res> get entity;
+  $Res call({List<PillSheetModel> entities});
 }
 
 /// @nodoc
@@ -97,37 +84,40 @@ class __$PillSheetStateCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object entity = freezed,
+    Object entities = freezed,
   }) {
     return _then(_PillSheetState(
-      entity: entity == freezed ? _value.entity : entity as PillSheetModel,
+      entities: entities == freezed
+          ? _value.entities
+          : entities as List<PillSheetModel>,
     ));
   }
 }
 
 /// @nodoc
 class _$_PillSheetState extends _PillSheetState {
-  _$_PillSheetState({this.entity}) : super._();
+  _$_PillSheetState({this.entities}) : super._();
 
   @override
-  final PillSheetModel entity;
+  final List<PillSheetModel> entities;
 
   @override
   String toString() {
-    return 'PillSheetState(entity: $entity)';
+    return 'PillSheetState(entities: $entities)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other is _PillSheetState &&
-            (identical(other.entity, entity) ||
-                const DeepCollectionEquality().equals(other.entity, entity)));
+            (identical(other.entities, entities) ||
+                const DeepCollectionEquality()
+                    .equals(other.entities, entities)));
   }
 
   @override
   int get hashCode =>
-      runtimeType.hashCode ^ const DeepCollectionEquality().hash(entity);
+      runtimeType.hashCode ^ const DeepCollectionEquality().hash(entities);
 
   @override
   _$PillSheetStateCopyWith<_PillSheetState> get copyWith =>
@@ -136,10 +126,10 @@ class _$_PillSheetState extends _PillSheetState {
 
 abstract class _PillSheetState extends PillSheetState {
   _PillSheetState._() : super._();
-  factory _PillSheetState({PillSheetModel entity}) = _$_PillSheetState;
+  factory _PillSheetState({List<PillSheetModel> entities}) = _$_PillSheetState;
 
   @override
-  PillSheetModel get entity;
+  List<PillSheetModel> get entities;
   @override
   _$PillSheetStateCopyWith<_PillSheetState> get copyWith;
 }

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -14,7 +14,7 @@ final pillSheetStoreProvider = StateNotifierProvider(
 
 class PillSheetStateStore extends StateNotifier<PillSheetState> {
   final PillSheetServiceInterface _service;
-  PillSheetStateStore(this._service) : super(PillSheetState()) {
+  PillSheetStateStore(this._service) : super(PillSheetState(entities: [])) {
     _reset();
   }
 

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -21,14 +21,14 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   var firstLoadIsEnded = false;
   void _reset() {
     Future(() async {
-      state =
-          PillSheetState.one(latestPillSheet: (await _service.fetchLatest()));
+      state = PillSheetState(entities: (await _service.fetchList(2)));
       analytics.logEvent(name: "count_of_remaining_pill", parameters: {
         "count": state.latestPillSheet == null
             ? 0
             : (state.latestPillSheet.todayPillNumber -
                 state.latestPillSheet.lastTakenPillNumber)
       });
+      print("state.entities:${state.entities}");
       firstLoadIsEnded = true;
       _subscribe();
     });

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -51,7 +51,7 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   Future<void> register(PillSheetModel model) {
     return _service
         .register(model)
-        .then((entity) => state = state.copyWith(latestPillSheet: entity));
+        .then((entity) => state = state.copyWithLatestPillSheet(entity));
   }
 
   Future<void> delete() {
@@ -63,7 +63,7 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
     final updated = state.latestPillSheet.copyWith(lastTakenDate: takenDate);
     return _service.update(updated).then((value) {
       hideIndicator();
-      state = state.copyWith(latestPillSheet: updated);
+      state = state.copyWithLatestPillSheet(updated);
     });
   }
 
@@ -78,11 +78,11 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
     _service
         .update(state.latestPillSheet.copyWith(
             beginingDate: calcBeginingDateFromNextTodayPillNumber(pillNumber)))
-        .then((entity) => state = state.copyWith(latestPillSheet: entity));
+        .then((entity) => state = state.copyWithLatestPillSheet(entity));
   }
 
   void update(PillSheetModel entity) {
-    state = state.copyWith(latestPillSheet: entity);
+    state = state.copyWithLatestPillSheet(entity);
   }
 
   PillMarkType markFor(int number) {

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -22,14 +22,15 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   void _reset() {
     Future(() async {
       // Because arguments of 2, in calendar_page want to show menstruation band
-      state = PillSheetState(entities: (await _service.fetchList(2)));
+      final entities = await _service.fetchList(2);
+      print("entities:$entities");
+      state = PillSheetState(entities: entities);
       analytics.logEvent(name: "count_of_remaining_pill", parameters: {
         "count": state.latestPillSheet == null
             ? 0
             : (state.latestPillSheet.todayPillNumber -
                 state.latestPillSheet.lastTakenPillNumber)
       });
-      print("state.entities:${state.entities}");
       firstLoadIsEnded = true;
       _subscribe();
     });
@@ -39,6 +40,7 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   void _subscribe() {
     canceller?.cancel();
     canceller = _service.subscribeForLatestPillSheet().listen((event) {
+      print("event:$event");
       state = state.copyWithLatestPillSheet(event);
     });
   }

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -21,7 +21,7 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   var firstLoadIsEnded = false;
   void _reset() {
     Future(() async {
-      state = PillSheetState(latestPillSheet: (await _service.fetchLatests()));
+      state = PillSheetState(latestPillSheet: (await _service.fetchLatest()));
       analytics.logEvent(name: "count_of_remaining_pill", parameters: {
         "count": state.latestPillSheet == null
             ? 0

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -21,11 +21,13 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   var firstLoadIsEnded = false;
   void _reset() {
     Future(() async {
-      state = PillSheetState(latestPillSheet: (await _service.fetchLatest()));
+      state =
+          PillSheetState.one(latestPillSheet: (await _service.fetchLatest()));
       analytics.logEvent(name: "count_of_remaining_pill", parameters: {
         "count": state.latestPillSheet == null
             ? 0
-            : (state.latestPillSheet.todayPillNumber - state.latestPillSheet.lastTakenPillNumber)
+            : (state.latestPillSheet.todayPillNumber -
+                state.latestPillSheet.lastTakenPillNumber)
       });
       firstLoadIsEnded = true;
       _subscribe();
@@ -36,7 +38,7 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   void _subscribe() {
     canceller?.cancel();
     canceller = _service.subscribeForLatestPillSheet().listen((event) {
-      state = PillSheetState(latestPillSheet: event);
+      state = PillSheetState.one(latestPillSheet: event);
     });
   }
 

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -21,7 +21,7 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   var firstLoadIsEnded = false;
   void _reset() {
     Future(() async {
-      state = PillSheetState(entity: await _service.fetchLast());
+      state = PillSheetState(entity: await _service.fetchLatests());
       analytics.logEvent(name: "count_of_remaining_pill", parameters: {
         "count": state.entity == null
             ? 0

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -21,6 +21,7 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   var firstLoadIsEnded = false;
   void _reset() {
     Future(() async {
+      // Because arguments of 2, in calendar_page want to show menstruation band
       state = PillSheetState(entities: (await _service.fetchList(2)));
       analytics.logEvent(name: "count_of_remaining_pill", parameters: {
         "count": state.latestPillSheet == null

--- a/lib/store/pill_sheet.dart
+++ b/lib/store/pill_sheet.dart
@@ -39,7 +39,7 @@ class PillSheetStateStore extends StateNotifier<PillSheetState> {
   void _subscribe() {
     canceller?.cancel();
     canceller = _service.subscribeForLatestPillSheet().listen((event) {
-      state = PillSheetState.one(latestPillSheet: event);
+      state = state.copyWithLatestPillSheet(event);
     });
   }
 

--- a/test/domain/record/record_page_tapped_pill_mark_test.dart
+++ b/test/domain/record/record_page_tapped_pill_mark_test.dart
@@ -51,7 +51,7 @@ void main() {
       final pillSheetService = MockPillSheetService();
       final pillSheetStore = PillSheetStateStore(pillSheetService);
 
-      when(pillSheetService.fetchLatests())
+      when(pillSheetService.fetchLatest())
           .thenAnswer((_) => Future.value(pillSheet));
       when(pillSheetService.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.value(pillSheet));
@@ -108,7 +108,7 @@ void main() {
     final pillSheetService = MockPillSheetService();
     final pillSheetStore = PillSheetStateStore(pillSheetService);
 
-    when(pillSheetService.fetchLatests())
+    when(pillSheetService.fetchLatest())
         .thenAnswer((_) => Future.value(pillSheet));
     when(pillSheetService.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.value(pillSheet));
@@ -167,7 +167,7 @@ void main() {
     final pillSheetService = MockPillSheetService();
     final pillSheetStore = PillSheetStateStore(pillSheetService);
 
-    when(pillSheetService.fetchLatests())
+    when(pillSheetService.fetchLatest())
         .thenAnswer((_) => Future.value(pillSheet));
     when(pillSheetService.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.value(pillSheet));

--- a/test/domain/record/record_page_tapped_pill_mark_test.dart
+++ b/test/domain/record/record_page_tapped_pill_mark_test.dart
@@ -51,7 +51,7 @@ void main() {
       final pillSheetService = MockPillSheetService();
       final pillSheetStore = PillSheetStateStore(pillSheetService);
 
-      when(pillSheetService.fetchList(1))
+      when(pillSheetService.fetchList(any))
           .thenAnswer((_) => Future.value([pillSheet]));
       when(pillSheetService.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.value(pillSheet));
@@ -108,7 +108,7 @@ void main() {
     final pillSheetService = MockPillSheetService();
     final pillSheetStore = PillSheetStateStore(pillSheetService);
 
-    when(pillSheetService.fetchList(1))
+    when(pillSheetService.fetchList(any))
         .thenAnswer((_) => Future.value([pillSheet]));
     when(pillSheetService.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.value(pillSheet));
@@ -167,7 +167,7 @@ void main() {
     final pillSheetService = MockPillSheetService();
     final pillSheetStore = PillSheetStateStore(pillSheetService);
 
-    when(pillSheetService.fetchList(1))
+    when(pillSheetService.fetchList(any))
         .thenAnswer((_) => Future.value([pillSheet]));
     when(pillSheetService.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.value(pillSheet));

--- a/test/domain/record/record_page_tapped_pill_mark_test.dart
+++ b/test/domain/record/record_page_tapped_pill_mark_test.dart
@@ -51,8 +51,8 @@ void main() {
       final pillSheetService = MockPillSheetService();
       final pillSheetStore = PillSheetStateStore(pillSheetService);
 
-      when(pillSheetService.fetchLatest())
-          .thenAnswer((_) => Future.value(pillSheet));
+      when(pillSheetService.fetchList(1))
+          .thenAnswer((_) => Future.value([pillSheet]));
       when(pillSheetService.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.value(pillSheet));
 
@@ -108,8 +108,8 @@ void main() {
     final pillSheetService = MockPillSheetService();
     final pillSheetStore = PillSheetStateStore(pillSheetService);
 
-    when(pillSheetService.fetchLatest())
-        .thenAnswer((_) => Future.value(pillSheet));
+    when(pillSheetService.fetchList(1))
+        .thenAnswer((_) => Future.value([pillSheet]));
     when(pillSheetService.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.value(pillSheet));
 
@@ -167,8 +167,8 @@ void main() {
     final pillSheetService = MockPillSheetService();
     final pillSheetStore = PillSheetStateStore(pillSheetService);
 
-    when(pillSheetService.fetchLatest())
-        .thenAnswer((_) => Future.value(pillSheet));
+    when(pillSheetService.fetchList(1))
+        .thenAnswer((_) => Future.value([pillSheet]));
     when(pillSheetService.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.value(pillSheet));
 

--- a/test/domain/record/record_page_tapped_pill_mark_test.dart
+++ b/test/domain/record/record_page_tapped_pill_mark_test.dart
@@ -51,7 +51,7 @@ void main() {
       final pillSheetService = MockPillSheetService();
       final pillSheetStore = PillSheetStateStore(pillSheetService);
 
-      when(pillSheetService.fetchLast())
+      when(pillSheetService.fetchLatests())
           .thenAnswer((_) => Future.value(pillSheet));
       when(pillSheetService.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.value(pillSheet));
@@ -108,7 +108,7 @@ void main() {
     final pillSheetService = MockPillSheetService();
     final pillSheetStore = PillSheetStateStore(pillSheetService);
 
-    when(pillSheetService.fetchLast())
+    when(pillSheetService.fetchLatests())
         .thenAnswer((_) => Future.value(pillSheet));
     when(pillSheetService.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.value(pillSheet));
@@ -167,7 +167,7 @@ void main() {
     final pillSheetService = MockPillSheetService();
     final pillSheetStore = PillSheetStateStore(pillSheetService);
 
-    when(pillSheetService.fetchLast())
+    when(pillSheetService.fetchLatests())
         .thenAnswer((_) => Future.value(pillSheet));
     when(pillSheetService.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.value(pillSheet));

--- a/test/pill_sheet/pill_sheet_store_test.dart
+++ b/test/pill_sheet/pill_sheet_store_test.dart
@@ -32,7 +32,7 @@ void main() {
       final state = PillSheetState(entities: [pillSheetEntity]);
 
       final service = MockPillSheetService();
-      when(service.fetchList(1)).thenAnswer(
+      when(service.fetchList(any)).thenAnswer(
           (realInvocation) => Future.value([state.latestPillSheet]));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
@@ -59,7 +59,7 @@ void main() {
     final state = PillSheetState(entities: [pillSheetEntity]);
 
     final service = MockPillSheetService();
-    when(service.fetchList(1))
+    when(service.fetchList(any))
         .thenAnswer((realInvocation) => Future.value([state.latestPillSheet]));
     when(service.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.empty());
@@ -87,7 +87,7 @@ void main() {
       final state = PillSheetState(entities: [pillSheetEntity]);
 
       final service = MockPillSheetService();
-      when(service.fetchList(1)).thenAnswer(
+      when(service.fetchList(any)).thenAnswer(
           (realInvocation) => Future.value([state.latestPillSheet]));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
@@ -114,7 +114,7 @@ void main() {
       final state = PillSheetState(entities: [pillSheetEntity]);
 
       final service = MockPillSheetService();
-      when(service.fetchList(1)).thenAnswer(
+      when(service.fetchList(any)).thenAnswer(
           (realInvocation) => Future.value([state.latestPillSheet]));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
@@ -143,7 +143,7 @@ void main() {
       final state = PillSheetState(entities: [pillSheetEntity]);
 
       final service = MockPillSheetService();
-      when(service.fetchList(1)).thenAnswer(
+      when(service.fetchList(any)).thenAnswer(
           (realInvocation) => Future.value([state.latestPillSheet]));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
@@ -169,7 +169,7 @@ void main() {
       final state = PillSheetState(entities: [pillSheetEntity]);
 
       final service = MockPillSheetService();
-      when(service.fetchList(1)).thenAnswer(
+      when(service.fetchList(any)).thenAnswer(
           (realInvocation) => Future.value([state.latestPillSheet]));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());

--- a/test/pill_sheet/pill_sheet_store_test.dart
+++ b/test/pill_sheet/pill_sheet_store_test.dart
@@ -29,7 +29,7 @@ void main() {
         beginingDate: DateTime.parse("2020-11-22"),
         createdAt: DateTime.parse("2020-11-22"),
       );
-      final state = PillSheetState(latestPillSheet: pillSheetEntity);
+      final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
       when(service.fetchLatest())
@@ -56,7 +56,7 @@ void main() {
       beginingDate: DateTime.parse("2020-11-21"),
       createdAt: DateTime.parse("2020-11-21"),
     );
-    final state = PillSheetState(latestPillSheet: pillSheetEntity);
+    final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
 
     final service = MockPillSheetService();
     when(service.fetchLatest())
@@ -84,7 +84,7 @@ void main() {
         lastTakenDate: DateTime.parse("2020-11-23"),
         createdAt: DateTime.parse("2020-11-21"),
       );
-      final state = PillSheetState(latestPillSheet: pillSheetEntity);
+      final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
       when(service.fetchLatest())
@@ -111,7 +111,7 @@ void main() {
         lastTakenDate: DateTime.parse("2020-11-22"),
         createdAt: DateTime.parse("2020-11-21"),
       );
-      final state = PillSheetState(latestPillSheet: pillSheetEntity);
+      final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
       when(service.fetchLatest())
@@ -140,7 +140,7 @@ void main() {
         lastTakenDate: DateTime.parse("2020-11-23"),
         createdAt: DateTime.parse("2020-11-21"),
       );
-      final state = PillSheetState(latestPillSheet: pillSheetEntity);
+      final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
       when(service.fetchLatest())
@@ -166,7 +166,7 @@ void main() {
         lastTakenDate: DateTime.parse("2020-11-22"),
         createdAt: DateTime.parse("2020-11-21"),
       );
-      final state = PillSheetState(latestPillSheet: pillSheetEntity);
+      final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
       when(service.fetchLatest())

--- a/test/pill_sheet/pill_sheet_store_test.dart
+++ b/test/pill_sheet/pill_sheet_store_test.dart
@@ -32,7 +32,7 @@ void main() {
       final state = PillSheetState(entity: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLast())
+      when(service.fetchLatests())
           .thenAnswer((realInvocation) => Future.value(state.entity));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
@@ -59,7 +59,7 @@ void main() {
     final state = PillSheetState(entity: pillSheetEntity);
 
     final service = MockPillSheetService();
-    when(service.fetchLast())
+    when(service.fetchLatests())
         .thenAnswer((realInvocation) => Future.value(state.entity));
     when(service.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.empty());
@@ -87,7 +87,7 @@ void main() {
       final state = PillSheetState(entity: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLast())
+      when(service.fetchLatests())
           .thenAnswer((realInvocation) => Future.value(state.entity));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
@@ -114,7 +114,7 @@ void main() {
       final state = PillSheetState(entity: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLast())
+      when(service.fetchLatests())
           .thenAnswer((realInvocation) => Future.value(state.entity));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
@@ -143,7 +143,7 @@ void main() {
       final state = PillSheetState(entity: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLast())
+      when(service.fetchLatests())
           .thenAnswer((realInvocation) => Future.value(state.entity));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
@@ -169,7 +169,7 @@ void main() {
       final state = PillSheetState(entity: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLast())
+      when(service.fetchLatests())
           .thenAnswer((realInvocation) => Future.value(state.entity));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());

--- a/test/pill_sheet/pill_sheet_store_test.dart
+++ b/test/pill_sheet/pill_sheet_store_test.dart
@@ -29,17 +29,17 @@ void main() {
         beginingDate: DateTime.parse("2020-11-22"),
         createdAt: DateTime.parse("2020-11-22"),
       );
-      final state = PillSheetState(entity: pillSheetEntity);
+      final state = PillSheetState(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
       when(service.fetchLatests())
-          .thenAnswer((realInvocation) => Future.value(state.entity));
+          .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
 
       final store = PillSheetStateStore(service);
       await Future.delayed(Duration(milliseconds: 100));
-      expect(state.entity.todayPillNumber, equals(1));
+      expect(state.latestPillSheet.todayPillNumber, equals(1));
 
       final expected = DateTime.parse("2020-11-13");
       final actual = store.calcBeginingDateFromNextTodayPillNumber(10);
@@ -56,17 +56,17 @@ void main() {
       beginingDate: DateTime.parse("2020-11-21"),
       createdAt: DateTime.parse("2020-11-21"),
     );
-    final state = PillSheetState(entity: pillSheetEntity);
+    final state = PillSheetState(latestPillSheet: pillSheetEntity);
 
     final service = MockPillSheetService();
     when(service.fetchLatests())
-        .thenAnswer((realInvocation) => Future.value(state.entity));
+        .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
     when(service.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.empty());
 
     final store = PillSheetStateStore(service);
     await Future.delayed(Duration(milliseconds: 100));
-    expect(state.entity.todayPillNumber, equals(3));
+    expect(state.latestPillSheet.todayPillNumber, equals(3));
 
     final expected = DateTime.parse("2020-11-22");
     final actual = store.calcBeginingDateFromNextTodayPillNumber(2);
@@ -84,17 +84,17 @@ void main() {
         lastTakenDate: DateTime.parse("2020-11-23"),
         createdAt: DateTime.parse("2020-11-21"),
       );
-      final state = PillSheetState(entity: pillSheetEntity);
+      final state = PillSheetState(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
       when(service.fetchLatests())
-          .thenAnswer((realInvocation) => Future.value(state.entity));
+          .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
 
       final store = PillSheetStateStore(service);
       await Future.delayed(Duration(milliseconds: 100));
-      expect(state.entity.allTaken, isTrue);
+      expect(state.latestPillSheet.allTaken, isTrue);
       expect(store.markFor(1), PillMarkType.done);
       expect(store.markFor(2), PillMarkType.done);
       expect(store.markFor(3), PillMarkType.done);
@@ -111,17 +111,17 @@ void main() {
         lastTakenDate: DateTime.parse("2020-11-22"),
         createdAt: DateTime.parse("2020-11-21"),
       );
-      final state = PillSheetState(entity: pillSheetEntity);
+      final state = PillSheetState(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
       when(service.fetchLatests())
-          .thenAnswer((realInvocation) => Future.value(state.entity));
+          .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
 
       final store = PillSheetStateStore(service);
       await Future.delayed(Duration(milliseconds: 100));
-      expect(state.entity.allTaken, isFalse);
+      expect(state.latestPillSheet.allTaken, isFalse);
       expect(store.markFor(1), PillMarkType.done);
       expect(store.markFor(2), PillMarkType.done);
       expect(store.markFor(3), PillMarkType.normal);
@@ -140,17 +140,17 @@ void main() {
         lastTakenDate: DateTime.parse("2020-11-23"),
         createdAt: DateTime.parse("2020-11-21"),
       );
-      final state = PillSheetState(entity: pillSheetEntity);
+      final state = PillSheetState(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
       when(service.fetchLatests())
-          .thenAnswer((realInvocation) => Future.value(state.entity));
+          .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
 
       final store = PillSheetStateStore(service);
       await Future.delayed(Duration(milliseconds: 100));
-      expect(state.entity.allTaken, isTrue);
+      expect(state.latestPillSheet.allTaken, isTrue);
       for (int i = 1; i <= pillSheetEntity.pillSheetType.totalCount; i++) {
         expect(store.shouldPillMarkAnimation(i), isFalse);
       }
@@ -166,17 +166,17 @@ void main() {
         lastTakenDate: DateTime.parse("2020-11-22"),
         createdAt: DateTime.parse("2020-11-21"),
       );
-      final state = PillSheetState(entity: pillSheetEntity);
+      final state = PillSheetState(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
       when(service.fetchLatests())
-          .thenAnswer((realInvocation) => Future.value(state.entity));
+          .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
 
       final store = PillSheetStateStore(service);
       await Future.delayed(Duration(milliseconds: 100));
-      expect(state.entity.allTaken, isFalse);
+      expect(state.latestPillSheet.allTaken, isFalse);
       expect(store.shouldPillMarkAnimation(3), isTrue);
     });
   });

--- a/test/pill_sheet/pill_sheet_store_test.dart
+++ b/test/pill_sheet/pill_sheet_store_test.dart
@@ -32,8 +32,8 @@ void main() {
       final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLatest())
-          .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
+      when(service.fetchList(1)).thenAnswer(
+          (realInvocation) => Future.value([state.latestPillSheet]));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
 
@@ -59,8 +59,8 @@ void main() {
     final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
 
     final service = MockPillSheetService();
-    when(service.fetchLatest())
-        .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
+    when(service.fetchList(1))
+        .thenAnswer((realInvocation) => Future.value([state.latestPillSheet]));
     when(service.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.empty());
 
@@ -87,8 +87,8 @@ void main() {
       final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLatest())
-          .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
+      when(service.fetchList(1)).thenAnswer(
+          (realInvocation) => Future.value([state.latestPillSheet]));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
 
@@ -114,8 +114,8 @@ void main() {
       final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLatest())
-          .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
+      when(service.fetchList(1)).thenAnswer(
+          (realInvocation) => Future.value([state.latestPillSheet]));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
 
@@ -143,8 +143,8 @@ void main() {
       final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLatest())
-          .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
+      when(service.fetchList(1)).thenAnswer(
+          (realInvocation) => Future.value([state.latestPillSheet]));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
 
@@ -169,8 +169,8 @@ void main() {
       final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLatest())
-          .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
+      when(service.fetchList(1)).thenAnswer(
+          (realInvocation) => Future.value([state.latestPillSheet]));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
 

--- a/test/pill_sheet/pill_sheet_store_test.dart
+++ b/test/pill_sheet/pill_sheet_store_test.dart
@@ -32,7 +32,7 @@ void main() {
       final state = PillSheetState(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLatests())
+      when(service.fetchLatest())
           .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
@@ -59,7 +59,7 @@ void main() {
     final state = PillSheetState(latestPillSheet: pillSheetEntity);
 
     final service = MockPillSheetService();
-    when(service.fetchLatests())
+    when(service.fetchLatest())
         .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
     when(service.subscribeForLatestPillSheet())
         .thenAnswer((realInvocation) => Stream.empty());
@@ -87,7 +87,7 @@ void main() {
       final state = PillSheetState(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLatests())
+      when(service.fetchLatest())
           .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
@@ -114,7 +114,7 @@ void main() {
       final state = PillSheetState(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLatests())
+      when(service.fetchLatest())
           .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
@@ -143,7 +143,7 @@ void main() {
       final state = PillSheetState(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLatests())
+      when(service.fetchLatest())
           .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());
@@ -169,7 +169,7 @@ void main() {
       final state = PillSheetState(latestPillSheet: pillSheetEntity);
 
       final service = MockPillSheetService();
-      when(service.fetchLatests())
+      when(service.fetchLatest())
           .thenAnswer((realInvocation) => Future.value(state.latestPillSheet));
       when(service.subscribeForLatestPillSheet())
           .thenAnswer((realInvocation) => Stream.empty());

--- a/test/pill_sheet/pill_sheet_store_test.dart
+++ b/test/pill_sheet/pill_sheet_store_test.dart
@@ -29,7 +29,7 @@ void main() {
         beginingDate: DateTime.parse("2020-11-22"),
         createdAt: DateTime.parse("2020-11-22"),
       );
-      final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
+      final state = PillSheetState(entities: [pillSheetEntity]);
 
       final service = MockPillSheetService();
       when(service.fetchList(1)).thenAnswer(
@@ -56,7 +56,7 @@ void main() {
       beginingDate: DateTime.parse("2020-11-21"),
       createdAt: DateTime.parse("2020-11-21"),
     );
-    final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
+    final state = PillSheetState(entities: [pillSheetEntity]);
 
     final service = MockPillSheetService();
     when(service.fetchList(1))
@@ -84,7 +84,7 @@ void main() {
         lastTakenDate: DateTime.parse("2020-11-23"),
         createdAt: DateTime.parse("2020-11-21"),
       );
-      final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
+      final state = PillSheetState(entities: [pillSheetEntity]);
 
       final service = MockPillSheetService();
       when(service.fetchList(1)).thenAnswer(
@@ -111,7 +111,7 @@ void main() {
         lastTakenDate: DateTime.parse("2020-11-22"),
         createdAt: DateTime.parse("2020-11-21"),
       );
-      final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
+      final state = PillSheetState(entities: [pillSheetEntity]);
 
       final service = MockPillSheetService();
       when(service.fetchList(1)).thenAnswer(
@@ -140,7 +140,7 @@ void main() {
         lastTakenDate: DateTime.parse("2020-11-23"),
         createdAt: DateTime.parse("2020-11-21"),
       );
-      final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
+      final state = PillSheetState(entities: [pillSheetEntity]);
 
       final service = MockPillSheetService();
       when(service.fetchList(1)).thenAnswer(
@@ -166,7 +166,7 @@ void main() {
         lastTakenDate: DateTime.parse("2020-11-22"),
         createdAt: DateTime.parse("2020-11-21"),
       );
-      final state = PillSheetState.one(latestPillSheet: pillSheetEntity);
+      final state = PillSheetState(entities: [pillSheetEntity]);
 
       final service = MockPillSheetService();
       when(service.fetchList(1)).thenAnswer(


### PR DESCRIPTION
## What
カレンダータブの画面において、服用していたピルシートが破棄されたり、終了すると 生理期間を表す帯が消えてしまう。現在対象としているピルシートが無くなった場合であっても表示されるように対応する

## Links
resolved: https://github.com/bannzai/_Pilll/issues/295

## How
- ピルシートのデータ取得を最後の1件ではなく最後から2件目まで取得する
  - fetchLastメソッドを削除してfetchList(limit)メソッドを用意する
  - PillSheetStateではgetterとしてlatestPillSheetを用意する。これは配列の一番最後の要素を取得するメソッドになっている
- CalendarPage以外ではpillSheet.latestPillSheetを使用する
- CalendarPageではPillSheetの配列を扱う。殆どの場合は2件分扱えば大丈夫だろうからこのくらいの対応でやる