### PR TITLE
Record user ids

### DIFF
--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -102,6 +102,7 @@ class RootState extends State<Root> {
     cacheOrAuth().then((authInfo) {
       final userService = UserService(DatabaseConnection(authInfo.uid));
       return userService.prepare(authInfo.uid).then((_) async {
+        userService.recordUserIDs();
         userService.saveLaunchInfo();
         userService.saveStats();
         final user = await userService.fetch();

--- a/lib/entity/initial_setting.freezed.dart
+++ b/lib/entity/initial_setting.freezed.dart
@@ -20,8 +20,8 @@ class _$InitialSettingModelTearOff {
       {int fromMenstruation = 23,
       int durationMenstruation = 4,
       List<ReminderTime> reminderTimes = const [
-        const ReminderTime(hour: 21, minute: 0),
-        const ReminderTime(hour: 22, minute: 0)
+        ReminderTime(hour: 21, minute: 0),
+        ReminderTime(hour: 22, minute: 0)
       ],
       bool isOnReminder = false,
       int? todayPillNumber,
@@ -224,8 +224,8 @@ class _$_InitialSettingModel extends _InitialSettingModel {
       {this.fromMenstruation = 23,
       this.durationMenstruation = 4,
       this.reminderTimes = const [
-        const ReminderTime(hour: 21, minute: 0),
-        const ReminderTime(hour: 22, minute: 0)
+        ReminderTime(hour: 21, minute: 0),
+        ReminderTime(hour: 22, minute: 0)
       ],
       this.isOnReminder = false,
       this.todayPillNumber,
@@ -239,8 +239,8 @@ class _$_InitialSettingModel extends _InitialSettingModel {
   @override
   final int durationMenstruation;
   @JsonKey(defaultValue: const [
-    const ReminderTime(hour: 21, minute: 0),
-    const ReminderTime(hour: 22, minute: 0)
+    ReminderTime(hour: 21, minute: 0),
+    ReminderTime(hour: 22, minute: 0)
   ])
   @override
   final List<ReminderTime> reminderTimes;

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -37,10 +37,9 @@ abstract class UserPrivate implements _$UserPrivate {
 }
 
 extension UserFirestoreFieldKeys on String {
-  static final userDocumentIDHistories = "userDocumentIDHistories";
-  static final anonymousUserIDHistories = "anonymousUserIDHistories";
-  static final firebaseCurrentUserIDHistories =
-      "firebaseCurrentUserIDHistories";
+  static final userDocumentIDSets = "userDocumentIDSets";
+  static final anonymousUserIDSets = "anonymousUserIDSets";
+  static final firebaseCurrentUserIDSets = "firebaseCurrentUserIDSets";
   static final userIDWhenCreateUser = "userIDWhenCreateUser";
   static final anonymousUserID = "anonymousUserID";
   static final settings = "settings";
@@ -55,6 +54,11 @@ abstract class User implements _$User {
   factory User({
     @JsonKey(name: "settings") Setting? setting,
     @Default(false) bool migratedFlutter,
+    String? userIDWhenCreateUser,
+    String? anonymousUserID,
+    @Default([]) List<String> userDocumentIDSets,
+    @Default([]) List<String> anonymousUserIDSets,
+    @Default([]) List<String> firebaseCurrentUserIDSets,
   }) = _User;
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -37,6 +37,10 @@ abstract class UserPrivate implements _$UserPrivate {
 }
 
 extension UserFirestoreFieldKeys on String {
+  static final userDocumentIDHistories = "userDocumentIDHistories";
+  static final anonymousUserIDHistories = "anonymousUserIDHistories";
+  static final firebaseCurrentUserIDHistories =
+      "firebaseCurrentUserIDHistories";
   static final userIDWhenCreateUser = "userIDWhenCreateUser";
   static final anonymousUserID = "anonymousUserID";
   static final settings = "settings";

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -37,6 +37,7 @@ abstract class UserPrivate implements _$UserPrivate {
 }
 
 extension UserFirestoreFieldKeys on String {
+  static final userIDWhenCreateUser = "userIDWhenCreateUser";
   static final anonymousUserID = "anonymousUserID";
   static final settings = "settings";
   static final migratedFlutter = "migratedFlutter";

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -51,6 +51,7 @@ extension UserFirestoreFieldKeys on String {
 @freezed
 abstract class User implements _$User {
   User._();
+  @JsonSerializable(explicitToJson: true)
   factory User({
     @JsonKey(name: "settings") Setting? setting,
     @Default(false) bool migratedFlutter,

--- a/lib/entity/user.freezed.dart
+++ b/lib/entity/user.freezed.dart
@@ -362,7 +362,8 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
 }
 
 /// @nodoc
-@JsonSerializable()
+
+@JsonSerializable(explicitToJson: true)
 class _$_User extends _User {
   _$_User(
       {@JsonKey(name: "settings") this.setting,

--- a/lib/entity/user.freezed.dart
+++ b/lib/entity/user.freezed.dart
@@ -171,10 +171,20 @@ class _$UserTearOff {
 
   _User call(
       {@JsonKey(name: "settings") Setting? setting,
-      bool migratedFlutter = false}) {
+      bool migratedFlutter = false,
+      String? userIDWhenCreateUser,
+      String? anonymousUserID,
+      List<String> userDocumentIDSets = const [],
+      List<String> anonymousUserIDSets = const [],
+      List<String> firebaseCurrentUserIDSets = const []}) {
     return _User(
       setting: setting,
       migratedFlutter: migratedFlutter,
+      userIDWhenCreateUser: userIDWhenCreateUser,
+      anonymousUserID: anonymousUserID,
+      userDocumentIDSets: userDocumentIDSets,
+      anonymousUserIDSets: anonymousUserIDSets,
+      firebaseCurrentUserIDSets: firebaseCurrentUserIDSets,
     );
   }
 
@@ -191,6 +201,12 @@ mixin _$User {
   @JsonKey(name: "settings")
   Setting? get setting => throw _privateConstructorUsedError;
   bool get migratedFlutter => throw _privateConstructorUsedError;
+  String? get userIDWhenCreateUser => throw _privateConstructorUsedError;
+  String? get anonymousUserID => throw _privateConstructorUsedError;
+  List<String> get userDocumentIDSets => throw _privateConstructorUsedError;
+  List<String> get anonymousUserIDSets => throw _privateConstructorUsedError;
+  List<String> get firebaseCurrentUserIDSets =>
+      throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -202,7 +218,13 @@ abstract class $UserCopyWith<$Res> {
   factory $UserCopyWith(User value, $Res Function(User) then) =
       _$UserCopyWithImpl<$Res>;
   $Res call(
-      {@JsonKey(name: "settings") Setting? setting, bool migratedFlutter});
+      {@JsonKey(name: "settings") Setting? setting,
+      bool migratedFlutter,
+      String? userIDWhenCreateUser,
+      String? anonymousUserID,
+      List<String> userDocumentIDSets,
+      List<String> anonymousUserIDSets,
+      List<String> firebaseCurrentUserIDSets});
 
   $SettingCopyWith<$Res>? get setting;
 }
@@ -219,6 +241,11 @@ class _$UserCopyWithImpl<$Res> implements $UserCopyWith<$Res> {
   $Res call({
     Object? setting = freezed,
     Object? migratedFlutter = freezed,
+    Object? userIDWhenCreateUser = freezed,
+    Object? anonymousUserID = freezed,
+    Object? userDocumentIDSets = freezed,
+    Object? anonymousUserIDSets = freezed,
+    Object? firebaseCurrentUserIDSets = freezed,
   }) {
     return _then(_value.copyWith(
       setting: setting == freezed
@@ -229,6 +256,26 @@ class _$UserCopyWithImpl<$Res> implements $UserCopyWith<$Res> {
           ? _value.migratedFlutter
           : migratedFlutter // ignore: cast_nullable_to_non_nullable
               as bool,
+      userIDWhenCreateUser: userIDWhenCreateUser == freezed
+          ? _value.userIDWhenCreateUser
+          : userIDWhenCreateUser // ignore: cast_nullable_to_non_nullable
+              as String?,
+      anonymousUserID: anonymousUserID == freezed
+          ? _value.anonymousUserID
+          : anonymousUserID // ignore: cast_nullable_to_non_nullable
+              as String?,
+      userDocumentIDSets: userDocumentIDSets == freezed
+          ? _value.userDocumentIDSets
+          : userDocumentIDSets // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      anonymousUserIDSets: anonymousUserIDSets == freezed
+          ? _value.anonymousUserIDSets
+          : anonymousUserIDSets // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      firebaseCurrentUserIDSets: firebaseCurrentUserIDSets == freezed
+          ? _value.firebaseCurrentUserIDSets
+          : firebaseCurrentUserIDSets // ignore: cast_nullable_to_non_nullable
+              as List<String>,
     ));
   }
 
@@ -250,7 +297,13 @@ abstract class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
       __$UserCopyWithImpl<$Res>;
   @override
   $Res call(
-      {@JsonKey(name: "settings") Setting? setting, bool migratedFlutter});
+      {@JsonKey(name: "settings") Setting? setting,
+      bool migratedFlutter,
+      String? userIDWhenCreateUser,
+      String? anonymousUserID,
+      List<String> userDocumentIDSets,
+      List<String> anonymousUserIDSets,
+      List<String> firebaseCurrentUserIDSets});
 
   @override
   $SettingCopyWith<$Res>? get setting;
@@ -269,6 +322,11 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
   $Res call({
     Object? setting = freezed,
     Object? migratedFlutter = freezed,
+    Object? userIDWhenCreateUser = freezed,
+    Object? anonymousUserID = freezed,
+    Object? userDocumentIDSets = freezed,
+    Object? anonymousUserIDSets = freezed,
+    Object? firebaseCurrentUserIDSets = freezed,
   }) {
     return _then(_User(
       setting: setting == freezed
@@ -279,6 +337,26 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
           ? _value.migratedFlutter
           : migratedFlutter // ignore: cast_nullable_to_non_nullable
               as bool,
+      userIDWhenCreateUser: userIDWhenCreateUser == freezed
+          ? _value.userIDWhenCreateUser
+          : userIDWhenCreateUser // ignore: cast_nullable_to_non_nullable
+              as String?,
+      anonymousUserID: anonymousUserID == freezed
+          ? _value.anonymousUserID
+          : anonymousUserID // ignore: cast_nullable_to_non_nullable
+              as String?,
+      userDocumentIDSets: userDocumentIDSets == freezed
+          ? _value.userDocumentIDSets
+          : userDocumentIDSets // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      anonymousUserIDSets: anonymousUserIDSets == freezed
+          ? _value.anonymousUserIDSets
+          : anonymousUserIDSets // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      firebaseCurrentUserIDSets: firebaseCurrentUserIDSets == freezed
+          ? _value.firebaseCurrentUserIDSets
+          : firebaseCurrentUserIDSets // ignore: cast_nullable_to_non_nullable
+              as List<String>,
     ));
   }
 }
@@ -287,7 +365,13 @@ class __$UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_User extends _User {
   _$_User(
-      {@JsonKey(name: "settings") this.setting, this.migratedFlutter = false})
+      {@JsonKey(name: "settings") this.setting,
+      this.migratedFlutter = false,
+      this.userIDWhenCreateUser,
+      this.anonymousUserID,
+      this.userDocumentIDSets = const [],
+      this.anonymousUserIDSets = const [],
+      this.firebaseCurrentUserIDSets = const []})
       : super._();
 
   factory _$_User.fromJson(Map<String, dynamic> json) =>
@@ -299,10 +383,23 @@ class _$_User extends _User {
   @JsonKey(defaultValue: false)
   @override
   final bool migratedFlutter;
+  @override
+  final String? userIDWhenCreateUser;
+  @override
+  final String? anonymousUserID;
+  @JsonKey(defaultValue: const [])
+  @override
+  final List<String> userDocumentIDSets;
+  @JsonKey(defaultValue: const [])
+  @override
+  final List<String> anonymousUserIDSets;
+  @JsonKey(defaultValue: const [])
+  @override
+  final List<String> firebaseCurrentUserIDSets;
 
   @override
   String toString() {
-    return 'User(setting: $setting, migratedFlutter: $migratedFlutter)';
+    return 'User(setting: $setting, migratedFlutter: $migratedFlutter, userIDWhenCreateUser: $userIDWhenCreateUser, anonymousUserID: $anonymousUserID, userDocumentIDSets: $userDocumentIDSets, anonymousUserIDSets: $anonymousUserIDSets, firebaseCurrentUserIDSets: $firebaseCurrentUserIDSets)';
   }
 
   @override
@@ -314,14 +411,36 @@ class _$_User extends _User {
                     .equals(other.setting, setting)) &&
             (identical(other.migratedFlutter, migratedFlutter) ||
                 const DeepCollectionEquality()
-                    .equals(other.migratedFlutter, migratedFlutter)));
+                    .equals(other.migratedFlutter, migratedFlutter)) &&
+            (identical(other.userIDWhenCreateUser, userIDWhenCreateUser) ||
+                const DeepCollectionEquality().equals(
+                    other.userIDWhenCreateUser, userIDWhenCreateUser)) &&
+            (identical(other.anonymousUserID, anonymousUserID) ||
+                const DeepCollectionEquality()
+                    .equals(other.anonymousUserID, anonymousUserID)) &&
+            (identical(other.userDocumentIDSets, userDocumentIDSets) ||
+                const DeepCollectionEquality()
+                    .equals(other.userDocumentIDSets, userDocumentIDSets)) &&
+            (identical(other.anonymousUserIDSets, anonymousUserIDSets) ||
+                const DeepCollectionEquality()
+                    .equals(other.anonymousUserIDSets, anonymousUserIDSets)) &&
+            (identical(other.firebaseCurrentUserIDSets,
+                    firebaseCurrentUserIDSets) ||
+                const DeepCollectionEquality().equals(
+                    other.firebaseCurrentUserIDSets,
+                    firebaseCurrentUserIDSets)));
   }
 
   @override
   int get hashCode =>
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(setting) ^
-      const DeepCollectionEquality().hash(migratedFlutter);
+      const DeepCollectionEquality().hash(migratedFlutter) ^
+      const DeepCollectionEquality().hash(userIDWhenCreateUser) ^
+      const DeepCollectionEquality().hash(anonymousUserID) ^
+      const DeepCollectionEquality().hash(userDocumentIDSets) ^
+      const DeepCollectionEquality().hash(anonymousUserIDSets) ^
+      const DeepCollectionEquality().hash(firebaseCurrentUserIDSets);
 
   @JsonKey(ignore: true)
   @override
@@ -337,7 +456,12 @@ class _$_User extends _User {
 abstract class _User extends User {
   factory _User(
       {@JsonKey(name: "settings") Setting? setting,
-      bool migratedFlutter}) = _$_User;
+      bool migratedFlutter,
+      String? userIDWhenCreateUser,
+      String? anonymousUserID,
+      List<String> userDocumentIDSets,
+      List<String> anonymousUserIDSets,
+      List<String> firebaseCurrentUserIDSets}) = _$_User;
   _User._() : super._();
 
   factory _User.fromJson(Map<String, dynamic> json) = _$_User.fromJson;
@@ -347,6 +471,17 @@ abstract class _User extends User {
   Setting? get setting => throw _privateConstructorUsedError;
   @override
   bool get migratedFlutter => throw _privateConstructorUsedError;
+  @override
+  String? get userIDWhenCreateUser => throw _privateConstructorUsedError;
+  @override
+  String? get anonymousUserID => throw _privateConstructorUsedError;
+  @override
+  List<String> get userDocumentIDSets => throw _privateConstructorUsedError;
+  @override
+  List<String> get anonymousUserIDSets => throw _privateConstructorUsedError;
+  @override
+  List<String> get firebaseCurrentUserIDSets =>
+      throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
   _$UserCopyWith<_User> get copyWith => throw _privateConstructorUsedError;

--- a/lib/entity/user.g.dart
+++ b/lib/entity/user.g.dart
@@ -42,7 +42,7 @@ _$_User _$_$_UserFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$_$_UserToJson(_$_User instance) => <String, dynamic>{
-      'settings': instance.setting,
+      'settings': instance.setting?.toJson(),
       'migratedFlutter': instance.migratedFlutter,
       'userIDWhenCreateUser': instance.userIDWhenCreateUser,
       'anonymousUserID': instance.anonymousUserID,

--- a/lib/entity/user.g.dart
+++ b/lib/entity/user.g.dart
@@ -23,10 +23,30 @@ _$_User _$_$_UserFromJson(Map<String, dynamic> json) {
         ? null
         : Setting.fromJson(json['settings'] as Map<String, dynamic>),
     migratedFlutter: json['migratedFlutter'] as bool? ?? false,
+    userIDWhenCreateUser: json['userIDWhenCreateUser'] as String?,
+    anonymousUserID: json['anonymousUserID'] as String?,
+    userDocumentIDSets: (json['userDocumentIDSets'] as List<dynamic>?)
+            ?.map((e) => e as String)
+            .toList() ??
+        [],
+    anonymousUserIDSets: (json['anonymousUserIDSets'] as List<dynamic>?)
+            ?.map((e) => e as String)
+            .toList() ??
+        [],
+    firebaseCurrentUserIDSets:
+        (json['firebaseCurrentUserIDSets'] as List<dynamic>?)
+                ?.map((e) => e as String)
+                .toList() ??
+            [],
   );
 }
 
 Map<String, dynamic> _$_$_UserToJson(_$_User instance) => <String, dynamic>{
       'settings': instance.setting,
       'migratedFlutter': instance.migratedFlutter,
+      'userIDWhenCreateUser': instance.userIDWhenCreateUser,
+      'anonymousUserID': instance.anonymousUserID,
+      'userDocumentIDSets': instance.userDocumentIDSets,
+      'anonymousUserIDSets': instance.anonymousUserIDSets,
+      'firebaseCurrentUserIDSets': instance.firebaseCurrentUserIDSets,
     };

--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -61,11 +61,16 @@ class UserService {
     );
   }
 
-  Future<void> _create(String uid) {
+  Future<void> _create(String uid) async {
     print("call create for $uid");
+    final sharedPreferences = await SharedPreferences.getInstance();
+    final anonymousUserID =
+        sharedPreferences.getString(StringKey.lastSigninAnonymousUID);
     return _database.userReference().set(
       {
-        UserFirestoreFieldKeys.anonymousUserID: uid,
+        if (anonymousUserID != null)
+          UserFirestoreFieldKeys.anonymousUserID: anonymousUserID,
+        UserFirestoreFieldKeys.userIDWhenCreateUser: uid,
       },
       SetOptions(merge: true),
     );

--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -40,6 +40,21 @@ class UserService {
     });
   }
 
+  Future<DocumentSnapshot> _fetchRawDocumentSnapshot() {
+    return _database.userReference().get();
+  }
+
+  recordUserIDHistory() {
+    Future(() async {
+      try {
+        final userDocumentSnapshot = await _fetchRawDocumentSnapshot();
+        final userDocumentID = userDocumentSnapshot.id;
+      } catch (error) {
+        print(error);
+      }
+    });
+  }
+
   Future<User> subscribe() {
     return _database
         .userReference()

--- a/lib/signin/signin_sheet_store.dart
+++ b/lib/signin/signin_sheet_store.dart
@@ -1,3 +1,4 @@
+import 'package:pilll/analytics.dart';
 import 'package:pilll/auth/apple.dart';
 import 'package:pilll/auth/boilerplate.dart';
 import 'package:pilll/auth/google.dart';
@@ -19,20 +20,24 @@ class SigninSheetStore extends StateNotifier<SigninSheetState> {
 
   Future<SigninWithAppleState> handleApple() {
     if (state.isLoginMode) {
+      analytics.logEvent(name: "signin_sheet_sign_in_apple");
       return signInWithApple().then((value) => value == null
           ? SigninWithAppleState.cancel
           : SigninWithAppleState.determined);
     } else {
+      analytics.logEvent(name: "signin_sheet_link_with_apple");
       return callLinkWithApple(_userService);
     }
   }
 
   Future<SigninWithGoogleState> handleGoogle() {
     if (state.isLoginMode) {
+      analytics.logEvent(name: "signin_sheet_sign_in_google");
       return signInWithGoogle().then((value) => value == null
           ? SigninWithGoogleState.cancel
           : SigninWithGoogleState.determined);
     } else {
+      analytics.logEvent(name: "signin_sheet_link_with_google");
       return callLinkWithGoogle(_userService);
     }
   }

--- a/lib/store/initial_setting.dart
+++ b/lib/store/initial_setting.dart
@@ -13,7 +13,7 @@ import 'package:pilll/service/user.dart';
 import 'package:pilll/state/initial_setting.dart';
 import 'package:riverpod/riverpod.dart';
 
-final initialSettingStoreProvider = StateNotifierProvider(
+final initialSettingStoreProvider = StateNotifierProvider.autoDispose(
   (ref) => InitialSettingStateStore(
     ref.watch(initialSettingServiceProvider),
     ref.watch(authServiceProvider),

--- a/lib/store/initial_setting.dart
+++ b/lib/store/initial_setting.dart
@@ -51,6 +51,7 @@ class InitialSettingStateStore extends StateNotifier<InitialSettingState> {
       if (isAccountCooperationDidEnd) {
         final userService = UserService(DatabaseConnection(user.uid));
         await userService.prepare(user.uid);
+        await userService.recordUserIDs();
         errorLogger.setUserIdentifier(user.uid);
         firebaseAnalytics.setUserId(user.uid);
       }


### PR DESCRIPTION
## What
UserIDの変化を /users/:id/ にレコードしておくようにする

## Why
特に今問題が起きているわけでは無いがいざとなったときの調査用のためにFirestoreに格納しておく。Pilllではuserの情報はsecurity rules上自分しか読めないのもあり手軽に /users/:id に格納することにした。あと読まれてもそこまで大きな問題も無い

## Checked
- [x] 初期設定が完了する(Anonymous)
- [x] 再起動時にDBにSharedPreferencesや既存のDBに格納されているデータから /users/:id に記録される
  - [x] 同じuidの場合は記録が更新されない
- [x] 初期設定でSignupをした場合に /users/:id にデータが記録される
- [x] 初期設定でSignin をした場合に /users/:id にデータが記録される
- [x] 設定画面からLinkをした場合に /users/:id にデータが保存される(再起動あと)