### PR TITLE
Skip exception when purchaseInfo.entitlements not found

### DIFF
--- a/lib/purchases.dart
+++ b/lib/purchases.dart
@@ -17,14 +17,11 @@ Future<void> callUpdatePurchaseInfo(PurchaserInfo info) async {
 
   final userService = UserService(DatabaseConnection(uid));
   final premiumEntitlement = info.entitlements.all[premiumEntitlements];
-  if (premiumEntitlement == null) {
-    throw FormatException("Unexpected entitlements is null");
-  }
   try {
     await userService.updatePurchaseInfo(
-      isActivated: premiumEntitlement.isActive,
-      entitlementIdentifier: premiumEntitlement.identifier,
-      premiumPlanIdentifier: premiumEntitlement.productIdentifier,
+      isActivated: premiumEntitlement?.isActive,
+      entitlementIdentifier: premiumEntitlement?.identifier,
+      premiumPlanIdentifier: premiumEntitlement?.productIdentifier,
       purchaseAppID: info.originalAppUserId,
       activeSubscriptions: info.activeSubscriptions,
       originalPurchaseDate: info.originalPurchaseDate,
@@ -46,14 +43,12 @@ Future<void> syncPurchaseInfo() async {
   PurchaserInfo purchaserInfo = await Purchases.getPurchaserInfo();
   final premiumEntitlement =
       purchaserInfo.entitlements.all[premiumEntitlements];
-  if (premiumEntitlement == null) {
-    throw FormatException("Unexpected entitlements is null");
-  }
+  final isActivated =
+      premiumEntitlement == null ? false : premiumEntitlement.isActive;
 
   try {
     final userService = UserService(DatabaseConnection(uid));
-    await userService.syncPurchaseInfo(
-        isActivated: premiumEntitlement.isActive);
+    await userService.syncPurchaseInfo(isActivated: isActivated);
   } catch (exception, stack) {
     errorLogger.recordError(exception, stack);
   }

--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -87,7 +87,7 @@ class UserService {
   }
 
   Future<void> updatePurchaseInfo({
-    required bool isActivated,
+    required bool? isActivated,
     required String? entitlementIdentifier,
     required String? premiumPlanIdentifier,
     required String purchaseAppID,
@@ -95,7 +95,7 @@ class UserService {
     required String? originalPurchaseDate,
   }) async {
     await _database.userReference().set({
-      UserFirestoreFieldKeys.isPremium: isActivated,
+      if (isActivated != null) UserFirestoreFieldKeys.isPremium: isActivated,
       UserFirestoreFieldKeys.purchaseAppID: purchaseAppID
     }, SetOptions(merge: true));
     final privates = {


### PR DESCRIPTION
## What
RevenueCatから購入情報が取得できない場合でも処理が継続できるようにした