### PR TITLE
Bugfix for appending pill sheet type

### DIFF
--- a/lib/components/organisms/setting/setting_menstruation_page.dart
+++ b/lib/components/organisms/setting/setting_menstruation_page.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:pilll/components/atoms/buttons.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
@@ -169,8 +171,9 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
   }
 
   void _showFromModalSheet(BuildContext context) {
-    int keepSelectedFromMenstruation =
-        this.widget.model.selectedFromMenstruation;
+    int keepSelectedFromMenstruation = min(
+        this.widget.model.selectedFromMenstruation,
+        this.widget.pillSheetTotalCount);
     showModalBottomSheet(
       context: context,
       builder: (BuildContext context) {

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -295,10 +295,14 @@ class RecordPage extends HookWidget {
     return GestureDetector(
       child: SizedBox(
         width: PillSheet.width,
-        height: PillSheet.lineHeight * pillSheetType.numberOfLineInPillSheet,
+        height: 316,
         child: Stack(
           children: <Widget>[
-            Center(child: SvgPicture.asset("images/empty_frame.svg")),
+            Center(
+              child: SvgPicture.asset(
+                "images/empty_frame.svg",
+              ),
+            ),
             Center(
                 child: Row(
               mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -196,7 +196,7 @@ class SettingsPage extends HookWidget {
                               return ConfirmDeletePillSheet(
                                   title: "現在のピルシートが削除されます",
                                   message: '''
-選択したピルシート(${entity.pillSheetType.fullName})に変更する場合、現在のピルシートは削除されます。削除後、ピル画面から新しいピルシートを作成すると${entity.pillSheetType.fullName}で開始されます。
+選択したピルシート(${entity.pillSheetType.fullName})に変更する場合、現在のピルシートは削除されます。削除後、ピル画面から新しいピルシートを作成すると${type.fullName}で開始されます。
 現在のピルシートを削除してピルシートのタイプを変更しますか？
                               ''',
                                   doneButtonText: "変更する",


### PR DESCRIPTION
## What[
[このPR](https://github.com/bannzai/Pilll/pull/181)で :bug: がいくつかあったので対応

- ピルシートを作る。の枠が小さくなっていた
- ピルシートタイプ変更前のダイアログで表示するピルシートタイプがおかしかった
- 生理期間変更で、ピルシートタイプを変えた場合に初期indexがおかしくなっており、pickerの表示が真っ白になってしまう