### PR TITLE
To more contextual for HUD and UniversalError

### DIFF
--- a/lib/components/page/hud.dart
+++ b/lib/components/page/hud.dart
@@ -1,6 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:pilll/components/molecules/indicator.dart';
 
+class _InheritedWidget extends InheritedWidget {
+  _InheritedWidget({
+    Key? key,
+    required Widget child,
+    required this.state,
+  }) : super(key: key, child: child);
+
+  final _HUDState state;
+
+  @override
+  bool updateShouldNotify(covariant InheritedWidget oldWidget) {
+    return true;
+  }
+}
+
 class HUD extends StatefulWidget {
   final bool shown;
   final bool barrierEnabled;
@@ -17,7 +32,8 @@ class HUD extends StatefulWidget {
   _HUDState createState() => _HUDState();
 
   static _HUDState of(BuildContext context) {
-    final state = context.findAncestorStateOfType<_HUDState>();
+    final state =
+        context.dependOnInheritedWidgetOfExactType<_InheritedWidget>()?.state;
     if (state == null) {
       throw AssertionError('''
       Not found HUD from this context: $context
@@ -29,25 +45,29 @@ class HUD extends StatefulWidget {
 }
 
 class _HUDState extends State<HUD> {
-  bool shown = false;
+  bool _shown = false;
   show() {
     setState(() {
-      shown = true;
+      _shown = true;
     });
   }
 
   hide() {
     setState(() {
-      shown = false;
+      _shown = false;
     });
   }
 
-  bool get _shown => widget.shown || shown;
+  bool get shown => widget.shown || _shown;
 
   @override
   Widget build(BuildContext context) {
+    return _InheritedWidget(child: _body(context), state: this);
+  }
+
+  Widget _body(BuildContext context) {
     final child = this.widget.child;
-    if (child != null && !_shown) {
+    if (child != null && !shown) {
       return child;
     }
     if (child == null) {
@@ -63,13 +83,13 @@ class _HUDState extends State<HUD> {
 
   Widget _hud(BuildContext context) {
     return IgnorePointer(
-      ignoring: !_shown,
+      ignoring: !shown,
       child: Stack(
         children: [
-          if (_shown) ...[
+          if (shown) ...[
             if (widget.barrierEnabled)
               Visibility(
-                visible: _shown,
+                visible: shown,
                 child: ModalBarrier(
                   color: Colors.black.withOpacity(0.08),
                 ),

--- a/lib/components/page/hud.dart
+++ b/lib/components/page/hud.dart
@@ -32,8 +32,6 @@ class HUD extends StatefulWidget {
   _HUDState createState() => _HUDState();
 
   static _HUDState of(BuildContext context) {
-    final state =
-        context.dependOnInheritedWidgetOfExactType<_InheritedWidget>()?.state;
     final exactType = context
         .getElementForInheritedWidgetOfExactType<_InheritedWidget>()
         ?.widget;

--- a/lib/components/page/hud.dart
+++ b/lib/components/page/hud.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pilll/components/molecules/indicator.dart';
 
-class HUD extends StatelessWidget {
+class HUD extends StatefulWidget {
   final bool shown;
   final bool barrierEnabled;
   final Widget? child;
@@ -14,9 +14,40 @@ class HUD extends StatelessWidget {
   }) : super(key: key);
 
   @override
+  _HUDState createState() => _HUDState();
+
+  static _HUDState of(BuildContext context) {
+    final state = context.findAncestorStateOfType<_HUDState>();
+    if (state == null) {
+      throw AssertionError('''
+      Not found HUD from this context: $context
+      The context should contains HUD widget into current widget tree
+      ''');
+    }
+    return state;
+  }
+}
+
+class _HUDState extends State<HUD> {
+  bool shown = false;
+  show() {
+    setState(() {
+      shown = true;
+    });
+  }
+
+  hide() {
+    setState(() {
+      shown = false;
+    });
+  }
+
+  bool get _shown => widget.shown || shown;
+
+  @override
   Widget build(BuildContext context) {
-    final child = this.child;
-    if (child != null && !shown) {
+    final child = this.widget.child;
+    if (child != null && !_shown) {
       return child;
     }
     if (child == null) {
@@ -32,13 +63,13 @@ class HUD extends StatelessWidget {
 
   Widget _hud(BuildContext context) {
     return IgnorePointer(
-      ignoring: !shown,
+      ignoring: !_shown,
       child: Stack(
         children: [
-          if (shown) ...[
-            if (barrierEnabled)
+          if (_shown) ...[
+            if (widget.barrierEnabled)
               Visibility(
-                visible: shown,
+                visible: _shown,
                 child: ModalBarrier(
                   color: Colors.black.withOpacity(0.08),
                 ),

--- a/lib/components/page/hud.dart
+++ b/lib/components/page/hud.dart
@@ -11,8 +11,8 @@ class _InheritedWidget extends InheritedWidget {
   final _HUDState state;
 
   @override
-  bool updateShouldNotify(covariant InheritedWidget oldWidget) {
-    return true;
+  bool updateShouldNotify(covariant _InheritedWidget oldWidget) {
+    return false;
   }
 }
 
@@ -34,6 +34,11 @@ class HUD extends StatefulWidget {
   static _HUDState of(BuildContext context) {
     final state =
         context.dependOnInheritedWidgetOfExactType<_InheritedWidget>()?.state;
+    final exactType = context
+        .getElementForInheritedWidgetOfExactType<_InheritedWidget>()
+        ?.widget;
+    final stateWidget = exactType as _InheritedWidget?;
+    final state = stateWidget?.state;
     if (state == null) {
       throw AssertionError('''
       Not found HUD from this context: $context
@@ -66,10 +71,7 @@ class _HUDState extends State<HUD> {
   }
 
   Widget _body(BuildContext context) {
-    final child = this.widget.child;
-    if (child != null && !shown) {
-      return child;
-    }
+    final child = widget.child;
     if (child == null) {
       return _hud(context);
     }

--- a/lib/domain/settings/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_cooperation_list_page.dart
@@ -26,51 +26,55 @@ class SettingAccountCooperationListPage extends HookWidget {
       child: UniversalErrorPage(
         error: state.exception,
         reload: () => store.reset(),
-        child: Scaffold(
-          backgroundColor: PilllColors.background,
-          appBar: AppBar(
-            leading: IconButton(
-              icon: Icon(Icons.arrow_back, color: Colors.black),
-              onPressed: () => Navigator.of(context).pop(),
-            ),
-            title: Text('アカウント設定', style: TextColorStyle.main),
-            backgroundColor: PilllColors.white,
-          ),
-          body: Container(
-            child: ListView(
-              children: [
-                Container(
-                  padding: EdgeInsets.only(top: 16, left: 15, right: 16),
-                  child: Text(
-                    "アカウント登録",
-                    style: FontType.assisting.merge(TextColorStyle.primary),
-                  ),
+        child: Builder(
+          builder: (BuildContext context) {
+            return Scaffold(
+              backgroundColor: PilllColors.background,
+              appBar: AppBar(
+                leading: IconButton(
+                  icon: Icon(Icons.arrow_back, color: Colors.black),
+                  onPressed: () => Navigator.of(context).pop(),
                 ),
-                SettingAccountCooperationRow(
-                  accountType: LinkAccountType.apple,
-                  isLinked: () => state.isLinkedApple,
-                  onTap: () async {
-                    if (state.isLinkedApple) {
-                      return;
-                    }
-                    _linkApple(context, store);
-                  },
+                title: Text('アカウント設定', style: TextColorStyle.main),
+                backgroundColor: PilllColors.white,
+              ),
+              body: Container(
+                child: ListView(
+                  children: [
+                    Container(
+                      padding: EdgeInsets.only(top: 16, left: 15, right: 16),
+                      child: Text(
+                        "アカウント登録",
+                        style: FontType.assisting.merge(TextColorStyle.primary),
+                      ),
+                    ),
+                    SettingAccountCooperationRow(
+                      accountType: LinkAccountType.apple,
+                      isLinked: () => state.isLinkedApple,
+                      onTap: () async {
+                        if (state.isLinkedApple) {
+                          return;
+                        }
+                        _linkApple(context, store);
+                      },
+                    ),
+                    Divider(indent: 16),
+                    SettingAccountCooperationRow(
+                      accountType: LinkAccountType.google,
+                      isLinked: () => state.isLinkedGoogle,
+                      onTap: () async {
+                        if (state.isLinkedGoogle) {
+                          return;
+                        }
+                        _linkGoogle(context, store);
+                      },
+                    ),
+                    Divider(indent: 16),
+                  ],
                 ),
-                Divider(indent: 16),
-                SettingAccountCooperationRow(
-                  accountType: LinkAccountType.google,
-                  isLinked: () => state.isLinkedGoogle,
-                  onTap: () async {
-                    if (state.isLinkedGoogle) {
-                      return;
-                    }
-                    _linkGoogle(context, store);
-                  },
-                ),
-                Divider(indent: 16),
-              ],
-            ),
-          ),
+              ),
+            );
+          },
         ),
       ),
     );
@@ -108,7 +112,7 @@ class SettingAccountCooperationListPage extends HookWidget {
     analytics.logEvent(
       name: "link_event_$eventSuffix",
     );
-    store.showHUD();
+    HUD.of(context).show();
     try {
       final bool isDetermined;
       switch (accountType) {
@@ -119,7 +123,7 @@ class SettingAccountCooperationListPage extends HookWidget {
           isDetermined = await _handleGoogle(store);
           break;
       }
-      store.hideHUD();
+      HUD.of(context).hide();
       analytics.logEvent(
         name: "did_end_link_event_$eventSuffix",
       );
@@ -131,7 +135,7 @@ class SettingAccountCooperationListPage extends HookWidget {
           name: "did_failure_link_event_$eventSuffix",
           parameters: {"errot_type": error.runtimeType.toString()});
 
-      store.hideHUD();
+      HUD.of(context).hide();
       if (error is UserDisplayedError) {
         showErrorAlertWithError(context, error);
       } else {

--- a/lib/domain/settings/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_cooperation_list_page.dart
@@ -139,7 +139,7 @@ class SettingAccountCooperationListPage extends HookWidget {
       if (error is UserDisplayedError) {
         showErrorAlertWithError(context, error);
       } else {
-        store.handleException(error);
+        UniversalErrorPage.of(context).showError(error);
       }
       return;
     }

--- a/lib/domain/settings/setting_account_cooperation_list_page_store.dart
+++ b/lib/domain/settings/setting_account_cooperation_list_page_store.dart
@@ -65,12 +65,4 @@ class SettingAccountCooperationListPageStore
   handleException(Object exception) {
     state = state.copyWith(exception: exception);
   }
-
-  showHUD() {
-    state = state.copyWith(isLoading: true);
-  }
-
-  hideHUD() {
-    state = state.copyWith(isLoading: false);
-  }
 }

--- a/lib/domain/settings/setting_account_cooperation_list_page_store.dart
+++ b/lib/domain/settings/setting_account_cooperation_list_page_store.dart
@@ -9,7 +9,7 @@ import 'package:pilll/service/auth.dart';
 import 'package:pilll/service/user.dart';
 import 'package:riverpod/riverpod.dart';
 
-final settingAccountCooperationListProvider = StateNotifierProvider(
+final settingAccountCooperationListProvider = StateNotifierProvider.autoDispose(
   (ref) => SettingAccountCooperationListPageStore(
     ref.watch(userServiceProvider),
     ref.watch(authServiceProvider),
@@ -27,8 +27,10 @@ class SettingAccountCooperationListPageStore
   }
 
   reset() {
-    state = state.copyWith(
-        user: FirebaseAuth.instance.currentUser, exception: null);
+    Future(() async {
+      state = state.copyWith(
+          user: FirebaseAuth.instance.currentUser, exception: null);
+    });
     _subscribe();
   }
 

--- a/lib/domain/settings/setting_account_cooperation_list_page_store.dart
+++ b/lib/domain/settings/setting_account_cooperation_list_page_store.dart
@@ -63,8 +63,4 @@ class SettingAccountCooperationListPageStore
     }
     return callLinkWithGoogle(_userService);
   }
-
-  handleException(Object exception) {
-    state = state.copyWith(exception: exception);
-  }
 }

--- a/lib/error/universal_error_page.dart
+++ b/lib/error/universal_error_page.dart
@@ -5,7 +5,22 @@ import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/inquiry/inquiry.dart';
 import 'package:flutter/material.dart';
 
-class UniversalErrorPage extends StatelessWidget {
+class _InheritedWidget extends InheritedWidget {
+  _InheritedWidget({
+    Key? key,
+    required Widget child,
+    required this.state,
+  }) : super(key: key, child: child);
+
+  final _UniversalErrorPageState state;
+
+  @override
+  bool updateShouldNotify(covariant _InheritedWidget oldWidget) {
+    return false;
+  }
+}
+
+class UniversalErrorPage extends StatefulWidget {
   final Object? error;
   final Widget? child;
   final VoidCallback? reload;
@@ -18,60 +33,83 @@ class UniversalErrorPage extends StatelessWidget {
   }) : super(key: key);
 
   @override
+  _UniversalErrorPageState createState() => _UniversalErrorPageState();
+}
+
+class _UniversalErrorPageState extends State<UniversalErrorPage> {
+  Object? _error;
+  showError(Object error) {
+    setState(() {
+      _error = error;
+    });
+  }
+
+  Object? get error => _error ?? widget.error;
+
+  @override
   Widget build(BuildContext context) {
-    final child = this.child;
+    final child = this.widget.child;
     final error = this.error;
-    if (error == null && child != null) {
-      return child;
-    }
-    return Scaffold(
-      backgroundColor: PilllColors.background,
-      body: Center(
-        child: Container(
-          width: 300,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Image.asset(
-                "images/universal_error.png",
-                width: 200,
-                height: 190,
-              ),
-              SizedBox(height: 25),
-              Text(error.toString(),
-                  style: FontType.assisting.merge(TextColorStyle.main)),
-              SizedBox(height: 25),
-              TextButton.icon(
-                icon: const Icon(
-                  Icons.refresh,
-                  size: 20,
+    return _InheritedWidget(
+      state: this,
+      child: Stack(
+        children: [
+          if (child != null) child,
+          if (error != null)
+            Scaffold(
+              backgroundColor: PilllColors.background,
+              body: Center(
+                child: Container(
+                  width: 300,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Image.asset(
+                        "images/universal_error.png",
+                        width: 200,
+                        height: 190,
+                      ),
+                      SizedBox(height: 25),
+                      Text(error.toString(),
+                          style: FontType.assisting.merge(TextColorStyle.main)),
+                      SizedBox(height: 25),
+                      TextButton.icon(
+                        icon: const Icon(
+                          Icons.refresh,
+                          size: 20,
+                        ),
+                        label: Text("画面を再読み込み",
+                            style:
+                                FontType.assisting.merge(TextColorStyle.black)),
+                        onPressed: () {
+                          analytics.logEvent(name: "reload_button_pressed");
+                          final reload = this.widget.reload;
+                          if (reload != null) {
+                            reload();
+                          }
+                        },
+                      ),
+                      TextButton.icon(
+                        icon: const Icon(
+                          Icons.mail,
+                          size: 20,
+                        ),
+                        label: Text("解決しない場合はこちら",
+                            style:
+                                FontType.assisting.merge(TextColorStyle.black)),
+                        onPressed: () {
+                          analytics.logEvent(
+                              name: "problem_unresolved_button_pressed");
+                          inquiry();
+                        },
+                      )
+                    ],
+                  ),
                 ),
-                label: Text("画面を再読み込み",
-                    style: FontType.assisting.merge(TextColorStyle.black)),
-                onPressed: () {
-                  analytics.logEvent(name: "reload_button_pressed");
-                  final reload = this.reload;
-                  if (reload != null) {
-                    reload();
-                  }
-                },
               ),
-              TextButton.icon(
-                icon: const Icon(
-                  Icons.mail,
-                  size: 20,
-                ),
-                label: Text("解決しない場合はこちら",
-                    style: FontType.assisting.merge(TextColorStyle.black)),
-                onPressed: () {
-                  analytics.logEvent(name: "problem_unresolved_button_pressed");
-                  inquiry();
-                },
-              )
-            ],
-          ),
-        ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/error/universal_error_page.dart
+++ b/lib/error/universal_error_page.dart
@@ -34,6 +34,21 @@ class UniversalErrorPage extends StatefulWidget {
 
   @override
   _UniversalErrorPageState createState() => _UniversalErrorPageState();
+
+  static _UniversalErrorPageState of(BuildContext context) {
+    final exactType = context
+        .getElementForInheritedWidgetOfExactType<_InheritedWidget>()
+        ?.widget;
+    final stateWidget = exactType as _InheritedWidget?;
+    final state = stateWidget?.state;
+    if (state == null) {
+      throw AssertionError('''
+      Not found UniversalErrorMessage from this context: $context
+      The context should contains UniversalErrorMessage widget into current widget tree
+      ''');
+    }
+    return state;
+  }
 }
 
 class _UniversalErrorPageState extends State<UniversalErrorPage> {
@@ -84,10 +99,13 @@ class _UniversalErrorPageState extends State<UniversalErrorPage> {
                                 FontType.assisting.merge(TextColorStyle.black)),
                         onPressed: () {
                           analytics.logEvent(name: "reload_button_pressed");
-                          final reload = this.widget.reload;
-                          if (reload != null) {
-                            reload();
-                          }
+                          setState(() {
+                            _error = null;
+                            final reload = this.widget.reload;
+                            if (reload != null) {
+                              reload();
+                            }
+                          });
                         },
                       ),
                       TextButton.icon(


### PR DESCRIPTION
## What
- HUD.of(context)メソッドを実装
- UniversalErrorPage.of(context)メソッドを実装

## Links
https://github.com/bannzai/Pilll/pull/260
https://github.com/bannzai/Pilll/pull/256

## Why
各ページでstate管理するのは大変に感じたので.of(context)メソッドを実装することにした。これで子供の各コンポーネントごとにAPI Requestを送る際のError HandlingやLoadingを出す処理が描けるようになった

UsecaseごとのButtonによってHUDやUniversalErrorを出したくなったが、表示先はPageにしたい場合にしようする

## Checked
とりあえず設定からのアカウント連携画面だけ置き換えて動作確認した
- HUD.of(context)が動作する
- UniversalErrorPage.of(context)が動作する
- 上記二つを実施してない旧実装でも既存の処理が動く