### PR TITLE
Remove pill number on appearance mode to date

### DIFF
--- a/lib/components/organisms/pill/pill_mark.dart
+++ b/lib/components/organisms/pill/pill_mark.dart
@@ -1,5 +1,3 @@
-import 'package:pilll/components/atoms/font.dart';
-import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/ripple.dart';
 import 'package:pilll/entity/pill_mark_type.dart';
 import 'package:pilll/components/atoms/color.dart';
@@ -16,14 +14,12 @@ abstract class PillMarkConst {
 
 class PremiumPillMarkModel {
   final DateTime date;
-  final int pillMarkNumber;
   final int pillNumberForMenstruationBegin;
   final int menstruationDuration;
   final int maxPillNumber;
 
   PremiumPillMarkModel(
     this.date,
-    this.pillMarkNumber,
     this.pillNumberForMenstruationBegin,
     this.menstruationDuration,
     this.maxPillNumber,
@@ -107,21 +103,6 @@ class _PillMarkState extends State<PillMark> with TickerProviderStateMixin {
     );
   }
 
-  TextStyle _pillMarkNumberTextColor(PillMarkType pillMarkType) {
-    switch (pillMarkType) {
-      case PillMarkType.normal:
-        return TextColorStyle.white;
-      case PillMarkType.fake:
-        return TextColorStyle.main;
-      case PillMarkType.rest:
-        return TextColorStyle.main;
-      case PillMarkType.selected:
-        return TextStyle();
-      case PillMarkType.done:
-        return TextStyle();
-    }
-  }
-
   Widget _mark(bool isDone, PillMarkType type, PremiumPillMarkModel? premium) {
     return DottedBorder(
       borderType: BorderType.RRect,
@@ -136,14 +117,6 @@ class _PillMarkState extends State<PillMark> with TickerProviderStateMixin {
           child: () {
             if (isDone) {
               return _checkImage();
-            }
-            if (premium != null) {
-              return Text(
-                "${premium.pillMarkNumber}",
-                style: FontType.sSmallNumber.merge(
-                  _pillMarkNumberTextColor(type),
-                ),
-              );
             }
             return null;
           }(),

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -217,7 +217,6 @@ class RecordPage extends HookWidget {
             pillMarkNumber,
             setting.pillNumberForFromMenstruation,
             setting.durationMenstruation,
-            pillSheet.pillSheetType.totalCount,
           );
         };
       }(),

--- a/lib/domain/settings/components/rows/taking_pill_notification.dart
+++ b/lib/domain/settings/components/rows/taking_pill_notification.dart
@@ -20,7 +20,6 @@ class TakingPillNotification extends HookWidget {
     final store = useProvider(settingStoreProvider);
     return SwitchListTile(
       title: Text("ピルの服用通知", style: FontType.listRow),
-      subtitle: Text("通知時間までに服用した場合は通知はきません", style: FontType.assisting),
       activeColor: PilllColors.primary,
       onChanged: (bool value) {
         analytics.logEvent(
@@ -44,7 +43,7 @@ class TakingPillNotification extends HookWidget {
       },
       value: setting.isOnReminder,
       // NOTE: when configured subtitle, the space between elements becomes very narrow
-      contentPadding: EdgeInsets.fromLTRB(14, 8, 6, 8),
+      contentPadding: EdgeInsets.fromLTRB(14, 4, 6, 0),
     );
   }
 }


### PR DESCRIPTION
## What
見づらいので日付表示モードの時にピル番号を中央に出すのをやめる
もともと出していた理由が数字表示の状態で出ていたため

ピルシートの画面から気軽に設定を切り替えられるものがあると良いよね。という話をした