### PR TITLE
:bug: Bugfix to dismiss when menstruation is not exists from db

### DIFF
--- a/lib/domain/menstruation/menstruation_edit_page.dart
+++ b/lib/domain/menstruation/menstruation_edit_page.dart
@@ -80,6 +80,8 @@ class MenstruationEditPage extends HookWidget {
                                   },
                                 ),
                               );
+                            } else if (store.isDismissWhenSaveButtonPressed()) {
+                              Navigator.of(context).pop();
                             } else {
                               store.save().then((value) => didEndSave(value));
                             }

--- a/lib/store/menstruation_edit.dart
+++ b/lib/store/menstruation_edit.dart
@@ -61,6 +61,9 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
     return (state.menstruation == null && isExistsDB);
   }
 
+  bool isDismissWhenSaveButtonPressed() =>
+      !shouldShowDiscardDialog() && state.menstruation == null;
+
   Future<void> delete() {
     final initialMenstruation = this.initialMenstruation;
     if (initialMenstruation == null) {


### PR DESCRIPTION
## What
生理を記録→開始日を選択する。のときに結果的にmenstruationが作られなかった場合にexceptionが発生した。保存ボタン押されたときにこれをチェックする