### PR TITLE
Bugfix for menstruation page

### DIFF
--- a/lib/components/atoms/font.dart
+++ b/lib/components/atoms/font.dart
@@ -84,11 +84,6 @@ class FontType {
   );
   static final TextStyle gridElement = TextStyle(
     fontFamily: FontFamily.number,
-    fontWeight: FontWeight.w400,
-    fontSize: FontSize.sLarge,
-  );
-  static final TextStyle gridElementBold = TextStyle(
-    fontFamily: FontFamily.number,
     fontWeight: FontWeight.w600,
     fontSize: FontSize.sLarge,
   );

--- a/lib/components/molecules/diagonal_striped_line.dart
+++ b/lib/components/molecules/diagonal_striped_line.dart
@@ -31,6 +31,6 @@ class DiagonalStripedLine extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) {
-    return false;
+    return true;
   }
 }

--- a/lib/domain/calendar/calendar.dart
+++ b/lib/domain/calendar/calendar.dart
@@ -43,39 +43,6 @@ class Calendar extends HookWidget {
   DateTime date() => calendarState.dateForMonth;
   double height() =>
       calendarState.lineCount().toDouble() * CalendarConstants.tileHeight;
-
-  Column _body(BuildContext context, List<Diary> diaries) {
-    return Column(
-      children: <Widget>[
-        Row(
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: List.generate(
-              Weekday.values.length,
-              (index) => Expanded(
-                    child: WeekdayBadge(
-                      weekday: Weekday.values[index],
-                    ),
-                  )),
-        ),
-        Divider(height: 1),
-        ...List.generate(calendarState.lineCount(), (_line) {
-          final line = _line + 1;
-          return Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: <Widget>[
-              CalendarWeekdayLine(
-                  diaries: diaries,
-                  calendarState: calendarState.weeklyCalendarState(line),
-                  bandModels: bandModels,
-                  horizontalPadding: horizontalPadding,
-                  onTap: (weeklyCalendarState, date) => onTap(date, diaries)),
-              Divider(height: 1),
-            ],
-          );
-        }),
-      ],
-    );
-  }
 }
 
 class CalendarBody extends StatelessWidget {

--- a/lib/domain/calendar/calendar.dart
+++ b/lib/domain/calendar/calendar.dart
@@ -29,10 +29,9 @@ class Calendar extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final store =
-        useProvider(monthlyDiariesStoreProvider(calendarState.dateForMonth));
-    // ignore: invalid_use_of_protected_member
-    return _body(context, store.state.entities);
+    final state = useProvider(
+        monthlyDiariesStoreProvider(calendarState.dateForMonth).state);
+    return _body(context, state.entities);
   }
 
   DateTime date() => calendarState.dateForMonth;

--- a/lib/domain/calendar/calendar_band.dart
+++ b/lib/domain/calendar/calendar_band.dart
@@ -15,29 +15,35 @@ class CalendarBand extends StatelessWidget {
     required this.model,
     required this.isLineBreaked,
     required this.width,
+    this.onTap,
   }) : super(key: key);
 
   final CalendarBandModel model;
   final bool isLineBreaked;
   final double width;
+  final Function(CalendarBandModel)? onTap;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: CalendarBandConst.height,
-      child: Stack(
-        children: [
-          CustomPaint(
-            painter: DiagonalStripedLine(
-                color: model.color, isNecessaryBorder: model.isNecessaryBorder),
-            size: Size(width, CalendarBandConst.height),
-          ),
-          Container(
-            padding: EdgeInsets.only(left: 10),
-            child: Text(isLineBreaked ? "" : model.label,
-                style: FontType.sSmallTitle.merge(TextColorStyle.white)),
-          ),
-        ],
+    return GestureDetector(
+      onTap: () => onTap != null ? onTap!(model) : null,
+      child: Container(
+        height: CalendarBandConst.height,
+        child: Stack(
+          children: [
+            CustomPaint(
+              painter: DiagonalStripedLine(
+                  color: model.color,
+                  isNecessaryBorder: model.isNecessaryBorder),
+              size: Size(width, CalendarBandConst.height),
+            ),
+            Container(
+              padding: EdgeInsets.only(left: 10),
+              child: Text(isLineBreaked ? "" : model.label,
+                  style: FontType.sSmallTitle.merge(TextColorStyle.white)),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/domain/calendar/calendar_band_model.dart
+++ b/lib/domain/calendar/calendar_band_model.dart
@@ -15,7 +15,7 @@ abstract class CalendarBandModel {
 
 class CalendarScheduledMenstruationBandModel extends CalendarBandModel {
   @override
-  Color get color => PilllColors.menstruation.withAlpha(153);
+  Color get color => PilllColors.menstruation;
   @override
   String get label => "";
   @override

--- a/lib/domain/calendar/calendar_band_model.dart
+++ b/lib/domain/calendar/calendar_band_model.dart
@@ -1,6 +1,7 @@
 import 'package:pilll/components/atoms/color.dart';
 import 'package:flutter/material.dart';
 import 'package:pilll/domain/calendar/calendar_band.dart';
+import 'package:pilll/entity/menstruation.dart';
 
 abstract class CalendarBandModel {
   Color get color;
@@ -36,8 +37,9 @@ class CalendarMenstruationBandModel extends CalendarBandModel {
   double get bottom => 0;
   @override
   bool get isNecessaryBorder => false;
-  CalendarMenstruationBandModel(DateTime begin, DateTime end)
-      : super(begin, end);
+  final Menstruation menstruation;
+  CalendarMenstruationBandModel(this.menstruation)
+      : super(menstruation.beginDate, menstruation.endDate);
 }
 
 class CalendarNextPillSheetBandModel extends CalendarBandModel {

--- a/lib/domain/calendar/calendar_card.dart
+++ b/lib/domain/calendar/calendar_card.dart
@@ -92,6 +92,8 @@ class CalendarCard extends StatelessWidget {
           SecondaryButton(
             text: "もっと見る",
             onPressed: () {
+              final bands =
+                  buildBandModels(latestPillSheet, setting, menstruations, 12);
               Navigator.of(context).push(
                 () {
                   var now = today();
@@ -101,17 +103,16 @@ class CalendarCard extends StatelessWidget {
                     CalendarListPageModel previous = CalendarListPageModel(
                         CalendarTabState(
                             DateTime(now.year, now.month - number, 1)),
-                        []);
+                        bands);
                     return previous;
                   });
                   CalendarListPageModel current = CalendarListPageModel(
                     CalendarTabState(now),
-                    buildBandModels(latestPillSheet, setting, menstruations, 1),
+                    bands,
                   );
                   List<CalendarBandModel> satisfyNextMonthDateRanges = [];
                   if (latestPillSheet != null) {
-                    satisfyNextMonthDateRanges = buildBandModels(
-                        latestPillSheet, setting, menstruations, 12);
+                    satisfyNextMonthDateRanges = bands;
                   }
                   final nextCalendars = List.generate(
                     6,

--- a/lib/domain/calendar/calendar_day_tile.dart
+++ b/lib/domain/calendar/calendar_day_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/domain/calendar/calendar.dart';
 import 'package:pilll/entity/weekday.dart';
 
@@ -103,11 +104,7 @@ class CalendarDayTile extends StatelessWidget {
   }
 
   TextStyle _font() {
-    if (shouldShowMenstruationMark) {
-      return FontType.gridElementBold;
-    } else {
-      return FontType.gridElement;
-    }
+    return FontType.gridElement;
   }
 
   Color _textColor() {
@@ -119,15 +116,15 @@ class CalendarDayTile extends StatelessWidget {
         case Weekday.Sunday:
           return weekday.weekdayColor();
         case Weekday.Monday:
-          return PilllColors.black;
+          return TextColor.main;
         case Weekday.Tuesday:
-          return PilllColors.black;
+          return TextColor.main;
         case Weekday.Wednesday:
-          return PilllColors.black;
+          return TextColor.main;
         case Weekday.Thursday:
-          return PilllColors.black;
+          return TextColor.main;
         case Weekday.Friday:
-          return PilllColors.black;
+          return TextColor.main;
         case Weekday.Saturday:
           return weekday.weekdayColor();
       }

--- a/lib/domain/calendar/calendar_weekday_line.dart
+++ b/lib/domain/calendar/calendar_weekday_line.dart
@@ -118,9 +118,11 @@ void transitionToPostDiary(
   if (!isExistsPostedDiary(diaries, date)) {
     Navigator.of(context).push(PostDiaryPageRoute.route(date));
   } else {
+    final diary =
+        diaries.lastWhere((element) => isSameDay(element.date, date));
     showModalBottomSheet(
       context: context,
-      builder: (context) => ConfirmDiarySheet(date),
+      builder: (context) => ConfirmDiarySheet(diary),
       backgroundColor: Colors.transparent,
     );
   }

--- a/lib/domain/calendar/calendar_weekday_line.dart
+++ b/lib/domain/calendar/calendar_weekday_line.dart
@@ -17,6 +17,7 @@ class CalendarWeekdayLine extends StatelessWidget {
   final List<CalendarBandModel> bandModels;
   final double horizontalPadding;
   final Function(WeeklyCalendarState, DateTime) onTap;
+  final Function(CalendarBandModel)? onTapBand;
 
   const CalendarWeekdayLine({
     Key? key,
@@ -25,6 +26,7 @@ class CalendarWeekdayLine extends StatelessWidget {
     required this.bandModels,
     required this.horizontalPadding,
     required this.onTap,
+    this.onTapBand,
   }) : super(key: key);
   @override
   Widget build(BuildContext context) {
@@ -98,6 +100,7 @@ class CalendarWeekdayLine extends StatelessWidget {
               model: bandModel,
               isLineBreaked: isLineBreaked,
               width: tileWidth * length,
+              onTap: onTapBand,
             ),
           );
         })
@@ -118,8 +121,7 @@ void transitionToPostDiary(
   if (!isExistsPostedDiary(diaries, date)) {
     Navigator.of(context).push(PostDiaryPageRoute.route(date));
   } else {
-    final diary =
-        diaries.lastWhere((element) => isSameDay(element.date, date));
+    final diary = diaries.lastWhere((element) => isSameDay(element.date, date));
     showModalBottomSheet(
       context: context,
       builder: (context) => ConfirmDiarySheet(diary),

--- a/lib/domain/calendar/utility.dart
+++ b/lib/domain/calendar/utility.dart
@@ -69,6 +69,11 @@ List<CalendarBandModel> buildBandModels(
     if (pillSheet != null) ...[
       ...scheduledMenstruationDateRanges(
               pillSheet, setting!, menstruations, maxPageCount)
+          .where((bandRange) => menstruations
+              .where((menstruation) =>
+                  bandRange.inRange(menstruation.beginDate) ||
+                  bandRange.inRange(menstruation.endDate))
+              .isEmpty)
           .map((range) =>
               CalendarScheduledMenstruationBandModel(range.begin, range.end)),
       ...nextPillSheetDateRanges(pillSheet, maxPageCount).map(

--- a/lib/domain/calendar/utility.dart
+++ b/lib/domain/calendar/utility.dart
@@ -63,9 +63,7 @@ List<CalendarBandModel> buildBandModels(
 ) {
   assert(maxPageCount > 0);
   return [
-    ...menstruations
-        .map((e) => e.dateRange)
-        .map((e) => CalendarMenstruationBandModel(e.begin, e.end)),
+    ...menstruations.map((e) => CalendarMenstruationBandModel(e)),
     if (pillSheet != null) ...[
       ...scheduledMenstruationDateRanges(
               pillSheet, setting!, menstruations, maxPageCount)

--- a/lib/domain/calendar/weekly_calendar_state.dart
+++ b/lib/domain/calendar/weekly_calendar_state.dart
@@ -54,7 +54,7 @@ class SinglelineWeeklyCalendarState extends WeeklyCalendarState {
   bool shouldShowDiaryMark(List<Diary> diaries, DateTime date) =>
       isExistsPostedDiary(diaries, date);
   bool shouldShowMenstruationMark(DateTime date) => false;
-  Alignment get contentAlignment => Alignment.topCenter;
+  Alignment get contentAlignment => Alignment.center;
 }
 
 class MultilineWeeklyCalendarState extends WeeklyCalendarState {

--- a/lib/domain/diary/confirm_diary_sheet.dart
+++ b/lib/domain/diary/confirm_diary_sheet.dart
@@ -2,8 +2,7 @@ import 'package:pilll/domain/diary/post_diary_page.dart';
 import 'package:pilll/entity/diary.dart';
 import 'package:pilll/service/diary.dart';
 import 'package:pilll/state/diary.dart';
-import 'package:pilll/store/diaries.dart';
-import 'package:pilll/store/post_diary.dart';
+import 'package:pilll/store/confirm_diary.dart';
 import 'package:pilll/components/atoms/buttons.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
@@ -14,21 +13,19 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-final _confirmDiaryProvider = StateNotifierProvider.autoDispose
-    .family<PostDiaryStore, DateTime>((ref, date) {
-  final diary =
-      ref.watch(monthlyDiariesStoreProvider(date).state).diaryForDateTime(date);
+final _confirmDiaryProvider =
+    StateNotifierProvider.autoDispose.family<ConfirmDiary, Diary>((ref, diary) {
   final service = ref.watch(diaryServiceProvider);
-  return PostDiaryStore(service, DiaryState(entity: diary.copyWith()));
+  return ConfirmDiary(service, DiaryState(entity: diary.copyWith()));
 });
 
 class ConfirmDiarySheet extends HookWidget {
-  final DateTime date;
+  final Diary diary;
 
-  ConfirmDiarySheet(this.date);
+  ConfirmDiarySheet(this.diary);
   @override
   Widget build(BuildContext context) {
-    final state = useProvider(_confirmDiaryProvider(date).state);
+    final state = useProvider(_confirmDiaryProvider(diary).state);
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.only(
@@ -61,17 +58,17 @@ class ConfirmDiarySheet extends HookWidget {
   }
 
   Widget _title(BuildContext context) {
-    final store = useProvider(_confirmDiaryProvider(date));
+    final store = useProvider(_confirmDiaryProvider(diary));
     return Row(
       mainAxisSize: MainAxisSize.max,
       children: [
-        Text(DateTimeFormatter.yearAndMonthAndDay(this.date),
+        Text(DateTimeFormatter.yearAndMonthAndDay(diary.date),
             style: FontType.sBigTitle.merge(TextColorStyle.main)),
         Spacer(),
         IconButton(
           icon: SvgPicture.asset("images/edit.svg"),
           onPressed: () {
-            Navigator.of(context).push(PostDiaryPageRoute.route(date));
+            Navigator.of(context).push(PostDiaryPageRoute.route(diary.date));
           },
         ),
         SizedBox(width: 12),
@@ -107,7 +104,7 @@ class ConfirmDiarySheet extends HookWidget {
   }
 
   Widget _physicalCondition() {
-    final state = useProvider(_confirmDiaryProvider(date).state);
+    final state = useProvider(_confirmDiaryProvider(diary).state);
     return Row(
       children: [
         Text("体調", style: FontType.componentTitle.merge(TextColorStyle.black)),
@@ -118,7 +115,6 @@ class ConfirmDiarySheet extends HookWidget {
   }
 
   Widget _physicalConditionDetails() {
-    final diary = useProvider(_confirmDiaryProvider(date).state).entity;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -150,7 +146,6 @@ class ConfirmDiarySheet extends HookWidget {
   }
 
   Widget _memo() {
-    final diary = useProvider(_confirmDiaryProvider(date).state).entity;
     return Text(
       diary.memo,
       maxLines: 2,

--- a/lib/domain/diary/confirm_diary_sheet.dart
+++ b/lib/domain/diary/confirm_diary_sheet.dart
@@ -87,7 +87,7 @@ class ConfirmDiarySheet extends HookWidget {
                       done: () {
                         int counter = 0;
                         store.delete().then((value) => Navigator.popUntil(
-                            context, (route) => counter++ >= 2));
+                            context, (route) => counter++ >= 1));
                       });
                 });
           },

--- a/lib/domain/diary/confirm_diary_sheet.dart
+++ b/lib/domain/diary/confirm_diary_sheet.dart
@@ -1,9 +1,9 @@
+import 'package:pilll/components/page/discard_dialog.dart';
 import 'package:pilll/domain/diary/post_diary_page.dart';
 import 'package:pilll/entity/diary.dart';
 import 'package:pilll/service/diary.dart';
 import 'package:pilll/state/diary.dart';
 import 'package:pilll/store/confirm_diary.dart';
-import 'package:pilll/components/atoms/buttons.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
@@ -80,11 +80,15 @@ class ConfirmDiarySheet extends HookWidget {
             showDialog(
                 context: context,
                 builder: (context) {
-                  return ConfirmDeleteDiary(onDelete: () {
-                    int counter = 0;
-                    store.delete().then((value) =>
-                        Navigator.popUntil(context, (route) => counter++ >= 2));
-                  });
+                  return DiscardDialog(
+                      title: "日記を削除します",
+                      message: "削除された日記は復元ができません",
+                      doneButtonText: "削除する",
+                      done: () {
+                        int counter = 0;
+                        store.delete().then((value) => Navigator.popUntil(
+                            context, (route) => counter++ >= 2));
+                      });
                 });
           },
         ),
@@ -153,48 +157,6 @@ class ConfirmDiarySheet extends HookWidget {
     return Text(
       state.entity.memo,
       maxLines: 2,
-    );
-  }
-}
-
-class ConfirmDeleteDiary extends StatelessWidget {
-  final Function() onDelete;
-
-  const ConfirmDeleteDiary({Key? key, required this.onDelete})
-      : super(key: key);
-  @override
-  Widget build(BuildContext context) {
-    return AlertDialog(
-      title: SvgPicture.asset("images/alert_24.svg"),
-      content: SizedBox(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Text("日記を削除します",
-                style: FontType.subTitle.merge(TextColorStyle.black)),
-            SizedBox(
-              height: 15,
-            ),
-            Text("削除された日記は復元ができません",
-                style: FontType.assisting.merge(TextColorStyle.lightGray)),
-          ],
-        ),
-      ),
-      actions: <Widget>[
-        SecondaryButton(
-          text: "キャンセル",
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
-        ),
-        SecondaryButton(
-          text: "削除する",
-          onPressed: () {
-            onDelete();
-          },
-        ),
-      ],
     );
   }
 }

--- a/lib/domain/diary/confirm_diary_sheet.dart
+++ b/lib/domain/diary/confirm_diary_sheet.dart
@@ -20,12 +20,12 @@ final _confirmDiaryProvider =
 });
 
 class ConfirmDiarySheet extends HookWidget {
-  final Diary diary;
+  final Diary _diary;
 
-  ConfirmDiarySheet(this.diary);
+  ConfirmDiarySheet(this._diary);
   @override
   Widget build(BuildContext context) {
-    final state = useProvider(_confirmDiaryProvider(diary).state);
+    final state = useProvider(_confirmDiaryProvider(_diary).state);
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.only(
@@ -58,17 +58,19 @@ class ConfirmDiarySheet extends HookWidget {
   }
 
   Widget _title(BuildContext context) {
-    final store = useProvider(_confirmDiaryProvider(diary));
+    final store = useProvider(_confirmDiaryProvider(_diary));
+    final state = useProvider(_confirmDiaryProvider(_diary).state);
     return Row(
       mainAxisSize: MainAxisSize.max,
       children: [
-        Text(DateTimeFormatter.yearAndMonthAndDay(diary.date),
+        Text(DateTimeFormatter.yearAndMonthAndDay(state.entity.date),
             style: FontType.sBigTitle.merge(TextColorStyle.main)),
         Spacer(),
         IconButton(
           icon: SvgPicture.asset("images/edit.svg"),
           onPressed: () {
-            Navigator.of(context).push(PostDiaryPageRoute.route(diary.date));
+            Navigator.of(context)
+                .push(PostDiaryPageRoute.route(state.entity.date));
           },
         ),
         SizedBox(width: 12),
@@ -104,7 +106,7 @@ class ConfirmDiarySheet extends HookWidget {
   }
 
   Widget _physicalCondition() {
-    final state = useProvider(_confirmDiaryProvider(diary).state);
+    final state = useProvider(_confirmDiaryProvider(_diary).state);
     return Row(
       children: [
         Text("体調", style: FontType.componentTitle.merge(TextColorStyle.black)),
@@ -115,12 +117,13 @@ class ConfirmDiarySheet extends HookWidget {
   }
 
   Widget _physicalConditionDetails() {
+    final state = useProvider(_confirmDiaryProvider(_diary).state);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Wrap(
           spacing: 10,
-          children: diary.physicalConditions
+          children: state.entity.physicalConditions
               .map((e) => ChoiceChip(
                     label: Text(e),
                     labelStyle: FontType.assisting.merge(TextColorStyle.white),
@@ -146,8 +149,9 @@ class ConfirmDiarySheet extends HookWidget {
   }
 
   Widget _memo() {
+    final state = useProvider(_confirmDiaryProvider(_diary).state);
     return Text(
-      diary.memo,
+      state.entity.memo,
       maxLines: 2,
     );
   }

--- a/lib/domain/diary/post_diary_page.dart
+++ b/lib/domain/diary/post_diary_page.dart
@@ -322,6 +322,7 @@ extension PostDiaryPageRoute on PostDiaryPage {
     return MaterialPageRoute(
       settings: RouteSettings(name: "PostDiaryPage"),
       builder: (_) => PostDiaryPage(date),
+      fullscreenDialog: true,
     );
   }
 }

--- a/lib/domain/menstruation/menstruation_card2.dart
+++ b/lib/domain/menstruation/menstruation_card2.dart
@@ -1,0 +1,66 @@
+import 'package:pilll/components/atoms/buttons.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/molecules/app_card.dart';
+import 'package:pilll/entity/menstruation.dart';
+import 'package:pilll/util/formatter/date_time_formatter.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:flutter/material.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/components/atoms/text_color.dart';
+
+class MenstruationCard2State {
+  final String prefix;
+  final Menstruation menstruation;
+
+  MenstruationCard2State({required this.menstruation, required this.prefix});
+
+  String get dateRange {
+    return DateTimeFormatter.monthAndDay(menstruation.beginDate) +
+        " - " +
+        DateTimeFormatter.monthAndDay(menstruation.endDate);
+  }
+}
+
+class MenstruationCard2 extends StatelessWidget {
+  final MenstruationCard2State state;
+  final Function(MenstruationCard2State) onTap;
+
+  MenstruationCard2(this.state, this.onTap);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.only(left: 16, right: 16),
+      height: 72,
+      child: AppCard(
+        child: Padding(
+          padding: EdgeInsets.only(left: 36, right: 20),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              SvgPicture.asset(
+                "images/menstruation.svg",
+                width: 24,
+                color: PilllColors.red,
+              ),
+              Text(state.prefix + "の生理",
+                  style: TextColorStyle.noshime.merge(FontType.assisting)),
+              Spacer(),
+              Text(
+                state.dateRange,
+                style: TextColorStyle.gray.merge(
+                  FontType.xBigTitle,
+                ),
+              ),
+              Spacer(),
+              AppBarTextActionButton(
+                text: "編集",
+                onPressed: () => onTap(state),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/domain/menstruation/menstruation_card_state.dart
+++ b/lib/domain/menstruation/menstruation_card_state.dart
@@ -22,7 +22,7 @@ abstract class MenstruationCardState implements _$MenstruationCardState {
           countdownString: () {
             final diff = scheduleDate.difference(today()).inDays;
             if (diff <= 0) {
-              return "${diff.abs() + 1}日目";
+              return "生理予定：${diff.abs() + 1}日目";
             }
             return "あと${scheduleDate.difference(today()).inDays}日";
           }());
@@ -33,8 +33,7 @@ abstract class MenstruationCardState implements _$MenstruationCardState {
       MenstruationCardState(
         title: "生理開始日",
         scheduleDate: menstruation.beginDate,
-        countdownString: menstruation.isNotYetUserEdited
-            ? "生理予定${today().difference(menstruation.beginDate).inDays + 1}日目"
-            : "${today().difference(menstruation.beginDate).inDays + 1}日目",
+        countdownString:
+            "${today().difference(menstruation.beginDate).inDays + 1}日目",
       );
 }

--- a/lib/domain/menstruation/menstruation_card_state.dart
+++ b/lib/domain/menstruation/menstruation_card_state.dart
@@ -19,7 +19,13 @@ abstract class MenstruationCardState implements _$MenstruationCardState {
       MenstruationCardState(
           title: "生理予定日",
           scheduleDate: scheduleDate,
-          countdownString: "あと${scheduleDate.difference(today()).inDays}日");
+          countdownString: () {
+            final diff = scheduleDate.difference(today()).inDays;
+            if (diff <= 0) {
+              return "${diff.abs() + 1}日目";
+            }
+            return "あと${scheduleDate.difference(today()).inDays}日";
+          }());
 
   factory MenstruationCardState.record({
     required Menstruation menstruation,

--- a/lib/domain/menstruation/menstruation_edit_page.dart
+++ b/lib/domain/menstruation/menstruation_edit_page.dart
@@ -46,7 +46,7 @@ class MenstruationEditPage extends HookWidget {
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    Text("生理期間を選択・編集",
+                    Text("生理期間の編集",
                         style: FontType.sBigTitle.merge(TextColorStyle.main)),
                     Spacer(),
                     SecondaryButton(

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -172,7 +172,7 @@ class MenstruationPage extends HookWidget {
                   color: PilllColors.background,
                   child: ListView.builder(
                     padding: EdgeInsets.only(top: 16),
-                    itemCount: max(1, min(3, state.entities.length)),
+                    itemCount: store.cardCount,
                     scrollDirection: Axis.vertical,
                     itemBuilder: (context, index) {
                       final body = () {
@@ -184,10 +184,8 @@ class MenstruationPage extends HookWidget {
                             }
                             return MenstruationCard(cardState);
                           default:
-                            final cardState = store.card2State(index);
-                            if (cardState == null) {
-                              return Container();
-                            }
+                            final cardState = store.card2Statuses()[
+                                index - [state.latestMenstruation].length];
                             return MenstruationCard2(
                               cardState,
                               (state) {

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -54,8 +54,7 @@ class MenstruationPage extends HookWidget {
         actions: [
           AppBarTextActionButton(
               onPressed: () {
-                store.updateCurrentCalendarIndex(
-                    state.todayCalendarIndex);
+                store.updateCurrentCalendarIndex(state.todayCalendarIndex);
                 itemScrollController.scrollTo(
                     index: state.todayCalendarIndex,
                     duration: Duration(milliseconds: 300));
@@ -103,14 +102,12 @@ class MenstruationPage extends HookWidget {
                       maxHeight: MenstruationPageConst.tileHeight,
                       child: ScrollablePositionedList.builder(
                         itemScrollController: itemScrollController,
-                        initialScrollIndex:
-                            state.currentCalendarIndex,
+                        initialScrollIndex: state.currentCalendarIndex,
                         physics: PageScrollPhysics(),
                         scrollDirection: Axis.horizontal,
                         itemPositionsListener: itemPositionsListener,
                         itemBuilder: (context, index) {
-                          final data =
-                              state.calendarDataSource[index];
+                          final data = state.calendarDataSource[index];
                           return _DateLine(
                             days: data,
                             state: state,
@@ -144,8 +141,7 @@ class MenstruationPage extends HookWidget {
                 child: PrimaryButton(
                   onPressed: () {
                     analytics.logEvent(name: "pressed_menstruation_record");
-                    final latestMenstruation =
-                        state.latestMenstruation;
+                    final latestMenstruation = state.latestMenstruation;
                     if (latestMenstruation != null &&
                         latestMenstruation.dateRange.inRange(today())) {
                       _showEditPage(
@@ -182,8 +178,7 @@ class MenstruationPage extends HookWidget {
                             analytics.logEvent(
                                 name: "tapped_menstruation_record_today");
                             Navigator.of(context).pop();
-                            final created =
-                                await store.recordFromToday();
+                            final created = await store.recordFromToday();
                             ScaffoldMessenger.of(context).showSnackBar(
                               SnackBar(
                                 duration: Duration(seconds: 1),
@@ -196,8 +191,7 @@ class MenstruationPage extends HookWidget {
                             analytics.logEvent(
                                 name: "tapped_menstruation_record_yesterday");
                             Navigator.of(context).pop();
-                            final created =
-                                await store.recordFromYesterday();
+                            final created = await store.recordFromYesterday();
                             ScaffoldMessenger.of(context).showSnackBar(
                               SnackBar(
                                 duration: Duration(seconds: 1),
@@ -235,7 +229,7 @@ class MenstruationPage extends HookWidget {
                             Navigator.of(context).pop();
                             return _showEditPage(
                               context,
-                              null,
+                              latestMenstruation,
                               didEndSave: (menstruation) {
                                 Navigator.of(context).pop();
                                 ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -259,7 +259,7 @@ class MenstruationPage extends HookWidget {
                       }),
                     );
                   },
-                  text: "生理期間を編集",
+                  text: menstruationState.buttonString,
                 ),
               ),
             ],

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -38,13 +38,13 @@ abstract class MenstruationPageConst {
 class MenstruationPage extends HookWidget {
   @override
   Scaffold build(BuildContext context) {
-    final menstruationStore = useProvider(menstruationsStoreProvider);
-    final menstruationState = useProvider(menstruationsStoreProvider.state);
+    final store = useProvider(menstruationsStoreProvider);
+    final state = useProvider(menstruationsStoreProvider.state);
     final ItemPositionsListener itemPositionsListener =
         ItemPositionsListener.create();
     itemPositionsListener.itemPositions.addListener(() {
       final index = itemPositionsListener.itemPositions.value.last.index;
-      menstruationStore.updateCurrentCalendarIndex(index);
+      store.updateCurrentCalendarIndex(index);
     });
     final ItemScrollController itemScrollController = ItemScrollController();
 
@@ -54,17 +54,17 @@ class MenstruationPage extends HookWidget {
         actions: [
           AppBarTextActionButton(
               onPressed: () {
-                menstruationStore.updateCurrentCalendarIndex(
-                    menstruationState.todayCalendarIndex);
+                store.updateCurrentCalendarIndex(
+                    state.todayCalendarIndex);
                 itemScrollController.scrollTo(
-                    index: menstruationState.todayCalendarIndex,
+                    index: state.todayCalendarIndex,
                     duration: Duration(milliseconds: 300));
               },
               text: "今日"),
         ],
         title: SizedBox(
           child: Text(
-            menstruationState.displayMonth,
+            state.displayMonth,
             style: TextStyle(color: TextColor.black),
           ),
         ),
@@ -104,19 +104,19 @@ class MenstruationPage extends HookWidget {
                       child: ScrollablePositionedList.builder(
                         itemScrollController: itemScrollController,
                         initialScrollIndex:
-                            menstruationState.currentCalendarIndex,
+                            state.currentCalendarIndex,
                         physics: PageScrollPhysics(),
                         scrollDirection: Axis.horizontal,
                         itemPositionsListener: itemPositionsListener,
                         itemBuilder: (context, index) {
                           final data =
-                              menstruationState.calendarDataSource[index];
+                              state.calendarDataSource[index];
                           return _DateLine(
                             days: data,
-                            state: menstruationState,
+                            state: state,
                           );
                         },
-                        itemCount: menstruationState.calendarDataSource.length,
+                        itemCount: state.calendarDataSource.length,
                       ),
                     ),
                   ],
@@ -130,7 +130,7 @@ class MenstruationPage extends HookWidget {
                     itemCount: 1,
                     scrollDirection: Axis.vertical,
                     itemBuilder: (context, index) {
-                      final cardState = menstruationStore.cardState();
+                      final cardState = store.cardState();
                       if (cardState == null) {
                         return Container();
                       }
@@ -145,7 +145,7 @@ class MenstruationPage extends HookWidget {
                   onPressed: () {
                     analytics.logEvent(name: "pressed_menstruation_record");
                     final latestMenstruation =
-                        menstruationState.latestMenstruation;
+                        state.latestMenstruation;
                     if (latestMenstruation != null &&
                         latestMenstruation.dateRange.inRange(today())) {
                       _showEditPage(
@@ -183,7 +183,7 @@ class MenstruationPage extends HookWidget {
                                 name: "tapped_menstruation_record_today");
                             Navigator.of(context).pop();
                             final created =
-                                await menstruationStore.recordFromToday();
+                                await store.recordFromToday();
                             ScaffoldMessenger.of(context).showSnackBar(
                               SnackBar(
                                 duration: Duration(seconds: 1),
@@ -197,7 +197,7 @@ class MenstruationPage extends HookWidget {
                                 name: "tapped_menstruation_record_yesterday");
                             Navigator.of(context).pop();
                             final created =
-                                await menstruationStore.recordFromYesterday();
+                                await store.recordFromYesterday();
                             ScaffoldMessenger.of(context).showSnackBar(
                               SnackBar(
                                 duration: Duration(seconds: 1),
@@ -259,7 +259,7 @@ class MenstruationPage extends HookWidget {
                       }),
                     );
                   },
-                  text: menstruationState.buttonString,
+                  text: state.buttonString,
                 ),
               ),
             ],

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -268,32 +268,6 @@ class MenstruationPage extends HookWidget {
                                 ),
                               );
                             });
-                          case MenstruationSelectModifyType.edit:
-                            analytics.logEvent(
-                                name: "tapped_menstruation_record_edit");
-                            Navigator.of(context).pop();
-                            return _showEditPage(
-                              context,
-                              latestMenstruation,
-                              didEndSave: (menstruation) {
-                                Navigator.of(context).pop();
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    duration: Duration(seconds: 1),
-                                    content: Text("生理期間を編集しました"),
-                                  ),
-                                );
-                              },
-                              didEndDelete: () {
-                                Navigator.of(context).pop();
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    duration: Duration(seconds: 1),
-                                    content: Text("生理期間を削除しました"),
-                                  ),
-                                );
-                              },
-                            );
                         }
                       }),
                     );

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -14,6 +16,7 @@ import 'package:pilll/domain/calendar/date_range.dart';
 import 'package:pilll/domain/calendar/utility.dart';
 import 'package:pilll/domain/calendar/weekly_calendar_state.dart';
 import 'package:pilll/domain/menstruation/menstruation_card.dart';
+import 'package:pilll/domain/menstruation/menstruation_card2.dart';
 import 'package:pilll/domain/menstruation/menstruation_edit_page.dart';
 import 'package:pilll/domain/menstruation/menstruation_select_modify_type_sheet.dart';
 import 'package:pilll/domain/record/weekday_badge.dart';
@@ -169,14 +172,54 @@ class MenstruationPage extends HookWidget {
                   color: PilllColors.background,
                   child: ListView.builder(
                     padding: EdgeInsets.only(top: 16),
-                    itemCount: 1,
+                    itemCount: max(1, min(3, state.entities.length)),
                     scrollDirection: Axis.vertical,
                     itemBuilder: (context, index) {
-                      final cardState = store.cardState();
-                      if (cardState == null) {
-                        return Container();
-                      }
-                      return MenstruationCard(cardState);
+                      final body = () {
+                        switch (index) {
+                          case 0:
+                            final cardState = store.cardState();
+                            if (cardState == null) {
+                              return Container();
+                            }
+                            return MenstruationCard(cardState);
+                          default:
+                            final cardState = store.card2State(index);
+                            if (cardState == null) {
+                              return Container();
+                            }
+                            return MenstruationCard2(
+                              cardState,
+                              (state) {
+                                _showEditPage(
+                                  context,
+                                  state.menstruation,
+                                  didEndSave: (menstruation) {
+                                    Navigator.of(context).pop();
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                        duration: Duration(seconds: 1),
+                                        content: Text("生理期間を編集しました"),
+                                      ),
+                                    );
+                                  },
+                                  didEndDelete: () {
+                                    Navigator.of(context).pop();
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                        duration: Duration(seconds: 1),
+                                        content: Text("生理期間を削除しました"),
+                                      ),
+                                    );
+                                  },
+                                );
+                              },
+                            );
+                        }
+                      };
+
+                      return Padding(
+                          padding: EdgeInsets.only(bottom: 24), child: body());
                     },
                   ),
                 ),

--- a/lib/domain/menstruation/menstruation_select_modify_type_sheet.dart
+++ b/lib/domain/menstruation/menstruation_select_modify_type_sheet.dart
@@ -4,7 +4,7 @@ import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 
-enum MenstruationSelectModifyType { today, yesterday, begin, edit }
+enum MenstruationSelectModifyType { today, yesterday, begin }
 
 extension _CellTypeFunction on MenstruationSelectModifyType {
   String get title {
@@ -15,8 +15,6 @@ extension _CellTypeFunction on MenstruationSelectModifyType {
         return "昨日から生理";
       case MenstruationSelectModifyType.begin:
         return "開始日を日付から選択";
-      case MenstruationSelectModifyType.edit:
-        return "生理期間を編集";
     }
   }
 
@@ -29,8 +27,6 @@ extension _CellTypeFunction on MenstruationSelectModifyType {
           return "images/menstruation_record_icon.svg";
         case MenstruationSelectModifyType.begin:
           return "images/menstruation_begin_record_icon.svg";
-        case MenstruationSelectModifyType.edit:
-          return "images/menstruation_edit_duration_icon.svg";
       }
     }
 

--- a/lib/domain/menstruation/menstruation_select_modify_type_sheet.dart
+++ b/lib/domain/menstruation/menstruation_select_modify_type_sheet.dart
@@ -34,6 +34,8 @@ extension _CellTypeFunction on MenstruationSelectModifyType {
   }
 }
 
+final double _tileHeight = 48;
+
 class MenstruationSelectModifyTypeSheet extends StatelessWidget {
   final Function(MenstruationSelectModifyType) onTap;
 
@@ -56,7 +58,7 @@ class MenstruationSelectModifyTypeSheet extends StatelessWidget {
             ),
             SizedBox(height: 24),
             SizedBox(
-              height: 192,
+              height: _tileHeight * MenstruationSelectModifyType.values.length,
               child: ListView(
                 physics: NeverScrollableScrollPhysics(),
                 children: MenstruationSelectModifyType.values
@@ -74,7 +76,7 @@ class MenstruationSelectModifyTypeSheet extends StatelessWidget {
 
   Widget _tile(MenstruationSelectModifyType type) {
     return SizedBox(
-      height: 48,
+      height: _tileHeight,
       child: ListTile(
         title: Text(
           type.title,

--- a/lib/domain/menstruation/menstruation_select_modify_type_sheet.dart
+++ b/lib/domain/menstruation/menstruation_select_modify_type_sheet.dart
@@ -14,7 +14,7 @@ extension _CellTypeFunction on MenstruationSelectModifyType {
       case MenstruationSelectModifyType.yesterday:
         return "昨日から生理";
       case MenstruationSelectModifyType.begin:
-        return "開始日を日付から選択";
+        return "生理開始日を選択";
     }
   }
 

--- a/lib/domain/settings/row_model.dart
+++ b/lib/domain/settings/row_model.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:flutter/material.dart';
@@ -11,16 +12,32 @@ abstract class SettingListRowModel {
 
 class SettingListTitleRowModel extends SettingListRowModel {
   final String title;
+  final String error;
   final VoidCallback onTap;
 
-  SettingListTitleRowModel({required this.title, required this.onTap});
+  SettingListTitleRowModel(
+      {required this.title, this.error = "", required this.onTap});
 
   @override
   Widget widget() {
-    return ListTile(
-      title: Text(title, style: FontType.listRow),
-      onTap: onTap,
-    );
+    if (error.isEmpty) {
+      return ListTile(
+        title: Text(title, style: FontType.listRow),
+        onTap: onTap,
+      );
+    } else {
+      return ListTile(
+        title: Row(
+          children: [
+            Text(title, style: FontType.listRow),
+            SizedBox(width: 8),
+            SvgPicture.asset("images/alert_24.svg", width: 24, height: 24),
+          ],
+        ),
+        subtitle: Text(error),
+        onTap: onTap,
+      );
+    }
   }
 }
 

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -331,6 +331,14 @@ class SettingsPage extends HookWidget {
         return [
           SettingListTitleRowModel(
               title: "生理について",
+              error: () {
+                final message =
+                    "生理開始日のピル番号をご確認ください。現在選択しているピルシートタイプには存在しないピル番号が設定されています";
+                return settingEntity.pillSheetType.totalCount <
+                        settingEntity.pillNumberForFromMenstruation
+                    ? message
+                    : "";
+              }(),
               onTap: () {
                 analytics.logEvent(
                   name: "did_select_changing_about_menstruation",

--- a/lib/entity/diary.dart
+++ b/lib/entity/diary.dart
@@ -54,4 +54,5 @@ abstract class Diary with _$Diary {
       Diary(date: date, memo: "", physicalConditions: [], hasSex: false);
   factory Diary.fromJson(Map<String, dynamic> json) => _$DiaryFromJson(json);
   Map<String, dynamic> toJson() => _$_$_DiaryToJson(this as _$_Diary);
+  bool get hasPhysicalConditionStatus => physicalConditionStatus != null;
 }

--- a/lib/inquiry/inquiry.dart
+++ b/lib/inquiry/inquiry.dart
@@ -1,7 +1,9 @@
 import 'package:pilll/auth/auth.dart';
 import 'package:pilll/database/database.dart';
+import 'package:pilll/entity/menstruation.dart';
 import 'package:pilll/entity/pill_sheet.dart';
 import 'package:pilll/entity/setting.dart';
+import 'package:pilll/service/menstruation.dart';
 import 'package:pilll/service/pill_sheet.dart';
 import 'package:pilll/service/setting.dart';
 import 'package:pilll/util/environment.dart';
@@ -23,6 +25,10 @@ Future<String> debugInfo(String separator) async {
   PillSheetModel pillSheet =
       await PillSheetService(databaseConnection).fetchLast();
   Setting setting = await SettingService(databaseConnection).fetch();
+  final menstruations =
+      await MenstruationService(databaseConnection).fetchAll();
+  Menstruation? menstruation =
+      menstruations.isNotEmpty ? menstruations.last : null;
   final package = await PackageInfo.fromPlatform();
   final appName = package.appName;
   final buildNumber = package.buildNumber;
@@ -34,6 +40,7 @@ Future<String> debugInfo(String separator) async {
     "buildNumber: $buildNumber",
     "env: ${Environment.isProduction ? "production" : "development"}",
     "user id: $userID",
+    "latestMenstruation: ${menstruation?.toJson()}",
     "pillSheet.entity.id: ${pillSheet.id}",
     "pillSheetState.entity: ${pillSheet.toJson()}",
     "settingState.entity: ${setting.toJson()}",

--- a/lib/state/diaries.dart
+++ b/lib/state/diaries.dart
@@ -28,7 +28,4 @@ abstract class DiariesState implements _$DiariesState {
     }
     return filtered.last;
   }
-
-  Diary diaryForDateTime(DateTime dateTime) =>
-      entities.lastWhere((element) => isSameDay(element.date, dateTime));
 }

--- a/lib/state/diary.dart
+++ b/lib/state/diary.dart
@@ -11,5 +11,5 @@ abstract class DiaryState implements _$DiaryState {
   bool hasPhysicalConditionStatusFor(PhysicalConditionStatus status) =>
       entity.physicalConditionStatus == status;
 
-  bool hasPhysicalConditionStatus() => entity.physicalConditionStatus != null;
+  bool hasPhysicalConditionStatus() => entity.hasPhysicalConditionStatus;
 }

--- a/lib/state/menstruation.dart
+++ b/lib/state/menstruation.dart
@@ -4,6 +4,7 @@ import 'package:pilll/entity/menstruation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:pilll/entity/pill_sheet.dart';
 import 'package:pilll/entity/setting.dart';
+import 'package:pilll/util/datetime/date_compare.dart';
 import 'package:pilll/util/formatter/date_time_formatter.dart';
 import 'package:flutter/material.dart';
 import 'package:pilll/entity/weekday.dart';
@@ -24,7 +25,8 @@ abstract class MenstruationState implements _$MenstruationState {
   }) = _MenstruationState;
 
   late final List<List<DateTime>> calendarDataSource = _calendarDataSource();
-  int get todayCalendarIndex => calendarDataSource.length ~/ 2;
+  int get todayCalendarIndex => calendarDataSource.lastIndexWhere((element) =>
+      element.where((element) => isSameDay(element, today())).isNotEmpty);
 
   DateTime _targetEndDayOfWeekday() {
     final diff = currentCalendarIndex - todayCalendarIndex;
@@ -79,7 +81,7 @@ List<List<DateTime>> _calendarDataSource() {
     days.add(begin.add(Duration(days: i)));
   }
   return List.generate(
-      (diffDay / Weekday.values.length).round(),
+      ((diffDay + 1) / Weekday.values.length).round(),
       (i) => days.sublist(i * Weekday.values.length,
           i * Weekday.values.length + Weekday.values.length));
 }

--- a/lib/state/menstruation.dart
+++ b/lib/state/menstruation.dart
@@ -38,15 +38,23 @@ abstract class MenstruationState implements _$MenstruationState {
     final latestPillSheet = this.latestPillSheet;
     final setting = this.setting;
     if (latestPillSheet == null || setting == null) {
-      return "生理期間を編集";
+      return "生理を記録";
     }
     final start = latestPillSheet.beginingDate
         .add(Duration(days: setting.pillNumberForFromMenstruation - 1));
     final end = start.add(Duration(days: setting.durationMenstruation - 1));
     if (DateRange(start, end).inRange(today())) {
+      return "生理期間を編集";
+    }
+
+    final latestMenstruation = this.latestMenstruation;
+    if (latestMenstruation == null) {
       return "生理を記録";
     }
-    return "生理期間を編集";
+    if (latestMenstruation.dateRange.inRange(today())) {
+      return "生理期間を編集";
+    }
+    return "生理を記録";
   }
 
   Menstruation? get latestMenstruation {

--- a/lib/state/menstruation.dart
+++ b/lib/state/menstruation.dart
@@ -1,4 +1,3 @@
-import 'package:pilll/domain/calendar/date_range.dart';
 import 'package:pilll/entity/diary.dart';
 import 'package:pilll/entity/menstruation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';

--- a/lib/state/menstruation.dart
+++ b/lib/state/menstruation.dart
@@ -44,7 +44,7 @@ abstract class MenstruationState implements _$MenstruationState {
         .add(Duration(days: setting.pillNumberForFromMenstruation - 1));
     final end = start.add(Duration(days: setting.durationMenstruation - 1));
     if (DateRange(start, end).inRange(today())) {
-      return "生理期間を編集";
+      return "生理を記録";
     }
     return "生理期間を編集";
   }

--- a/lib/state/menstruation.dart
+++ b/lib/state/menstruation.dart
@@ -37,18 +37,6 @@ abstract class MenstruationState implements _$MenstruationState {
   String get displayMonth =>
       DateTimeFormatter.jaMonth(_targetEndDayOfWeekday());
   String get buttonString {
-    final latestPillSheet = this.latestPillSheet;
-    final setting = this.setting;
-    if (latestPillSheet == null || setting == null) {
-      return "生理を記録";
-    }
-    final start = latestPillSheet.beginingDate
-        .add(Duration(days: setting.pillNumberForFromMenstruation - 1));
-    final end = start.add(Duration(days: setting.durationMenstruation - 1));
-    if (DateRange(start, end).inRange(today())) {
-      return "生理期間を編集";
-    }
-
     final latestMenstruation = this.latestMenstruation;
     if (latestMenstruation == null) {
       return "生理を記録";

--- a/lib/state/menstruation.dart
+++ b/lib/state/menstruation.dart
@@ -1,3 +1,4 @@
+import 'package:pilll/domain/calendar/date_range.dart';
 import 'package:pilll/entity/diary.dart';
 import 'package:pilll/entity/menstruation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -33,6 +34,20 @@ abstract class MenstruationState implements _$MenstruationState {
 
   String get displayMonth =>
       DateTimeFormatter.jaMonth(_targetEndDayOfWeekday());
+  String get buttonString {
+    final latestPillSheet = this.latestPillSheet;
+    final setting = this.setting;
+    if (latestPillSheet == null || setting == null) {
+      return "生理期間を編集";
+    }
+    final start = latestPillSheet.beginingDate
+        .add(Duration(days: setting.pillNumberForFromMenstruation - 1));
+    final end = start.add(Duration(days: setting.durationMenstruation - 1));
+    if (DateRange(start, end).inRange(today())) {
+      return "生理期間を編集";
+    }
+    return "生理期間を編集";
+  }
 
   Menstruation? get latestMenstruation {
     return entities.isEmpty ? null : entities.last;

--- a/lib/state/menstruation_edit.dart
+++ b/lib/state/menstruation_edit.dart
@@ -1,6 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:pilll/entity/menstruation.dart';
-import 'package:pilll/util/datetime/day.dart';
 
 part 'menstruation_edit.freezed.dart';
 
@@ -9,24 +8,8 @@ abstract class MenstruationEditState implements _$MenstruationEditState {
   MenstruationEditState._();
   factory MenstruationEditState({
     required Menstruation? menstruation,
+    required List<DateTime> displayedDates,
   }) = _MenstruationEditState;
 
-  List<DateTime> dates() {
-    final menstruation = this.menstruation;
-    if (menstruation != null) {
-      return [
-        DateTime(
-            menstruation.beginDate.year, menstruation.beginDate.month - 1, 1),
-        menstruation.beginDate,
-        DateTime(
-            menstruation.beginDate.year, menstruation.beginDate.month + 1, 1),
-      ];
-    } else {
-      final t = today();
-      return [
-        t,
-        DateTime(t.year, t.month + 1, 1),
-      ];
-    }
-  }
+  List<DateTime> dates() => displayedDates;
 }

--- a/lib/state/menstruation_edit.dart
+++ b/lib/state/menstruation_edit.dart
@@ -15,6 +15,8 @@ abstract class MenstruationEditState implements _$MenstruationEditState {
     final menstruation = this.menstruation;
     if (menstruation != null) {
       return [
+        DateTime(
+            menstruation.beginDate.year, menstruation.beginDate.month - 1, 1),
         menstruation.beginDate,
         DateTime(
             menstruation.beginDate.year, menstruation.beginDate.month + 1, 1),

--- a/lib/state/menstruation_edit.freezed.dart
+++ b/lib/state/menstruation_edit.freezed.dart
@@ -16,9 +16,12 @@ final _privateConstructorUsedError = UnsupportedError(
 class _$MenstruationEditStateTearOff {
   const _$MenstruationEditStateTearOff();
 
-  _MenstruationEditState call({required Menstruation? menstruation}) {
+  _MenstruationEditState call(
+      {required Menstruation? menstruation,
+      required List<DateTime> displayedDates}) {
     return _MenstruationEditState(
       menstruation: menstruation,
+      displayedDates: displayedDates,
     );
   }
 }
@@ -29,6 +32,7 @@ const $MenstruationEditState = _$MenstruationEditStateTearOff();
 /// @nodoc
 mixin _$MenstruationEditState {
   Menstruation? get menstruation => throw _privateConstructorUsedError;
+  List<DateTime> get displayedDates => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $MenstruationEditStateCopyWith<MenstruationEditState> get copyWith =>
@@ -40,7 +44,7 @@ abstract class $MenstruationEditStateCopyWith<$Res> {
   factory $MenstruationEditStateCopyWith(MenstruationEditState value,
           $Res Function(MenstruationEditState) then) =
       _$MenstruationEditStateCopyWithImpl<$Res>;
-  $Res call({Menstruation? menstruation});
+  $Res call({Menstruation? menstruation, List<DateTime> displayedDates});
 
   $MenstruationCopyWith<$Res>? get menstruation;
 }
@@ -57,12 +61,17 @@ class _$MenstruationEditStateCopyWithImpl<$Res>
   @override
   $Res call({
     Object? menstruation = freezed,
+    Object? displayedDates = freezed,
   }) {
     return _then(_value.copyWith(
       menstruation: menstruation == freezed
           ? _value.menstruation
           : menstruation // ignore: cast_nullable_to_non_nullable
               as Menstruation?,
+      displayedDates: displayedDates == freezed
+          ? _value.displayedDates
+          : displayedDates // ignore: cast_nullable_to_non_nullable
+              as List<DateTime>,
     ));
   }
 
@@ -85,7 +94,7 @@ abstract class _$MenstruationEditStateCopyWith<$Res>
           $Res Function(_MenstruationEditState) then) =
       __$MenstruationEditStateCopyWithImpl<$Res>;
   @override
-  $Res call({Menstruation? menstruation});
+  $Res call({Menstruation? menstruation, List<DateTime> displayedDates});
 
   @override
   $MenstruationCopyWith<$Res>? get menstruation;
@@ -105,26 +114,35 @@ class __$MenstruationEditStateCopyWithImpl<$Res>
   @override
   $Res call({
     Object? menstruation = freezed,
+    Object? displayedDates = freezed,
   }) {
     return _then(_MenstruationEditState(
       menstruation: menstruation == freezed
           ? _value.menstruation
           : menstruation // ignore: cast_nullable_to_non_nullable
               as Menstruation?,
+      displayedDates: displayedDates == freezed
+          ? _value.displayedDates
+          : displayedDates // ignore: cast_nullable_to_non_nullable
+              as List<DateTime>,
     ));
   }
 }
 
 /// @nodoc
 class _$_MenstruationEditState extends _MenstruationEditState {
-  _$_MenstruationEditState({required this.menstruation}) : super._();
+  _$_MenstruationEditState(
+      {required this.menstruation, required this.displayedDates})
+      : super._();
 
   @override
   final Menstruation? menstruation;
+  @override
+  final List<DateTime> displayedDates;
 
   @override
   String toString() {
-    return 'MenstruationEditState(menstruation: $menstruation)';
+    return 'MenstruationEditState(menstruation: $menstruation, displayedDates: $displayedDates)';
   }
 
   @override
@@ -133,12 +151,17 @@ class _$_MenstruationEditState extends _MenstruationEditState {
         (other is _MenstruationEditState &&
             (identical(other.menstruation, menstruation) ||
                 const DeepCollectionEquality()
-                    .equals(other.menstruation, menstruation)));
+                    .equals(other.menstruation, menstruation)) &&
+            (identical(other.displayedDates, displayedDates) ||
+                const DeepCollectionEquality()
+                    .equals(other.displayedDates, displayedDates)));
   }
 
   @override
   int get hashCode =>
-      runtimeType.hashCode ^ const DeepCollectionEquality().hash(menstruation);
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(menstruation) ^
+      const DeepCollectionEquality().hash(displayedDates);
 
   @JsonKey(ignore: true)
   @override
@@ -148,12 +171,15 @@ class _$_MenstruationEditState extends _MenstruationEditState {
 }
 
 abstract class _MenstruationEditState extends MenstruationEditState {
-  factory _MenstruationEditState({required Menstruation? menstruation}) =
-      _$_MenstruationEditState;
+  factory _MenstruationEditState(
+      {required Menstruation? menstruation,
+      required List<DateTime> displayedDates}) = _$_MenstruationEditState;
   _MenstruationEditState._() : super._();
 
   @override
   Menstruation? get menstruation => throw _privateConstructorUsedError;
+  @override
+  List<DateTime> get displayedDates => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
   _$MenstruationEditStateCopyWith<_MenstruationEditState> get copyWith =>

--- a/lib/store/confirm_diary.dart
+++ b/lib/store/confirm_diary.dart
@@ -1,0 +1,12 @@
+import 'package:pilll/service/diary.dart';
+import 'package:pilll/state/diary.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class ConfirmDiary extends StateNotifier<DiaryState> {
+  final DiaryService _service;
+  ConfirmDiary(this._service, DiaryState state) : super(state);
+
+  Future<void> delete() {
+    return _service.delete(state.entity);
+  }
+}

--- a/lib/store/confirm_diary.dart
+++ b/lib/store/confirm_diary.dart
@@ -1,10 +1,33 @@
+import 'dart:async';
+
 import 'package:pilll/service/diary.dart';
 import 'package:pilll/state/diary.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/util/datetime/date_compare.dart';
 
 class ConfirmDiary extends StateNotifier<DiaryState> {
   final DiaryService _service;
-  ConfirmDiary(this._service, DiaryState state) : super(state);
+  ConfirmDiary(this._service, DiaryState state) : super(state) {
+    _subscribe();
+  }
+
+  StreamSubscription? canceller;
+  void _subscribe() {
+    canceller?.cancel();
+    canceller = _service.subscribe().listen((entities) {
+      entities
+          .where((element) => isSameDay(element.date, state.entity.date))
+          .forEach((element) {
+        state = state.copyWith(entity: element);
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    canceller?.cancel();
+    super.dispose();
+  }
 
   Future<void> delete() {
     return _service.delete(state.entity);

--- a/lib/store/menstruation.dart
+++ b/lib/store/menstruation.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/domain/menstruation/menstruation_card2.dart';
 import 'package:pilll/domain/menstruation/menstruation_card_state.dart';
 import 'package:pilll/entity/menstruation.dart';
 import 'package:pilll/service/diary.dart';
@@ -131,5 +132,14 @@ class MenstruationStore extends StateNotifier<MenstruationState> {
               .add(Duration(days: setting.pillNumberForFromMenstruation - 1)));
     }
     return null;
+  }
+
+  MenstruationCard2State? card2State(int index) {
+    if (state.entities.length <= index) {
+      return null;
+    }
+    final prefix = index == 1 ? "前回" : "前々回";
+    final menstruation = state.entities[index];
+    return MenstruationCard2State(menstruation: menstruation, prefix: prefix);
   }
 }

--- a/lib/store/menstruation.dart
+++ b/lib/store/menstruation.dart
@@ -139,7 +139,7 @@ class MenstruationStore extends StateNotifier<MenstruationState> {
       return null;
     }
     final prefix = index == 1 ? "前回" : "前々回";
-    final menstruation = state.entities[index];
+    final menstruation = state.entities.reversed.toList()[index];
     return MenstruationCard2State(menstruation: menstruation, prefix: prefix);
   }
 }

--- a/lib/store/menstruation_edit.dart
+++ b/lib/store/menstruation_edit.dart
@@ -15,6 +15,25 @@ final menstruationEditProvider = StateNotifierProvider.family
   ),
 );
 
+List<DateTime> displaedDates(Menstruation? menstruation) {
+  if (menstruation != null) {
+    return [
+      DateTime(
+          menstruation.beginDate.year, menstruation.beginDate.month - 1, 1),
+      menstruation.beginDate,
+      DateTime(
+          menstruation.beginDate.year, menstruation.beginDate.month + 1, 1),
+    ];
+  } else {
+    final t = today();
+    return [
+      DateTime(t.year, t.month - 1, 1),
+      t,
+      DateTime(t.year, t.month + 1, 1),
+    ];
+  }
+}
+
 class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
   late Menstruation? initialMenstruation;
   final MenstruationService service;
@@ -24,7 +43,9 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
     Menstruation? menstruation,
     required this.service,
     required this.settingService,
-  }) : super(MenstruationEditState(menstruation: menstruation)) {
+  }) : super(MenstruationEditState(
+            menstruation: menstruation,
+            displayedDates: displaedDates(menstruation))) {
     initialMenstruation = menstruation;
   }
 

--- a/lib/store/menstruation_edit.dart
+++ b/lib/store/menstruation_edit.dart
@@ -18,8 +18,6 @@ final menstruationEditProvider = StateNotifierProvider.family
 List<DateTime> displaedDates(Menstruation? menstruation) {
   if (menstruation != null) {
     return [
-      DateTime(
-          menstruation.beginDate.year, menstruation.beginDate.month - 1, 1),
       menstruation.beginDate,
       DateTime(
           menstruation.beginDate.year, menstruation.beginDate.month + 1, 1),
@@ -27,7 +25,6 @@ List<DateTime> displaedDates(Menstruation? menstruation) {
   } else {
     final t = today();
     return [
-      DateTime(t.year, t.month - 1, 1),
       t,
       DateTime(t.year, t.month + 1, 1),
     ];

--- a/lib/store/menstruation_edit.dart
+++ b/lib/store/menstruation_edit.dart
@@ -72,7 +72,8 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
   }
 
   Future<Menstruation> save() {
-    final menstruation = state.menstruation;
+    final menstruation =
+        state.menstruation?.copyWith(isNotYetUserEdited: false);
     if (menstruation == null) {
       throw FormatException("menstruation is not exists when save");
     }

--- a/test/domain/calendar/widget/calendar_test.dart
+++ b/test/domain/calendar/widget/calendar_test.dart
@@ -50,7 +50,8 @@ void main() {
             )
           ],
           child: MaterialApp(
-            home: Calendar(
+            home: CalendarBody(
+              diaries: diaries,
               calendarState: CalendarTabState(now),
               bandModels: [model],
               onTap: (date, diaries) => () {},
@@ -98,7 +99,8 @@ void main() {
             )
           ],
           child: MaterialApp(
-            home: Calendar(
+            home: CalendarBody(
+              diaries: diaries,
               calendarState: CalendarTabState(now),
               bandModels: [model],
               onTap: (date, diaries) => () {},
@@ -131,7 +133,8 @@ void main() {
                 .overrideWithProvider((ref, param) => mock)
           ],
           child: MaterialApp(
-            home: Calendar(
+            home: CalendarBody(
+              diaries: [],
               calendarState: CalendarTabState(now),
               bandModels: [
                 CalendarNextPillSheetBandModel(
@@ -160,7 +163,8 @@ void main() {
                 .overrideWithProvider((ref, param) => mock)
           ],
           child: MaterialApp(
-            home: Calendar(
+            home: CalendarBody(
+              diaries: [],
               calendarState: CalendarTabState(now),
               bandModels: [
                 CalendarNextPillSheetBandModel(


### PR DESCRIPTION
## What
- 生理データがある場合かつ、その期間内にもともと表示される生理予定日の帯のデータが有れば除外する
- 生理予定日 X 日目を表示する
- 生理期間中/期間外でボタンのワーディングを分ける

## Why
[生理タブ](https://github.com/bannzai/Pilll/pull/180) 機能を作成していた。が、生理予定日を編集したり今日の無ピル番号の変更等を加味していない状態だったのでソレを補った。具体的には毎時0:00に生理予定日に入ったら生理データの作成を行っていて、それを期待してのロジックになっていたため、アプリ上で生理予定日の状態で生理記録等の手順は確認しきれていなかった

その他に普通に考慮漏れがあった
## Links
reference: https://github.com/bannzai/Pilll/pull/180