### PR TITLE
Add invalid message when menstruation edit

### DIFF
--- a/lib/components/atoms/text_color.dart
+++ b/lib/components/atoms/text_color.dart
@@ -14,6 +14,7 @@ class TextColor {
   static final Color primary = PilllColors.primary;
   static final Color main = HexColor.fromHex("29304D");
   static final Color link = primary;
+  static final Color danger = PilllColors.red;
 }
 
 class TextColorStyle {
@@ -28,4 +29,5 @@ class TextColorStyle {
   static final TextStyle primary = TextStyle(color: TextColor.primary);
   static final TextStyle main = TextStyle(color: TextColor.main);
   static final TextStyle link = TextStyle(color: TextColor.link);
+  static final TextStyle danger = TextStyle(color: TextColor.danger);
 }

--- a/lib/domain/menstruation/menstruation_edit_page.dart
+++ b/lib/domain/menstruation/menstruation_edit_page.dart
@@ -50,12 +50,6 @@ class MenstruationEditPage extends HookWidget {
                   mainAxisAlignment: MainAxisAlignment.start,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    if (invalidMessage != null) ...[
-                      SizedBox(height: 12),
-                      Text(invalidMessage,
-                          style:
-                              FontType.assisting.merge(TextColorStyle.danger)),
-                    ],
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
@@ -94,6 +88,12 @@ class MenstruationEditPage extends HookWidget {
                         )
                       ],
                     ),
+                    if (invalidMessage != null) ...[
+                      SizedBox(height: 12),
+                      Text(invalidMessage,
+                          style:
+                              FontType.assisting.merge(TextColorStyle.danger)),
+                    ],
                   ],
                 ),
               ),

--- a/lib/domain/menstruation/menstruation_edit_page.dart
+++ b/lib/domain/menstruation/menstruation_edit_page.dart
@@ -30,6 +30,7 @@ class MenstruationEditPage extends HookWidget {
   Widget build(BuildContext context) {
     final store = useProvider(menstruationEditProvider(menstruation));
     final state = useProvider(menstruationEditProvider(menstruation).state);
+    final invalidMessage = state.invalidMessage;
     return DraggableScrollableSheet(
       initialChildSize: 0.7,
       builder: (context, scrollController) {
@@ -45,41 +46,54 @@ class MenstruationEditPage extends HookWidget {
             children: [
               Padding(
                 padding: const EdgeInsets.only(top: 21.0, left: 16, right: 16),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(title,
-                        style: FontType.sBigTitle.merge(TextColorStyle.main)),
-                    Spacer(),
-                    SecondaryButton(
-                      onPressed: () {
-                        analytics.logEvent(
-                            name: "pressed_saving_menstruation_edit");
-                        if (store.shouldShowDiscardDialog()) {
-                          showDialog(
-                            context: context,
-                            builder: (context) => DiscardDialog(
-                              title: "生理期間を削除しますか？",
-                              message: "",
-                              doneButtonText: "削除する",
-                              done: () => store
-                                  .delete()
-                                  .then((_) => didEndDelete())
-                                  .then((_) => analytics.logEvent(
-                                      name: "pressed_delete_menstruation")),
-                              cancel: () {
-                                analytics.logEvent(
-                                    name: "cancelled_delete_menstruation");
-                                Navigator.of(context).pop();
-                              },
-                            ),
-                          );
-                        } else {
-                          store.save().then((value) => didEndSave(value));
-                        }
-                      },
-                      text: "保存",
-                    )
+                    if (invalidMessage != null) ...[
+                      SizedBox(height: 12),
+                      Text(invalidMessage,
+                          style:
+                              FontType.assisting.merge(TextColorStyle.danger)),
+                    ],
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Text(title,
+                            style:
+                                FontType.sBigTitle.merge(TextColorStyle.main)),
+                        Spacer(),
+                        SecondaryButton(
+                          onPressed: () {
+                            analytics.logEvent(
+                                name: "pressed_saving_menstruation_edit");
+                            if (store.shouldShowDiscardDialog()) {
+                              showDialog(
+                                context: context,
+                                builder: (context) => DiscardDialog(
+                                  title: "生理期間を削除しますか？",
+                                  message: "",
+                                  doneButtonText: "削除する",
+                                  done: () => store
+                                      .delete()
+                                      .then((_) => didEndDelete())
+                                      .then((_) => analytics.logEvent(
+                                          name: "pressed_delete_menstruation")),
+                                  cancel: () {
+                                    analytics.logEvent(
+                                        name: "cancelled_delete_menstruation");
+                                    Navigator.of(context).pop();
+                                  },
+                                ),
+                              );
+                            } else {
+                              store.save().then((value) => didEndSave(value));
+                            }
+                          },
+                          text: "保存",
+                        )
+                      ],
+                    ),
                   ],
                 ),
               ),

--- a/lib/domain/menstruation/menstruation_edit_page.dart
+++ b/lib/domain/menstruation/menstruation_edit_page.dart
@@ -15,10 +15,12 @@ import 'package:pilll/entity/menstruation.dart';
 import 'package:pilll/store/menstruation_edit.dart';
 
 class MenstruationEditPage extends HookWidget {
+  final String title;
   final Menstruation? menstruation;
   final Function(Menstruation) didEndSave;
   final VoidCallback didEndDelete;
   MenstruationEditPage({
+    required this.title,
     required this.menstruation,
     required this.didEndSave,
     required this.didEndDelete,
@@ -46,7 +48,7 @@ class MenstruationEditPage extends HookWidget {
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    Text("生理期間の編集",
+                    Text(title,
                         style: FontType.sBigTitle.merge(TextColorStyle.main)),
                     Spacer(),
                     SecondaryButton(

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -138,6 +136,7 @@ class MenstruationPage extends HookWidget {
                                 _showEditPage(
                                   context,
                                   model.menstruation,
+                                  title: "生理期間の編集",
                                   didEndSave: (menstruation) {
                                     Navigator.of(context).pop();
                                     ScaffoldMessenger.of(context).showSnackBar(
@@ -192,6 +191,7 @@ class MenstruationPage extends HookWidget {
                                 _showEditPage(
                                   context,
                                   state.menstruation,
+                                  title: "生理期間の編集",
                                   didEndSave: (menstruation) {
                                     Navigator.of(context).pop();
                                     ScaffoldMessenger.of(context).showSnackBar(
@@ -233,6 +233,7 @@ class MenstruationPage extends HookWidget {
                       _showEditPage(
                         context,
                         latestMenstruation,
+                        title: "生理期間の編集",
                         didEndSave: (menstruation) {
                           Navigator.of(context).pop();
                           ScaffoldMessenger.of(context).showSnackBar(
@@ -290,25 +291,30 @@ class MenstruationPage extends HookWidget {
                             analytics.logEvent(
                                 name: "tapped_menstruation_record_begin");
                             Navigator.of(context).pop();
-                            return _showEditPage(context, null,
-                                didEndSave: (menstruation) {
-                              Navigator.of(context).pop();
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(
-                                  duration: Duration(seconds: 1),
-                                  content: Text(
-                                      "${DateTimeFormatter.monthAndDay(menstruation.beginDate)}から生理開始で記録しました"),
-                                ),
-                              );
-                            }, didEndDelete: () {
-                              Navigator.of(context).pop();
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(
-                                  duration: Duration(seconds: 1),
-                                  content: Text("生理期間を削除しました"),
-                                ),
-                              );
-                            });
+                            return _showEditPage(
+                              context,
+                              null,
+                              title: "生理開始日を選択",
+                              didEndSave: (menstruation) {
+                                Navigator.of(context).pop();
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    duration: Duration(seconds: 1),
+                                    content: Text(
+                                        "${DateTimeFormatter.monthAndDay(menstruation.beginDate)}から生理開始で記録しました"),
+                                  ),
+                                );
+                              },
+                              didEndDelete: () {
+                                Navigator.of(context).pop();
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    duration: Duration(seconds: 1),
+                                    content: Text("生理期間を削除しました"),
+                                  ),
+                                );
+                              },
+                            );
                         }
                       }),
                     );
@@ -326,12 +332,14 @@ class MenstruationPage extends HookWidget {
   void _showEditPage(
     BuildContext context,
     Menstruation? menstruation, {
+    required String title,
     required Function(Menstruation) didEndSave,
     required VoidCallback didEndDelete,
   }) {
     showModalBottomSheet(
       context: context,
       builder: (context) => MenstruationEditPage(
+        title: title,
         menstruation: menstruation,
         didEndSave: didEndSave,
         didEndDelete: didEndDelete,

--- a/lib/state/menstruation_edit.dart
+++ b/lib/state/menstruation_edit.dart
@@ -9,6 +9,7 @@ abstract class MenstruationEditState implements _$MenstruationEditState {
   factory MenstruationEditState({
     required Menstruation? menstruation,
     required List<DateTime> displayedDates,
+    String? invalidMessage,
   }) = _MenstruationEditState;
 
   List<DateTime> dates() => displayedDates;

--- a/lib/state/menstruation_edit.freezed.dart
+++ b/lib/state/menstruation_edit.freezed.dart
@@ -18,10 +18,12 @@ class _$MenstruationEditStateTearOff {
 
   _MenstruationEditState call(
       {required Menstruation? menstruation,
-      required List<DateTime> displayedDates}) {
+      required List<DateTime> displayedDates,
+      String? invalidMessage}) {
     return _MenstruationEditState(
       menstruation: menstruation,
       displayedDates: displayedDates,
+      invalidMessage: invalidMessage,
     );
   }
 }
@@ -33,6 +35,7 @@ const $MenstruationEditState = _$MenstruationEditStateTearOff();
 mixin _$MenstruationEditState {
   Menstruation? get menstruation => throw _privateConstructorUsedError;
   List<DateTime> get displayedDates => throw _privateConstructorUsedError;
+  String? get invalidMessage => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $MenstruationEditStateCopyWith<MenstruationEditState> get copyWith =>
@@ -44,7 +47,10 @@ abstract class $MenstruationEditStateCopyWith<$Res> {
   factory $MenstruationEditStateCopyWith(MenstruationEditState value,
           $Res Function(MenstruationEditState) then) =
       _$MenstruationEditStateCopyWithImpl<$Res>;
-  $Res call({Menstruation? menstruation, List<DateTime> displayedDates});
+  $Res call(
+      {Menstruation? menstruation,
+      List<DateTime> displayedDates,
+      String? invalidMessage});
 
   $MenstruationCopyWith<$Res>? get menstruation;
 }
@@ -62,6 +68,7 @@ class _$MenstruationEditStateCopyWithImpl<$Res>
   $Res call({
     Object? menstruation = freezed,
     Object? displayedDates = freezed,
+    Object? invalidMessage = freezed,
   }) {
     return _then(_value.copyWith(
       menstruation: menstruation == freezed
@@ -72,6 +79,10 @@ class _$MenstruationEditStateCopyWithImpl<$Res>
           ? _value.displayedDates
           : displayedDates // ignore: cast_nullable_to_non_nullable
               as List<DateTime>,
+      invalidMessage: invalidMessage == freezed
+          ? _value.invalidMessage
+          : invalidMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 
@@ -94,7 +105,10 @@ abstract class _$MenstruationEditStateCopyWith<$Res>
           $Res Function(_MenstruationEditState) then) =
       __$MenstruationEditStateCopyWithImpl<$Res>;
   @override
-  $Res call({Menstruation? menstruation, List<DateTime> displayedDates});
+  $Res call(
+      {Menstruation? menstruation,
+      List<DateTime> displayedDates,
+      String? invalidMessage});
 
   @override
   $MenstruationCopyWith<$Res>? get menstruation;
@@ -115,6 +129,7 @@ class __$MenstruationEditStateCopyWithImpl<$Res>
   $Res call({
     Object? menstruation = freezed,
     Object? displayedDates = freezed,
+    Object? invalidMessage = freezed,
   }) {
     return _then(_MenstruationEditState(
       menstruation: menstruation == freezed
@@ -125,6 +140,10 @@ class __$MenstruationEditStateCopyWithImpl<$Res>
           ? _value.displayedDates
           : displayedDates // ignore: cast_nullable_to_non_nullable
               as List<DateTime>,
+      invalidMessage: invalidMessage == freezed
+          ? _value.invalidMessage
+          : invalidMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -132,17 +151,21 @@ class __$MenstruationEditStateCopyWithImpl<$Res>
 /// @nodoc
 class _$_MenstruationEditState extends _MenstruationEditState {
   _$_MenstruationEditState(
-      {required this.menstruation, required this.displayedDates})
+      {required this.menstruation,
+      required this.displayedDates,
+      this.invalidMessage})
       : super._();
 
   @override
   final Menstruation? menstruation;
   @override
   final List<DateTime> displayedDates;
+  @override
+  final String? invalidMessage;
 
   @override
   String toString() {
-    return 'MenstruationEditState(menstruation: $menstruation, displayedDates: $displayedDates)';
+    return 'MenstruationEditState(menstruation: $menstruation, displayedDates: $displayedDates, invalidMessage: $invalidMessage)';
   }
 
   @override
@@ -154,14 +177,18 @@ class _$_MenstruationEditState extends _MenstruationEditState {
                     .equals(other.menstruation, menstruation)) &&
             (identical(other.displayedDates, displayedDates) ||
                 const DeepCollectionEquality()
-                    .equals(other.displayedDates, displayedDates)));
+                    .equals(other.displayedDates, displayedDates)) &&
+            (identical(other.invalidMessage, invalidMessage) ||
+                const DeepCollectionEquality()
+                    .equals(other.invalidMessage, invalidMessage)));
   }
 
   @override
   int get hashCode =>
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(menstruation) ^
-      const DeepCollectionEquality().hash(displayedDates);
+      const DeepCollectionEquality().hash(displayedDates) ^
+      const DeepCollectionEquality().hash(invalidMessage);
 
   @JsonKey(ignore: true)
   @override
@@ -173,13 +200,16 @@ class _$_MenstruationEditState extends _MenstruationEditState {
 abstract class _MenstruationEditState extends MenstruationEditState {
   factory _MenstruationEditState(
       {required Menstruation? menstruation,
-      required List<DateTime> displayedDates}) = _$_MenstruationEditState;
+      required List<DateTime> displayedDates,
+      String? invalidMessage}) = _$_MenstruationEditState;
   _MenstruationEditState._() : super._();
 
   @override
   Menstruation? get menstruation => throw _privateConstructorUsedError;
   @override
   List<DateTime> get displayedDates => throw _privateConstructorUsedError;
+  @override
+  String? get invalidMessage => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
   _$MenstruationEditStateCopyWith<_MenstruationEditState> get copyWith =>

--- a/lib/store/menstruation_edit.dart
+++ b/lib/store/menstruation_edit.dart
@@ -94,8 +94,9 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
   bool _containsRangeForExistsMenstruation(Menstruation menstruation) {
     return allMenstruation
         .where((element) =>
-            element.dateRange.inRange(menstruation.beginDate) ||
-            element.dateRange.inRange(menstruation.endDate))
+            menstruation.id != element.id &&
+            (element.dateRange.inRange(menstruation.beginDate) ||
+                element.dateRange.inRange(menstruation.endDate)))
         .isNotEmpty;
   }
 

--- a/lib/store/menstruation_edit.dart
+++ b/lib/store/menstruation_edit.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/entity/menstruation.dart';
 import 'package:pilll/service/menstruation.dart';
@@ -53,22 +51,7 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
   void _reset() {
     Future(() async {
       allMenstruation = await service.fetchAll();
-      _subscribe();
     });
-  }
-
-  StreamSubscription? _canceller;
-  void _subscribe() {
-    _canceller?.cancel();
-    _canceller = service.subscribeAll().listen((entities) {
-      allMenstruation = entities;
-    });
-  }
-
-  @override
-  void dispose() {
-    _canceller?.cancel();
-    super.dispose();
   }
 
   bool shouldShowDiscardDialog() {

--- a/lib/store/menstruation_edit.dart
+++ b/lib/store/menstruation_edit.dart
@@ -84,6 +84,12 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
 
   tappedDate(DateTime date) {
     final menstruation = state.menstruation;
+    if (date.isAfter(today()) && menstruation == null) {
+      state = state.copyWith(invalidMessage: "未来の日付は選択できません");
+      return;
+    }
+    state = state.copyWith(invalidMessage: null);
+
     if (menstruation == null) {
       settingService.fetch().then((setting) {
         state = state.copyWith(

--- a/lib/store/menstruation_edit.dart
+++ b/lib/store/menstruation_edit.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/entity/menstruation.dart';
 import 'package:pilll/service/menstruation.dart';
@@ -35,6 +37,7 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
   late Menstruation? initialMenstruation;
   final MenstruationService service;
   final SettingService settingService;
+  List<Menstruation> allMenstruation = [];
   bool get isExistsDB => initialMenstruation != null;
   MenstruationEditStore({
     Menstruation? menstruation,
@@ -44,6 +47,28 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
             menstruation: menstruation,
             displayedDates: displaedDates(menstruation))) {
     initialMenstruation = menstruation;
+    _reset();
+  }
+
+  void _reset() {
+    Future(() async {
+      allMenstruation = await service.fetchAll();
+      _subscribe();
+    });
+  }
+
+  StreamSubscription? _canceller;
+  void _subscribe() {
+    _canceller?.cancel();
+    _canceller = service.subscribeAll().listen((entities) {
+      allMenstruation = entities;
+    });
+  }
+
+  @override
+  void dispose() {
+    _canceller?.cancel();
+    super.dispose();
   }
 
   bool shouldShowDiscardDialog() {


### PR DESCRIPTION
## What
- 生理開始日・編集画面においてvalidationを追加
- ついでに編集画面に行くcontextによってtitleを変える

## Checked
### 生理開始日を選択
- [x] タイトルが**生理開始日を選択**に変わっている
- [x] 未来の日付を選べない
- [x] 過去の日付を選べる
- [x] 今日の日付を選べる
- [x] 開始日を選んだ後に終わりの日付が未来であっても伸ばすことができる
### 生理期間を編集
- [x] タイトルが**生理期間を編集**に変わっている
- [x] 一度生理期間を削除して
  - [x] 未来の日付を選べない
  - [x] 過去の日付を選べる
  - [x] 今日の日付を選べる
  - [x] 開始日を選んだ後に終わりの日付が未来であっても伸ばすことができる