### PR TITLE
Bugfix for history card appearance condition

### DIFF
--- a/lib/domain/menstruation/menstruation_history_card.dart
+++ b/lib/domain/menstruation/menstruation_history_card.dart
@@ -10,6 +10,7 @@ import 'package:pilll/domain/menstruation/menstruation_list_page.dart';
 import 'package:pilll/entity/menstruation.dart';
 import 'package:flutter/material.dart';
 import 'package:pilll/store/menstruation.dart';
+import 'package:pilll/util/datetime/day.dart';
 
 class MenstruationHistoryCardState {
   final List<Menstruation> _allMenstruations;
@@ -18,8 +19,16 @@ class MenstruationHistoryCardState {
     this._allMenstruations,
   );
 
-  bool get moreButtonIsHidden => rows.length <= 2;
+  bool get _latestPillSheetIntoToday {
+    if (_allMenstruations.isEmpty) {
+      return false;
+    }
+    return _allMenstruations.last.dateRange.inRange(today());
+  }
 
+  bool get moreButtonIsHidden => _latestPillSheetIntoToday
+      ? _allMenstruations.length <= 3
+      : _allMenstruations.length <= 2;
   List<MenstruationHistoryRowState> get rows {
     if (_allMenstruations.isEmpty) {
       return [];

--- a/lib/domain/menstruation/menstruation_history_card.dart
+++ b/lib/domain/menstruation/menstruation_history_card.dart
@@ -14,17 +14,15 @@ import 'package:pilll/util/datetime/day.dart';
 
 class MenstruationHistoryCardState {
   final List<Menstruation> _allMenstruations;
+  final Menstruation _latestMenstruation;
 
   MenstruationHistoryCardState(
     this._allMenstruations,
+    this._latestMenstruation,
   );
 
-  bool get _latestPillSheetIntoToday {
-    if (_allMenstruations.isEmpty) {
-      return false;
-    }
-    return _allMenstruations.last.dateRange.inRange(today());
-  }
+  bool get _latestPillSheetIntoToday =>
+      _latestMenstruation.dateRange.inRange(today());
 
   bool get moreButtonIsHidden => _latestPillSheetIntoToday
       ? _allMenstruations.length <= 3

--- a/lib/domain/menstruation/menstruation_history_card.dart
+++ b/lib/domain/menstruation/menstruation_history_card.dart
@@ -18,7 +18,8 @@ class MenstruationHistoryCardState {
     this._allMenstruations,
   );
 
-  bool get moreButtonIsHidden => _allMenstruations.length <= 2;
+  bool get moreButtonIsHidden => rows.length <= 2;
+
   List<MenstruationHistoryRowState> get rows {
     if (_allMenstruations.isEmpty) {
       return [];

--- a/lib/store/menstruation.dart
+++ b/lib/store/menstruation.dart
@@ -164,7 +164,7 @@ class MenstruationStore extends StateNotifier<MenstruationState> {
         latestMenstruation.dateRange.inRange(today())) {
       return null;
     }
-    return MenstruationHistoryCardState(state.entities);
+    return MenstruationHistoryCardState(state.entities, latestMenstruation);
   }
 }
 

--- a/lib/store/menstruation.dart
+++ b/lib/store/menstruation.dart
@@ -160,6 +160,10 @@ class MenstruationStore extends StateNotifier<MenstruationState> {
     if (latestMenstruation == null) {
       return null;
     }
+    if (state.entities.length == 1 &&
+        latestMenstruation.dateRange.inRange(today())) {
+      return null;
+    }
     return MenstruationHistoryCardState(state.entities);
   }
 }


### PR DESCRIPTION
## What
生理履歴カードが出る条件を修正

## Why
最後のMenstruationデータをもとに条件分岐を行っていたが、今日生理期間中かつ生理記録が1件しかない場合に空の生理履歴カードが表示されていた。条件を見直して対応した