### PR TITLE
Add pill sheet to setting menstruation

### DIFF
--- a/lib/components/organisms/setting/setting_menstruation_page.dart
+++ b/lib/components/organisms/setting/setting_menstruation_page.dart
@@ -4,6 +4,9 @@ import 'package:pilll/components/atoms/buttons.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/components/organisms/pill/pill_sheet.dart';
+import 'package:pilll/entity/pill_mark_type.dart';
+import 'package:pilll/entity/pill_sheet_type.dart';
 import 'package:pilll/util/toolbar/picker_toolbar.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -17,10 +20,12 @@ abstract class SettingMenstruationPageConstants {
 class SettingMenstruationPageModel {
   int selectedFromMenstruation;
   int selectedDurationMenstruation;
+  PillSheetType pillSheetType;
 
   SettingMenstruationPageModel({
     required this.selectedFromMenstruation,
     required this.selectedDurationMenstruation,
+    required this.pillSheetType,
   });
 }
 
@@ -68,66 +73,76 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
       ),
       body: SafeArea(
         child: Container(
-          child: Center(
-            child: Column(
-              children: <Widget>[
-                SizedBox(height: 24),
-                Text(
-                  "生理について教えてください",
-                  style: FontType.sBigTitle.merge(TextColorStyle.main),
-                  textAlign: TextAlign.center,
+          child: Column(
+            children: <Widget>[
+              SizedBox(height: 24),
+              Text(
+                "生理について教えてください",
+                style: FontType.sBigTitle.merge(TextColorStyle.main),
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: 12),
+              PillSheet(
+                pillSheetType: widget.model.pillSheetType,
+                pillMarkTypeBuilder: (number) {
+                  return _pillMarkTypeFor(number);
+                },
+                doneStateBuilder: (number) {
+                  return false;
+                },
+                enabledMarkAnimation: null,
+                markSelected: (number) {},
+              ),
+              SizedBox(height: 24),
+              Container(
+                height: 156,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Text("いつから生理がはじまる？",
+                        style: FontType.subTitle.merge(TextColorStyle.main)),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        Text("ピル番号 ",
+                            style:
+                                FontType.assisting.merge(TextColorStyle.main)),
+                        GestureDetector(
+                          onTap: () => _showFromModalSheet(context),
+                          child: _from(),
+                        ),
+                        Text(" 番目ぐらいから",
+                            style:
+                                FontType.assisting.merge(TextColorStyle.main)),
+                      ],
+                    ),
+                    Text("何日間生理が続く？",
+                        style:
+                            FontType.assistingBold.merge(TextColorStyle.main)),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        GestureDetector(
+                          onTap: () => _showDurationModalSheet(context),
+                          child: _duration(),
+                        ),
+                        Text(" 日間生理が続く",
+                            style:
+                                FontType.assisting.merge(TextColorStyle.main)),
+                      ],
+                    )
+                  ],
                 ),
-                Spacer(),
-                Container(
-                  height: 156,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Text("いつから生理がはじまる？",
-                          style: FontType.subTitle.merge(TextColorStyle.main)),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: <Widget>[
-                          Text("ピル番号 ",
-                              style: FontType.assisting
-                                  .merge(TextColorStyle.main)),
-                          GestureDetector(
-                            onTap: () => _showFromModalSheet(context),
-                            child: _from(),
-                          ),
-                          Text(" 番目ぐらいから",
-                              style: FontType.assisting
-                                  .merge(TextColorStyle.main)),
-                        ],
-                      ),
-                      Text("何日間生理が続く？",
-                          style: FontType.assistingBold
-                              .merge(TextColorStyle.main)),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: <Widget>[
-                          GestureDetector(
-                            onTap: () => _showDurationModalSheet(context),
-                            child: _duration(),
-                          ),
-                          Text(" 日間生理が続く",
-                              style: FontType.assisting
-                                  .merge(TextColorStyle.main)),
-                        ],
-                      )
-                    ],
-                  ),
+              ),
+              Spacer(),
+              if (this.widget.done != null) ...[
+                PrimaryButton(
+                  text: this.widget.doneText ?? "",
+                  onPressed: this.widget.done,
                 ),
-                Spacer(),
-                if (this.widget.done != null) ...[
-                  PrimaryButton(
-                    text: this.widget.doneText ?? "",
-                    onPressed: this.widget.done,
-                  ),
-                  SizedBox(height: 35),
-                ]
-              ],
-            ),
+                SizedBox(height: 35),
+              ]
+            ],
           ),
         ),
       ),
@@ -274,6 +289,17 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
 
   Widget _pickerItem(String str) {
     return Text(str);
+  }
+
+  PillMarkType _pillMarkTypeFor(
+    int number,
+  ) {
+    if (widget.model.pillSheetType.dosingPeriod < number) {
+      return widget.model.pillSheetType == PillSheetType.pillsheet_21
+          ? PillMarkType.rest
+          : PillMarkType.fake;
+    }
+    return PillMarkType.normal;
   }
 }
 

--- a/lib/components/organisms/setting/setting_menstruation_page.dart
+++ b/lib/components/organisms/setting/setting_menstruation_page.dart
@@ -72,79 +72,91 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
         backgroundColor: PilllColors.white,
       ),
       body: SafeArea(
-        child: Container(
-          child: Column(
-            children: <Widget>[
-              SizedBox(height: 24),
-              Text(
-                "生理について教えてください",
-                style: FontType.sBigTitle.merge(TextColorStyle.main),
-                textAlign: TextAlign.center,
-              ),
-              SizedBox(height: 12),
-              PillSheet(
-                pillSheetType: widget.model.pillSheetType,
-                pillMarkTypeBuilder: (number) {
-                  return _pillMarkTypeFor(number);
-                },
-                doneStateBuilder: (number) {
-                  return false;
-                },
-                enabledMarkAnimation: null,
-                markSelected: (number) {},
-              ),
-              SizedBox(height: 24),
-              Container(
-                height: 156,
+        child: LayoutBuilder(builder: (context, viewport) {
+          return ConstrainedBox(
+            constraints: BoxConstraints(minHeight: viewport.maxHeight),
+            child: SingleChildScrollView(
+              child: IntrinsicHeight(
                 child: Column(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: <Widget>[
-                    Text("いつから生理がはじまる？",
-                        style: FontType.subTitle.merge(TextColorStyle.main)),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: <Widget>[
-                        Text("ピル番号 ",
-                            style:
-                                FontType.assisting.merge(TextColorStyle.main)),
-                        GestureDetector(
-                          onTap: () => _showFromModalSheet(context),
-                          child: _from(),
-                        ),
-                        Text(" 番目ぐらいから",
-                            style:
-                                FontType.assisting.merge(TextColorStyle.main)),
-                      ],
+                    SizedBox(height: 24),
+                    Text(
+                      "生理について教えてください",
+                      style: FontType.sBigTitle.merge(TextColorStyle.main),
+                      textAlign: TextAlign.center,
                     ),
-                    Text("何日間生理が続く？",
-                        style:
-                            FontType.assistingBold.merge(TextColorStyle.main)),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: <Widget>[
-                        GestureDetector(
-                          onTap: () => _showDurationModalSheet(context),
-                          child: _duration(),
+                    SizedBox(height: 12),
+                    PillSheet(
+                      pillSheetType: widget.model.pillSheetType,
+                      pillMarkTypeBuilder: (number) {
+                        return _pillMarkTypeFor(number);
+                      },
+                      doneStateBuilder: (number) {
+                        return false;
+                      },
+                      enabledMarkAnimation: null,
+                      markSelected: (number) {},
+                    ),
+                    SizedBox(height: 24),
+                    Container(
+                      height: 156,
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          Text("いつから生理がはじまる？",
+                              style:
+                                  FontType.subTitle.merge(TextColorStyle.main)),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: <Widget>[
+                              Text("ピル番号 ",
+                                  style: FontType.assisting
+                                      .merge(TextColorStyle.main)),
+                              GestureDetector(
+                                onTap: () => _showFromModalSheet(context),
+                                child: _from(),
+                              ),
+                              Text(" 番目ぐらいから",
+                                  style: FontType.assisting
+                                      .merge(TextColorStyle.main)),
+                            ],
+                          ),
+                          Text("何日間生理が続く？",
+                              style: FontType.assistingBold
+                                  .merge(TextColorStyle.main)),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: <Widget>[
+                              GestureDetector(
+                                onTap: () => _showDurationModalSheet(context),
+                                child: _duration(),
+                              ),
+                              Text(" 日間生理が続く",
+                                  style: FontType.assisting
+                                      .merge(TextColorStyle.main)),
+                            ],
+                          )
+                        ],
+                      ),
+                    ),
+                    if (this.widget.done != null) ...[
+                      Expanded(
+                        child: Container(
+                          constraints: BoxConstraints(minHeight: 32),
                         ),
-                        Text(" 日間生理が続く",
-                            style:
-                                FontType.assisting.merge(TextColorStyle.main)),
-                      ],
-                    )
+                      ),
+                      PrimaryButton(
+                        text: this.widget.doneText ?? "",
+                        onPressed: this.widget.done,
+                      ),
+                      SizedBox(height: 35),
+                    ]
                   ],
                 ),
               ),
-              Spacer(),
-              if (this.widget.done != null) ...[
-                PrimaryButton(
-                  text: this.widget.doneText ?? "",
-                  onPressed: this.widget.done,
-                ),
-                SizedBox(height: 35),
-              ]
-            ],
-          ),
-        ),
+            ),
+          );
+        }),
       ),
     );
   }

--- a/lib/domain/initial_setting/initial_setting_3_page.dart
+++ b/lib/domain/initial_setting/initial_setting_3_page.dart
@@ -22,6 +22,7 @@ class InitialSetting3Page extends HookWidget {
       model: SettingMenstruationPageModel(
         selectedFromMenstruation: state.entity.fromMenstruation,
         selectedDurationMenstruation: state.entity.durationMenstruation,
+        pillSheetType: state.entity.pillSheetType!,
       ),
       fromMenstructionDidDecide: (selectedFromMenstruction) {
         store.modify((model) =>

--- a/lib/domain/settings/settings_page.dart
+++ b/lib/domain/settings/settings_page.dart
@@ -354,6 +354,7 @@ class SettingsPage extends HookWidget {
                         settingEntity.pillNumberForFromMenstruation,
                     selectedDurationMenstruation:
                         settingEntity.durationMenstruation,
+                    pillSheetType: settingEntity.pillSheetType,
                   ),
                   fromMenstructionDidDecide: (selectedFromMenstruction) =>
                       settingStore

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -1,3 +1,4 @@
+import 'package:pilll/analytics.dart';
 import 'package:pilll/domain/initial_setting/initial_setting_1_page.dart';
 import 'package:pilll/domain/home/home_page.dart';
 import 'package:pilll/domain/root/root.dart';
@@ -21,6 +22,7 @@ class AppRouter {
   }
 
   static void endInitialSetting(BuildContext context) {
+    analytics.logEvent(name: "end_initial_setteing");
     SharedPreferences.getInstance().then((storage) {
       storage.setBool(BoolKey.didEndInitialSetting, true);
       requestNotificationPermissions().then((value) {


### PR DESCRIPTION
## What
- 生理期間設定画面にピルシートを追加

## Links
resolve: https://github.com/bannzai/_Pilll/issues/318

## Checked
- [x] ピルシートが出ている
- [x] 小さい端末でも大丈夫(Scrollする)
- [x] 生理期間が設定できる
- [x] 初期設定のときにボタンが出る
- [x] 設定画面からのときにはボタンがでない