### PR TITLE
fix interaction for setting menstruation pillsheet

### DIFF
--- a/lib/components/organisms/setting/setting_menstruation_page.dart
+++ b/lib/components/organisms/setting/setting_menstruation_page.dart
@@ -81,7 +81,7 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
                   children: <Widget>[
                     SizedBox(height: 24),
                     Text(
-                      "生理について教えてください",
+                      "生理がはじまるピル番号をタップ",
                       style: FontType.sBigTitle.merge(TextColorStyle.main),
                       textAlign: TextAlign.center,
                     ),
@@ -108,9 +108,7 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
                       child: Column(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: <Widget>[
-                          Text("いつから生理がはじまる？",
-                              style:
-                                  FontType.subTitle.merge(TextColorStyle.main)),
+                          SizedBox(height: 20),
                           Row(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: <Widget>[

--- a/lib/components/organisms/setting/setting_menstruation_page.dart
+++ b/lib/components/organisms/setting/setting_menstruation_page.dart
@@ -95,7 +95,12 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
                         return false;
                       },
                       enabledMarkAnimation: null,
-                      markSelected: (number) {},
+                      markSelected: (number) {
+                        this.widget.fromMenstructionDidDecide(number);
+                        setState(() {
+                          this.widget.model.selectedFromMenstruation = number;
+                        });
+                      },
                     ),
                     SizedBox(height: 24),
                     Container(
@@ -310,6 +315,9 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
       return widget.model.pillSheetType == PillSheetType.pillsheet_21
           ? PillMarkType.rest
           : PillMarkType.fake;
+    }
+    if (widget.model.selectedFromMenstruation == number) {
+      return PillMarkType.selected;
     }
     return PillMarkType.normal;
   }


### PR DESCRIPTION
## What
生理期間の設定において、何番目かを把握しやすくするためにピルシートを追加したがピルをタップしても設定ができるようにはしてなかった。実際触ってみて違和感がすごかったので触って設定できるようにした

## Checked
- [x] 文言が変わっている
- [x] ピルマークをタップしたら数字が変わる
- [x] 数字が変わったらピルシートのUIも連動して変わる
- [x] 初期設定で設定できる
- [x] 設定タブの遷移から設定できる