### PR TITLE
:memo: remove id

### DIFF
--- a/lib/entity/link_account_type.dart
+++ b/lib/entity/link_account_type.dart
@@ -4,7 +4,7 @@ extension LinkAccountTypeExtension on LinkAccountType {
   String get providerName {
     switch (this) {
       case LinkAccountType.apple:
-        return "Apple ID";
+        return "Apple";
       case LinkAccountType.google:
         return "Google アカウント";
     }


### PR DESCRIPTION
## What
Fix rejection

> Your app offers Sign in with Apple as a login option but does not use the appropriate Sign in with Apple button design, placement, and/or user interface elements. Specifically:
> - The  Sign in with Apple says Apple IDでサインイン but should use the following localized version: Appleでサインイン.