### PR TITLE
Remove auto created menstruation

### DIFF
--- a/lib/domain/menstruation/menstruation_card_state.dart
+++ b/lib/domain/menstruation/menstruation_card_state.dart
@@ -15,17 +15,14 @@ abstract class MenstruationCardState implements _$MenstruationCardState {
 
   factory MenstruationCardState.schedule({
     required DateTime scheduleDate,
-  }) =>
-      MenstruationCardState(
-          title: "生理予定日",
-          scheduleDate: scheduleDate,
-          countdownString: () {
-            final diff = scheduleDate.difference(today()).inDays;
-            if (diff <= 0) {
-              return "生理予定：${diff.abs() + 1}日目";
-            }
-            return "あと${scheduleDate.difference(today()).inDays}日";
-          }());
+  }) {
+    final diff = scheduleDate.difference(today()).inDays;
+    return MenstruationCardState(
+      title: "生理予定日",
+      scheduleDate: scheduleDate,
+      countdownString: diff <= 0 ? "生理予定：${diff.abs() + 1}日目" : "あと$diff日",
+    );
+  }
 
   factory MenstruationCardState.record({
     required Menstruation menstruation,

--- a/lib/entity/menstruation.dart
+++ b/lib/entity/menstruation.dart
@@ -36,7 +36,6 @@ abstract class Menstruation with _$Menstruation {
       toJson: NonNullTimestampConverter.dateTimeToTimestamp,
     )
         required DateTime endDate,
-    required bool isNotYetUserEdited,
     @JsonKey(
       fromJson: TimestampConverter.timestampToDateTime,
       toJson: TimestampConverter.dateTimeToTimestamp,

--- a/lib/entity/menstruation.freezed.dart
+++ b/lib/entity/menstruation.freezed.dart
@@ -27,7 +27,6 @@ class _$MenstruationTearOff {
           required DateTime beginDate,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
           required DateTime endDate,
-      required bool isNotYetUserEdited,
       @JsonKey(fromJson: TimestampConverter.timestampToDateTime, toJson: TimestampConverter.dateTimeToTimestamp)
           DateTime? deletedAt,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
@@ -36,7 +35,6 @@ class _$MenstruationTearOff {
       id: id,
       beginDate: beginDate,
       endDate: endDate,
-      isNotYetUserEdited: isNotYetUserEdited,
       deletedAt: deletedAt,
       createdAt: createdAt,
     );
@@ -62,7 +60,6 @@ mixin _$Menstruation {
       fromJson: NonNullTimestampConverter.timestampToDateTime,
       toJson: NonNullTimestampConverter.dateTimeToTimestamp)
   DateTime get endDate => throw _privateConstructorUsedError;
-  bool get isNotYetUserEdited => throw _privateConstructorUsedError;
   @JsonKey(
       fromJson: TimestampConverter.timestampToDateTime,
       toJson: TimestampConverter.dateTimeToTimestamp)
@@ -90,7 +87,6 @@ abstract class $MenstruationCopyWith<$Res> {
           DateTime beginDate,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
           DateTime endDate,
-      bool isNotYetUserEdited,
       @JsonKey(fromJson: TimestampConverter.timestampToDateTime, toJson: TimestampConverter.dateTimeToTimestamp)
           DateTime? deletedAt,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
@@ -110,7 +106,6 @@ class _$MenstruationCopyWithImpl<$Res> implements $MenstruationCopyWith<$Res> {
     Object? id = freezed,
     Object? beginDate = freezed,
     Object? endDate = freezed,
-    Object? isNotYetUserEdited = freezed,
     Object? deletedAt = freezed,
     Object? createdAt = freezed,
   }) {
@@ -127,10 +122,6 @@ class _$MenstruationCopyWithImpl<$Res> implements $MenstruationCopyWith<$Res> {
           ? _value.endDate
           : endDate // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      isNotYetUserEdited: isNotYetUserEdited == freezed
-          ? _value.isNotYetUserEdited
-          : isNotYetUserEdited // ignore: cast_nullable_to_non_nullable
-              as bool,
       deletedAt: deletedAt == freezed
           ? _value.deletedAt
           : deletedAt // ignore: cast_nullable_to_non_nullable
@@ -157,7 +148,6 @@ abstract class _$MenstruationCopyWith<$Res>
           DateTime beginDate,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
           DateTime endDate,
-      bool isNotYetUserEdited,
       @JsonKey(fromJson: TimestampConverter.timestampToDateTime, toJson: TimestampConverter.dateTimeToTimestamp)
           DateTime? deletedAt,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
@@ -179,7 +169,6 @@ class __$MenstruationCopyWithImpl<$Res> extends _$MenstruationCopyWithImpl<$Res>
     Object? id = freezed,
     Object? beginDate = freezed,
     Object? endDate = freezed,
-    Object? isNotYetUserEdited = freezed,
     Object? deletedAt = freezed,
     Object? createdAt = freezed,
   }) {
@@ -196,10 +185,6 @@ class __$MenstruationCopyWithImpl<$Res> extends _$MenstruationCopyWithImpl<$Res>
           ? _value.endDate
           : endDate // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      isNotYetUserEdited: isNotYetUserEdited == freezed
-          ? _value.isNotYetUserEdited
-          : isNotYetUserEdited // ignore: cast_nullable_to_non_nullable
-              as bool,
       deletedAt: deletedAt == freezed
           ? _value.deletedAt
           : deletedAt // ignore: cast_nullable_to_non_nullable
@@ -223,7 +208,6 @@ class _$_Menstruation extends _Menstruation {
           required this.beginDate,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
           required this.endDate,
-      required this.isNotYetUserEdited,
       @JsonKey(fromJson: TimestampConverter.timestampToDateTime, toJson: TimestampConverter.dateTimeToTimestamp)
           this.deletedAt,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
@@ -247,8 +231,6 @@ class _$_Menstruation extends _Menstruation {
       toJson: NonNullTimestampConverter.dateTimeToTimestamp)
   final DateTime endDate;
   @override
-  final bool isNotYetUserEdited;
-  @override
   @JsonKey(
       fromJson: TimestampConverter.timestampToDateTime,
       toJson: TimestampConverter.dateTimeToTimestamp)
@@ -261,7 +243,7 @@ class _$_Menstruation extends _Menstruation {
 
   @override
   String toString() {
-    return 'Menstruation(id: $id, beginDate: $beginDate, endDate: $endDate, isNotYetUserEdited: $isNotYetUserEdited, deletedAt: $deletedAt, createdAt: $createdAt)';
+    return 'Menstruation(id: $id, beginDate: $beginDate, endDate: $endDate, deletedAt: $deletedAt, createdAt: $createdAt)';
   }
 
   @override
@@ -276,9 +258,6 @@ class _$_Menstruation extends _Menstruation {
             (identical(other.endDate, endDate) ||
                 const DeepCollectionEquality()
                     .equals(other.endDate, endDate)) &&
-            (identical(other.isNotYetUserEdited, isNotYetUserEdited) ||
-                const DeepCollectionEquality()
-                    .equals(other.isNotYetUserEdited, isNotYetUserEdited)) &&
             (identical(other.deletedAt, deletedAt) ||
                 const DeepCollectionEquality()
                     .equals(other.deletedAt, deletedAt)) &&
@@ -293,7 +272,6 @@ class _$_Menstruation extends _Menstruation {
       const DeepCollectionEquality().hash(id) ^
       const DeepCollectionEquality().hash(beginDate) ^
       const DeepCollectionEquality().hash(endDate) ^
-      const DeepCollectionEquality().hash(isNotYetUserEdited) ^
       const DeepCollectionEquality().hash(deletedAt) ^
       const DeepCollectionEquality().hash(createdAt);
 
@@ -316,7 +294,6 @@ abstract class _Menstruation extends Menstruation {
           required DateTime beginDate,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
           required DateTime endDate,
-      required bool isNotYetUserEdited,
       @JsonKey(fromJson: TimestampConverter.timestampToDateTime, toJson: TimestampConverter.dateTimeToTimestamp)
           DateTime? deletedAt,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
@@ -339,8 +316,6 @@ abstract class _Menstruation extends Menstruation {
       fromJson: NonNullTimestampConverter.timestampToDateTime,
       toJson: NonNullTimestampConverter.dateTimeToTimestamp)
   DateTime get endDate => throw _privateConstructorUsedError;
-  @override
-  bool get isNotYetUserEdited => throw _privateConstructorUsedError;
   @override
   @JsonKey(
       fromJson: TimestampConverter.timestampToDateTime,

--- a/lib/entity/menstruation.g.dart
+++ b/lib/entity/menstruation.g.dart
@@ -13,7 +13,6 @@ _$_Menstruation _$_$_MenstruationFromJson(Map<String, dynamic> json) {
         json['beginDate'] as Timestamp),
     endDate: NonNullTimestampConverter.timestampToDateTime(
         json['endDate'] as Timestamp),
-    isNotYetUserEdited: json['isNotYetUserEdited'] as bool,
     deletedAt:
         TimestampConverter.timestampToDateTime(json['deletedAt'] as Timestamp?),
     createdAt: NonNullTimestampConverter.timestampToDateTime(
@@ -35,7 +34,6 @@ Map<String, dynamic> _$_$_MenstruationToJson(_$_Menstruation instance) {
       NonNullTimestampConverter.dateTimeToTimestamp(instance.beginDate);
   val['endDate'] =
       NonNullTimestampConverter.dateTimeToTimestamp(instance.endDate);
-  val['isNotYetUserEdited'] = instance.isNotYetUserEdited;
   val['deletedAt'] = TimestampConverter.dateTimeToTimestamp(instance.deletedAt);
   val['createdAt'] =
       NonNullTimestampConverter.dateTimeToTimestamp(instance.createdAt);

--- a/lib/store/menstruation.dart
+++ b/lib/store/menstruation.dart
@@ -100,7 +100,6 @@ class MenstruationStore extends StateNotifier<MenstruationState> {
     final menstruation = Menstruation(
         beginDate: begin,
         endDate: begin.add(Duration(days: duration - 1)),
-        isNotYetUserEdited: false,
         createdAt: now());
     return menstruationService.create(menstruation);
   }
@@ -114,7 +113,6 @@ class MenstruationStore extends StateNotifier<MenstruationState> {
     final menstruation = Menstruation(
         beginDate: begin,
         endDate: begin.add(Duration(days: duration - 1)),
-        isNotYetUserEdited: false,
         createdAt: now());
     return menstruationService.create(menstruation);
   }

--- a/lib/store/menstruation_edit.dart
+++ b/lib/store/menstruation_edit.dart
@@ -5,7 +5,6 @@ import 'package:pilll/service/setting.dart';
 import 'package:pilll/state/menstruation_edit.dart';
 import 'package:pilll/util/datetime/date_compare.dart';
 import 'package:pilll/util/datetime/day.dart';
-import 'package:pilll/util/formatter/date_time_formatter.dart';
 
 final menstruationEditProvider = StateNotifierProvider.family
     .autoDispose<MenstruationEditStore, Menstruation?>(

--- a/lib/store/menstruation_edit.dart
+++ b/lib/store/menstruation_edit.dart
@@ -131,6 +131,7 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
       state = state.copyWith(invalidMessage: "未来の日付は選択できません");
       return;
     }
+    state = state.copyWith(invalidMessage: null);
 
     if (menstruation == null) {
       try {
@@ -151,39 +152,39 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
             createdAt: now(),
           );
         }
-        _setMenstruationOrInvalidMessage(menstruation);
+        state = state.copyWith(menstruation: menstruation);
         return;
       } catch (error) {
         throw error;
       }
     }
 
-    state = state.copyWith(invalidMessage: null);
-
     if (isSameDay(menstruation.beginDate, date) &&
         isSameDay(menstruation.endDate, date)) {
-      _setMenstruationOrInvalidMessage(null);
+      state = state.copyWith(menstruation: null);
       return;
     }
 
     if (date.isBefore(menstruation.beginDate)) {
-      _setMenstruationOrInvalidMessage(menstruation.copyWith(beginDate: date));
+      state =
+          state.copyWith(menstruation: menstruation.copyWith(beginDate: date));
       return;
     }
     if (date.isAfter(menstruation.endDate)) {
-      _setMenstruationOrInvalidMessage(menstruation.copyWith(endDate: date));
+      state =
+          state.copyWith(menstruation: menstruation.copyWith(endDate: date));
       return;
     }
 
     if ((isSameDay(menstruation.beginDate, date) ||
             date.isAfter(menstruation.beginDate)) &&
         date.isBefore(menstruation.endDate)) {
-      _setMenstruationOrInvalidMessage(menstruation.copyWith(endDate: date));
+      state = state.copyWith(menstruation: menstruation.copyWith(endDate: date));
       return;
     }
 
     if (isSameDay(menstruation.endDate, date)) {
-      _setMenstruationOrInvalidMessage(
+      state = state.copyWith(menstruation: 
           menstruation.copyWith(endDate: date.subtract(Duration(days: 1))));
       return;
     }

--- a/lib/store/menstruation_edit.dart
+++ b/lib/store/menstruation_edit.dart
@@ -93,38 +93,6 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
     }
   }
 
-  Menstruation? _menstruationForDuplicatedDuration(Menstruation menstruation) {
-    final filtered = _allMenstruation.where((element) =>
-        menstruation.id != element.id &&
-            (element.dateRange.inRange(menstruation.beginDate) ||
-                element.dateRange.inRange(menstruation.endDate)) ||
-        menstruation.dateRange.inRange(element.beginDate) ||
-        menstruation.dateRange.inRange(element.endDate));
-    if (filtered.isEmpty) {
-      return null;
-    }
-    return filtered.last;
-  }
-
-  _setMenstruationOrInvalidMessage(Menstruation? menstruation) {
-    if (menstruation == null) {
-      state = state.copyWith(menstruation: menstruation);
-      return;
-    }
-    final duplicatedMenstruation =
-        _menstruationForDuplicatedDuration(menstruation);
-    if (duplicatedMenstruation != null) {
-      final begin =
-          DateTimeFormatter.monthAndDay(duplicatedMenstruation.beginDate);
-      final end = DateTimeFormatter.monthAndDay(duplicatedMenstruation.endDate);
-      state = state.copyWith(invalidMessage: "$begin-$endの期間にすでに生理が記録されています");
-      return;
-    }
-
-    state = state.copyWith(invalidMessage: null);
-    state = state.copyWith(menstruation: menstruation);
-  }
-
   tappedDate(DateTime date) async {
     final menstruation = state.menstruation;
     if (date.isAfter(today()) && menstruation == null) {
@@ -179,13 +147,15 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
     if ((isSameDay(menstruation.beginDate, date) ||
             date.isAfter(menstruation.beginDate)) &&
         date.isBefore(menstruation.endDate)) {
-      state = state.copyWith(menstruation: menstruation.copyWith(endDate: date));
+      state =
+          state.copyWith(menstruation: menstruation.copyWith(endDate: date));
       return;
     }
 
     if (isSameDay(menstruation.endDate, date)) {
-      state = state.copyWith(menstruation: 
-          menstruation.copyWith(endDate: date.subtract(Duration(days: 1))));
+      state = state.copyWith(
+          menstruation:
+              menstruation.copyWith(endDate: date.subtract(Duration(days: 1))));
       return;
     }
   }

--- a/lib/store/menstruation_edit.dart
+++ b/lib/store/menstruation_edit.dart
@@ -81,8 +81,7 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
   }
 
   Future<Menstruation> save() {
-    final menstruation =
-        state.menstruation?.copyWith(isNotYetUserEdited: false);
+    final menstruation = state.menstruation;
     if (menstruation == null) {
       throw FormatException("menstruation is not exists when save");
     }
@@ -144,13 +143,11 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
           menstruation = initialMenstruation.copyWith(
             beginDate: date,
             endDate: end,
-            isNotYetUserEdited: false,
           );
         } else {
           menstruation = Menstruation(
             beginDate: begin,
             endDate: end,
-            isNotYetUserEdited: false,
             createdAt: now(),
           );
         }


### PR DESCRIPTION
## What
- menstruation.isNotYetUserEdited を削除
- menstruation_card_state で freezed の generatorが失敗したので回避策を投入
- 生理カードの表示を調整

## Why
もともと `次のピルシートに移ったときに生理予定日がカレンダーから消えないで欲しい` という要望があってこの機能を実装した背景があった。しかし下記のケースで困るパターンが出てきた。そのあと出した結論として `生理記録が無かったから今までユーザーは予定日の帯に頼るしか無かったが、実際の生理記録ができるようになったことにより以前抱えていた欲求は小さく(無くなる)のでは` と仮設が立ち自動で裏側でMenstruationのデータを作るfunctionsは消すことにした

ref: https://neko-network.slack.com/archives/CC574H50E/p1618313881048500
```
このケースちょっと見てほしい！
本来は生理開始日4/7になって欲しい。予定日が4/10で生理予定4日目と書かれている事に違和感を感じた。
シナリオ
生理がいつもより早くきた
生理が予定日と被らなかった
生理を記録したã®で、生理カードは生理予定日じゃなくて生理開始日になって欲しい
```

## Links
ref: https://github.com/bannzai/pilllbackend/pull/69