### PR TITLE
Disable all animation when development

### DIFF
--- a/lib/components/molecules/indicator.dart
+++ b/lib/components/molecules/indicator.dart
@@ -11,7 +11,8 @@ class Indicator extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       child: Center(
-        child: Container(color: PilllColors.primary),
+        child: CircularProgressIndicator(
+            valueColor: AlwaysStoppedAnimation(PilllColors.primary)),
       ),
     );
   }

--- a/lib/components/molecules/indicator.dart
+++ b/lib/components/molecules/indicator.dart
@@ -1,6 +1,7 @@
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/domain/root/root.dart';
 import 'package:flutter/material.dart';
+import 'package:pilll/util/environment.dart';
 
 class Indicator extends StatelessWidget {
   const Indicator({
@@ -9,6 +10,13 @@ class Indicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (Environment.disableWidgetAnimation) {
+      return Container(
+        color: PilllColors.primary,
+        width: 40,
+        height: 40,
+      );
+    }
     return Container(
       child: Center(
         child: CircularProgressIndicator(

--- a/lib/components/molecules/indicator.dart
+++ b/lib/components/molecules/indicator.dart
@@ -11,8 +11,7 @@ class Indicator extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       child: Center(
-        child: CircularProgressIndicator(
-            valueColor: AlwaysStoppedAnimation(PilllColors.primary)),
+        child: Container(color: PilllColors.primary),
       ),
     );
   }

--- a/lib/components/organisms/pill/pill_mark.dart
+++ b/lib/components/organisms/pill/pill_mark.dart
@@ -35,7 +35,7 @@ class _PillMarkState extends State<PillMark> with TickerProviderStateMixin {
       vsync: this,
     );
     // NOTE: This statement for avoid of tester.pumpAndSettle exception about timeout
-    if (!Environment.isTest) {
+    if (!Environment.isTest && !Environment.disableWidgetAnimation) {
       _controller!.repeat();
     }
 

--- a/lib/components/organisms/pill/pill_mark.dart
+++ b/lib/components/organisms/pill/pill_mark.dart
@@ -30,13 +30,13 @@ class _PillMarkState extends State<PillMark> with TickerProviderStateMixin {
 
   @override
   void initState() {
-    _controller = AnimationController(
-      duration: const Duration(milliseconds: 1500),
-      vsync: this,
-    );
+    // _controller = AnimationController(
+    //   duration: const Duration(milliseconds: 1500),
+    //   vsync: this,
+    // );
     // NOTE: This statement for avoid of tester.pumpAndSettle exception about timeout
     if (!Environment.isTest) {
-      _controller!.repeat();
+      // _controller!.repeat();
     }
 
     super.initState();
@@ -62,14 +62,15 @@ class _PillMarkState extends State<PillMark> with TickerProviderStateMixin {
             left: -30,
             top: -30,
             child: Container(
-              child: CustomPaint(
-                size: Size(
-                    PillMarkConst.edgeOfRipple, PillMarkConst.edgeOfRipple),
-                painter: Ripple(
-                  _controller,
-                  color: PilllColors.primary,
-                ),
-              ),
+              child: Text("あいうえお"),
+              // child: CustomPaint(
+              //   size: Size(
+              //       PillMarkConst.edgeOfRipple, PillMarkConst.edgeOfRipple),
+              //   painter: Ripple(
+              //     _controller,
+              //     color: PilllColors.primary,
+              //   ),
+              // ),
             ),
           ),
       ],

--- a/lib/components/organisms/pill/pill_mark.dart
+++ b/lib/components/organisms/pill/pill_mark.dart
@@ -30,13 +30,13 @@ class _PillMarkState extends State<PillMark> with TickerProviderStateMixin {
 
   @override
   void initState() {
-    // _controller = AnimationController(
-    //   duration: const Duration(milliseconds: 1500),
-    //   vsync: this,
-    // );
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1500),
+      vsync: this,
+    );
     // NOTE: This statement for avoid of tester.pumpAndSettle exception about timeout
     if (!Environment.isTest) {
-      // _controller!.repeat();
+      _controller!.repeat();
     }
 
     super.initState();
@@ -62,15 +62,14 @@ class _PillMarkState extends State<PillMark> with TickerProviderStateMixin {
             left: -30,
             top: -30,
             child: Container(
-              child: Text("あいうえお"),
-              // child: CustomPaint(
-              //   size: Size(
-              //       PillMarkConst.edgeOfRipple, PillMarkConst.edgeOfRipple),
-              //   painter: Ripple(
-              //     _controller,
-              //     color: PilllColors.primary,
-              //   ),
-              // ),
+              child: CustomPaint(
+                size: Size(
+                    PillMarkConst.edgeOfRipple, PillMarkConst.edgeOfRipple),
+                painter: Ripple(
+                  _controller,
+                  color: PilllColors.primary,
+                ),
+              ),
             ),
           ),
       ],

--- a/lib/util/environment.dart
+++ b/lib/util/environment.dart
@@ -11,4 +11,7 @@ abstract class Environment {
   static bool get isLocal => flavor == Flavor.LOCAL;
   static bool isTest = false;
   static Flavor? flavor;
+  // Avoid too, too much CPU usage.
+  // Ref: https://github.com/flutter/flutter/issues/13203#issuecomment-430134157
+  static bool get disableWidgetAnimation => true && isDevelopment;
 }


### PR DESCRIPTION
## What
開発時はrepeat: trueなアニメーションをすべて無効できるように調整する

## Why

IndicatorやPilllのRippleEffectのアニメーションを開発時のJITモードで動かしているとPCのCPU Usageが150%とかになりDebugビルド中はずっとその状態でまともに開発ができなくなっていた
調査して下記リンクを参考にWidgetのAnimationをすべてOFFにした。結果、CPU UsageがSimulatorでビルド中などで1.0%まで下がった

ref: https://github.com/flutter/flutter/issues/13203#issuecomment-430134157