### PR TITLE
:bug: Fix throw exception when watch provider out of context

### DIFF
--- a/lib/domain/settings/reminder_times_page.dart
+++ b/lib/domain/settings/reminder_times_page.dart
@@ -14,6 +14,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 class ReminderTimesPage extends HookWidget {
   @override
   Widget build(BuildContext context) {
+    final store = useProvider(settingStoreProvider);
     final state = useProvider(settingStoreProvider.state);
     final settingEntity = state.entity;
     if (settingEntity == null) {
@@ -36,7 +37,7 @@ class ReminderTimesPage extends HookWidget {
         child: Container(
           child: ListView(
             children: [
-              ..._components(context, settingEntity).map((e) {
+              ..._components(context, store, settingEntity).map((e) {
                 return [e, _separator()];
               }).expand((element) => element),
               _footer(context),
@@ -48,23 +49,23 @@ class ReminderTimesPage extends HookWidget {
     );
   }
 
-  List<Widget> _components(BuildContext context, Setting setting) {
+  List<Widget> _components(
+      BuildContext context, SettingStateStore store, Setting setting) {
     return setting.reminderTimes
         .asMap()
-        .map((offset, reminderTime) => MapEntry(
-            offset, _component(context, setting, reminderTime, offset + 1)))
+        .map((offset, reminderTime) => MapEntry(offset,
+            _component(context, store, setting, reminderTime, offset + 1)))
         .values
         .toList();
   }
 
   Widget _component(
     BuildContext context,
+    SettingStateStore store,
     Setting setting,
     ReminderTime reminderTime,
     int number,
   ) {
-    final store = useProvider(settingStoreProvider);
-
     Widget body = GestureDetector(
       onTap: () {
         _showPicker(context, store, setting, number - 1);


### PR DESCRIPTION
## What
通知設定画面で、設定項目の増減があった場合に一瞬Exceptionが走っていたので修正。
たまにCrashlytics煮上がってきていた。ちゃんと原因は特定してないけどおそらくProviderが使える範囲で参照していなかったために起きたものだと思う。storeをbuildの頭で作ってそれを引数で渡す形に変えたところ発生しなくなったのでこれでいく

```

flutter: ════════════════════════════════════════════════════════════════════════════════════════════════════
flutter: ----------------FIREBASE CRASHLYTICS----------------
flutter: The following exception was thrown building ReminderTimesPage(dirty, dependencies: [UncontrolledProviderScope, _LocalizationsScope-[GlobalKey#635cf]], SettingState(entity: Setting(pillSheetTypeRawPath: pillsheet_28_0, pillNumberForFromMenstruation: 20, durationMenstruation: 4, reminderTimes: [ReminderTime(hour: 21, minute: 0), ReminderTime(hour: 13, minute: 0), ReminderTime(hour: 22, minute: 0)], isOnReminder: true, isOnNotifyInNotTakenDuration: true), userIsUpdatedFrom132: false), Instance of 'SettingStateStore', Instance of 'SettingStateStore'):
flutter: Bad state: Type mismatch between hooks:
- previous hook: _ProviderHook<SettingState>
- new hook: _ProviderHook<SettingStateStore>
flutter:
debugCreator: ReminderTimesPage ← Semantics ← Builder ← RepaintBoundary-[GlobalKey#ba384] ← IgnorePointer ← AnimatedBuilder ← Stack ← _CupertinoBackGestureDetector<dynamic> ← DecoratedBox ← DecoratedBoxTransition ← FractionalTranslation ← SlideTransition ← ⋯
flutter:
#0      HookElement._use
package:flutter_hooks/src/framework.dart:446
#1      Hook.use
package:flutter_hooks/src/framework.dart:140
#2      use
package:flutter_hooks/src/framework.dart:19
#3      useProvider
package:hooks_riverpod/src/use_provider.dart:32
#4      ReminderTimesPage._component
package:pilll/…/settings/reminder_times_page.dart:66
#5      ReminderTimesPage._components.<anonymous closure>
package:pilll/…/settings/reminder_times_page.dart:55
#6      MapMixin.map (dart:collection/maps.dart:170:28)

```