### PR TITLE
Add event for initial setting

### DIFF
--- a/lib/analytics.dart
+++ b/lib/analytics.dart
@@ -13,6 +13,8 @@ class Analytics extends AbstractAnalytics {
   @override
   Future<void> logEvent(
       {required String name, Map<String, dynamic>? parameters}) async {
+    assert(name.length <= 40,
+        "firebase analytics log event name limit length up to 40");
     return firebaseAnalytics.logEvent(name: name, parameters: parameters);
   }
 

--- a/lib/domain/initial_setting/initial_setting_1_page.dart
+++ b/lib/domain/initial_setting/initial_setting_1_page.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:pilll/store/initial_setting.dart';
 import 'package:flutter/material.dart';
+import 'package:pilll/entity/pill_sheet_type.dart';
 
 class InitialSetting1Page extends HookWidget {
   @override
@@ -15,11 +16,15 @@ class InitialSetting1Page extends HookWidget {
       title: "1/4",
       backButtonIsHidden: true,
       selected: (type) {
+        analytics.logEvent(
+            name: "selected_type_initial_setting_1",
+            parameters: {"pill_sheet_type": type.rawPath});
         store.selectedPillSheetType(type);
       },
       done: state.entity.pillSheetType == null
           ? null
           : () {
+              analytics.logEvent(name: "done_initial_setting_1");
               Navigator.of(context).push(InitialSetting2PageRoute.route());
             },
       doneButtonText: "次へ",

--- a/lib/domain/initial_setting/initial_setting_2_page.dart
+++ b/lib/domain/initial_setting/initial_setting_2_page.dart
@@ -1,3 +1,4 @@
+import 'package:pilll/analytics.dart';
 import 'package:pilll/store/initial_setting.dart';
 import 'package:pilll/components/atoms/buttons.dart';
 import 'package:pilll/components/atoms/color.dart';
@@ -61,6 +62,9 @@ class InitialSetting2Page extends HookWidget {
                         },
                         enabledMarkAnimation: null,
                         markSelected: (number) {
+                          analytics.logEvent(
+                              name: "selected_number_initial_setting_2",
+                              parameters: {"pill_number": number});
                           store.modify((model) =>
                               model.copyWith(todayPillNumber: number));
                         },
@@ -72,6 +76,8 @@ class InitialSetting2Page extends HookWidget {
                         onPressed: () {
                           store.modify(
                               (model) => model.copyWith(todayPillNumber: null));
+                          analytics.logEvent(
+                              name: "selected_unknown_initial_setting_2");
                           Navigator.of(context)
                               .push(InitialSetting3PageRoute.route());
                         },
@@ -88,6 +94,7 @@ class InitialSetting2Page extends HookWidget {
                     onPressed: state.entity.todayPillNumber == null
                         ? null
                         : () {
+                            analytics.logEvent(name: "done_initial_setting_2");
                             Navigator.of(context)
                                 .push(InitialSetting3PageRoute.route());
                           },

--- a/lib/domain/initial_setting/initial_setting_3_page.dart
+++ b/lib/domain/initial_setting/initial_setting_3_page.dart
@@ -1,3 +1,4 @@
+import 'package:pilll/analytics.dart';
 import 'package:pilll/components/organisms/setting/setting_menstruation_page.dart';
 import 'package:pilll/domain/initial_setting/initial_setting_4_page.dart';
 import 'package:pilll/store/initial_setting.dart';
@@ -16,6 +17,7 @@ class InitialSetting3Page extends HookWidget {
       title: "3/4",
       doneText: "次へ",
       done: () {
+        analytics.logEvent(name: "done_initial_setting_3");
         Navigator.of(context).push(InitialSetting4PageRoute.route());
       },
       pillSheetTotalCount: state.entity.pillSheetType!.totalCount,
@@ -25,10 +27,12 @@ class InitialSetting3Page extends HookWidget {
         pillSheetType: state.entity.pillSheetType!,
       ),
       fromMenstructionDidDecide: (selectedFromMenstruction) {
+        analytics.logEvent(name: "decided_from_initial_setting_3");
         store.modify((model) =>
             model.copyWith(fromMenstruation: selectedFromMenstruction));
       },
       durationMenstructionDidDecide: (selectedDurationMenstruation) {
+        analytics.logEvent(name: "decided_duration_initial_setting_3");
         store.modify((model) =>
             model.copyWith(durationMenstruation: selectedDurationMenstruation));
       },

--- a/lib/domain/initial_setting/initial_setting_4_page.dart
+++ b/lib/domain/initial_setting/initial_setting_4_page.dart
@@ -1,3 +1,4 @@
+import 'package:pilll/analytics.dart';
 import 'package:pilll/router/router.dart';
 import 'package:pilll/state/initial_setting.dart';
 import 'package:pilll/store/initial_setting.dart';
@@ -23,6 +24,7 @@ class InitialSetting4Page extends HookWidget {
     InitialSettingState state,
     InitialSettingStateStore store,
   ) {
+    analytics.logEvent(name: "show_initial_setting_reminder_picker");
     final reminderDateTime = state.reminderTimeOrDefault(index);
     final n = now();
     DateTime initialDateTime = reminderDateTime != null
@@ -34,6 +36,9 @@ class InitialSetting4Page extends HookWidget {
         return DateTimePicker(
           initialDateTime: initialDateTime,
           done: (dateTime) {
+            analytics.logEvent(
+                name: "selected_date_initial_setting_4",
+                parameters: {"hour": dateTime.hour, "minute": dateTime.minute});
             store.setReminderTime(index, dateTime.hour, dateTime.minute);
             Navigator.pop(context);
           },
@@ -176,6 +181,7 @@ class InitialSetting4Page extends HookWidget {
                     PrimaryButton(
                       text: "設定完了",
                       onPressed: () {
+                        analytics.logEvent(name: "done_initial_setting_4");
                         store
                             .register(state.entity.copyWith(isOnReminder: true))
                             .then((_) => AppRouter.endInitialSetting(context));


### PR DESCRIPTION
## What
初期設定周りでユーザーが行うタップイベントに対してログを追加する

## Why
- Funnels とか設定するときに便利
- :bug: が起きたときの調査に使える