### PR TITLE
Bugfix calculate menstruation duration

### DIFF
--- a/lib/components/organisms/pill/pill_mark.dart
+++ b/lib/components/organisms/pill/pill_mark.dart
@@ -18,12 +18,12 @@ class PremiumPillMarkModel {
   final int menstruationDuration;
   final int maxPillNumber;
 
-  PremiumPillMarkModel(
-    this.date,
-    this.pillNumberForMenstruationBegin,
-    this.menstruationDuration,
-    this.maxPillNumber,
-  );
+  PremiumPillMarkModel({
+    required this.date,
+    required this.pillNumberForMenstruationBegin,
+    required this.menstruationDuration,
+    required this.maxPillNumber,
+  });
 }
 
 class PillMark extends StatefulWidget {

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -209,14 +209,19 @@ class RecordPage extends HookWidget {
         if (state.appearanceMode != PillSheetAppearanceMode.date) {
           return null;
         }
+        final pillSheet = state.entity;
+        if (pillSheet == null) {
+          return null;
+        }
         return (pillMarkNumber) {
           final date =
               pillSheet.beginingDate.add(Duration(days: pillMarkNumber - 1));
           return PremiumPillMarkModel(
-            date,
-            pillMarkNumber,
-            setting.pillNumberForFromMenstruation,
-            setting.durationMenstruation,
+            date: date,
+            pillNumberForMenstruationBegin:
+                setting.pillNumberForFromMenstruation,
+            menstruationDuration: setting.durationMenstruation,
+            maxPillNumber: pillSheet.pillSheetType.totalCount,
           );
         };
       }(),


### PR DESCRIPTION
## What
ピルシートの日付モードの時に表示する生理期間の設定がおかしくなっていた
直接的な要因は引数の順番を間違えていた。引数ラベル等をつけることで間違いを防ぐようにした