### PR TITLE
Add row of CreatingNewPillSheet

### DIFF
--- a/lib/domain/settings/components/rows/creating_new_pillsheet.dart
+++ b/lib/domain/settings/components/rows/creating_new_pillsheet.dart
@@ -71,7 +71,7 @@ class CreatingNewPillSheetRow extends HookWidget {
         }
       },
       value: setting.isAutomaticallyCreatePillSheet && (isPremium || isTrial),
-      contentPadding: EdgeInsets.fromLTRB(14, 0, 6, 0),
+      contentPadding: EdgeInsets.fromLTRB(14, 8, 6, 8),
     );
   }
 }

--- a/lib/domain/settings/components/rows/creating_new_pillsheet.dart
+++ b/lib/domain/settings/components/rows/creating_new_pillsheet.dart
@@ -71,6 +71,7 @@ class CreatingNewPillSheetRow extends HookWidget {
         }
       },
       value: setting.isAutomaticallyCreatePillSheet,
+      contentPadding: EdgeInsets.fromLTRB(14, 0, 6, 0),
     );
   }
 }

--- a/lib/domain/settings/components/rows/creating_new_pillsheet.dart
+++ b/lib/domain/settings/components/rows/creating_new_pillsheet.dart
@@ -38,6 +38,8 @@ class CreatingNewPillSheetRow extends HookWidget {
           ]
         ],
       ),
+      subtitle:
+          Text("ピルシートすべてを服用した場合、新しいシートを自動で追加します。", style: FontType.assisting),
       activeColor: PilllColors.primary,
       onChanged: (bool value) {
         analytics.logEvent(

--- a/lib/domain/settings/components/rows/creating_new_pillsheet.dart
+++ b/lib/domain/settings/components/rows/creating_new_pillsheet.dart
@@ -31,7 +31,7 @@ class CreatingNewPillSheetRow extends HookWidget {
     return SwitchListTile(
       title: Row(
         children: [
-          Text("ピルシートの自動作成", style: FontType.listRow),
+          Text("ピルシートの自動追加", style: FontType.listRow),
           if (!isPremium) ...[
             SizedBox(width: 8),
             PremiumBadge(),
@@ -57,7 +57,7 @@ class CreatingNewPillSheetRow extends HookWidget {
               SnackBar(
                 duration: Duration(seconds: 2),
                 content: Text(
-                  "ピルシートの自動作成を${setting.isAutomaticallyCreatePillSheet ? "ON" : "OFF"}にしました",
+                  "ピルシートの自動追加を${setting.isAutomaticallyCreatePillSheet ? "ON" : "OFF"}にしました",
                 ),
               ),
             );

--- a/lib/domain/settings/components/rows/creating_new_pillsheet.dart
+++ b/lib/domain/settings/components/rows/creating_new_pillsheet.dart
@@ -70,7 +70,7 @@ class CreatingNewPillSheetRow extends HookWidget {
           showPremiumIntroductionSheet(context);
         }
       },
-      value: setting.isAutomaticallyCreatePillSheet,
+      value: setting.isAutomaticallyCreatePillSheet && (isPremium || isTrial),
       contentPadding: EdgeInsets.fromLTRB(14, 0, 6, 0),
     );
   }

--- a/lib/domain/settings/components/rows/creating_new_pillsheet.dart
+++ b/lib/domain/settings/components/rows/creating_new_pillsheet.dart
@@ -71,8 +71,6 @@ class CreatingNewPillSheetRow extends HookWidget {
         }
       },
       value: setting.isAutomaticallyCreatePillSheet,
-      // NOTE: when configured subtitle, the space between elements becomes very narrow
-      contentPadding: EdgeInsets.fromLTRB(14, 8, 6, 8),
     );
   }
 }

--- a/lib/domain/settings/components/rows/creating_new_pillsheet.dart
+++ b/lib/domain/settings/components/rows/creating_new_pillsheet.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/analytics.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/domain/settings/setting_page_store.dart';
+import 'package:pilll/entity/setting.dart';
+
+class CreatingNewPillSheetRow extends HookWidget {
+  final Setting setting;
+
+  const CreatingNewPillSheetRow({
+    Key? key,
+    required this.setting,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final store = useProvider(settingStoreProvider);
+    return SwitchListTile(
+      title: Text("ピルシートの自動作成", style: FontType.listRow),
+      activeColor: PilllColors.primary,
+      onChanged: (bool value) {
+        analytics.logEvent(
+          name: "toggle_creating_new_pillsheet",
+        );
+        ScaffoldMessenger.of(context).hideCurrentSnackBar();
+        store
+            .modifiyIsAutomaticallyCreatePillSheet(
+                !setting.isAutomaticallyCreatePillSheet)
+            .then((state) {
+          final setting = state.entity;
+          if (setting == null) {
+            return null;
+          }
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              duration: Duration(seconds: 2),
+              content: Text(
+                "ピルシートの自動作成を${setting.isAutomaticallyCreatePillSheet ? "ON" : "OFF"}にしました",
+              ),
+            ),
+          );
+        });
+      },
+      value: setting.isAutomaticallyCreatePillSheet,
+      // NOTE: when configured subtitle, the space between elements becomes very narrow
+      contentPadding: EdgeInsets.fromLTRB(14, 8, 6, 8),
+    );
+  }
+}

--- a/lib/domain/settings/components/rows/creating_new_pillsheet.dart
+++ b/lib/domain/settings/components/rows/creating_new_pillsheet.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/analytics.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/components/molecules/premium_badge.dart';
 import 'package:pilll/domain/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/domain/premium_trial/premium_trial_complete_modal.dart';
 import 'package:pilll/domain/premium_trial/premium_trial_modal.dart';
@@ -28,7 +29,15 @@ class CreatingNewPillSheetRow extends HookWidget {
   Widget build(BuildContext context) {
     final store = useProvider(settingStoreProvider);
     return SwitchListTile(
-      title: Text("ピルシートの自動作成", style: FontType.listRow),
+      title: Row(
+        children: [
+          Text("ピルシートの自動作成", style: FontType.listRow),
+          if (!isPremium) ...[
+            SizedBox(width: 8),
+            PremiumBadge(),
+          ]
+        ],
+      ),
       activeColor: PilllColors.primary,
       onChanged: (bool value) {
         analytics.logEvent(

--- a/lib/domain/settings/components/rows/pill_sheet_appearance_mode.dart
+++ b/lib/domain/settings/components/rows/pill_sheet_appearance_mode.dart
@@ -42,7 +42,7 @@ class PillSheetAppearanceModeRow extends HookWidget {
         ],
       ),
       trailing: Switch(
-        value: isOn,
+        value: (isOn && (isPremium || isTrial)),
         onChanged: (value) => _onChanged(context, value, store),
       ),
       onTap: () => _onChanged(context, !isOn, store),

--- a/lib/domain/settings/setting_page.dart
+++ b/lib/domain/settings/setting_page.dart
@@ -84,7 +84,14 @@ class SettingPage extends HookWidget {
                         _separator(),
                         PillSheetRemoveRow(),
                         _separator(),
-                      ]
+                      ],
+                      CreatingNewPillSheetRow(
+                        setting: setting,
+                        isPremium: state.isPremium,
+                        isTrial: state.isTrial,
+                        trialDeadlineDate: state.trialDeadlineDate,
+                      ),
+                      _separator(),
                     ],
                   );
                 case SettingSection.notification:
@@ -94,13 +101,6 @@ class SettingPage extends HookWidget {
                       TakingPillNotification(setting: setting),
                       _separator(),
                       NotificationTimeRow(setting: setting),
-                      _separator(),
-                      CreatingNewPillSheetRow(
-                        setting: setting,
-                        isPremium: state.isPremium,
-                        isTrial: state.isTrial,
-                        trialDeadlineDate: state.trialDeadlineDate,
-                      ),
                       _separator(),
                       if (pillSheet != null && pillSheet.hasRestDuration) ...[
                         NotificationInRestDuration(

--- a/lib/domain/settings/setting_page.dart
+++ b/lib/domain/settings/setting_page.dart
@@ -1,6 +1,7 @@
 import 'package:pilll/analytics.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/page/discard_dialog.dart';
+import 'package:pilll/domain/settings/components/rows/creating_new_pillsheet.dart';
 import 'package:pilll/domain/settings/components/rows/menstruation.dart';
 import 'package:pilll/domain/settings/components/rows/account_link.dart';
 import 'package:pilll/domain/settings/components/rows/list_explain.dart';
@@ -93,6 +94,13 @@ class SettingPage extends HookWidget {
                       TakingPillNotification(setting: setting),
                       _separator(),
                       NotificationTimeRow(setting: setting),
+                      _separator(),
+                      CreatingNewPillSheetRow(
+                        setting: setting,
+                        isPremium: state.isPremium,
+                        isTrial: state.isTrial,
+                        trialDeadlineDate: state.trialDeadlineDate,
+                      ),
                       _separator(),
                       if (pillSheet != null && pillSheet.hasRestDuration) ...[
                         NotificationInRestDuration(

--- a/lib/domain/settings/setting_page_store.dart
+++ b/lib/domain/settings/setting_page_store.dart
@@ -201,4 +201,14 @@ class SettingStateStore extends StateNotifier<SettingState> {
         .update(updated)
         .then((value) => state = state.copyWith(entity: value));
   }
+
+  Future<SettingState> modifiyIsAutomaticallyCreatePillSheet(bool isOn) {
+    final entity = state.entity;
+    if (entity == null) {
+      throw FormatException("setting entity not found");
+    }
+    return _service
+        .update(entity.copyWith(isAutomaticallyCreatePillSheet: isOn))
+        .then((entity) => state = state.copyWith(entity: entity));
+  }
 }

--- a/lib/entity/initial_setting.freezed.dart
+++ b/lib/entity/initial_setting.freezed.dart
@@ -20,8 +20,8 @@ class _$InitialSettingModelTearOff {
       {int fromMenstruation = 23,
       int durationMenstruation = 4,
       List<ReminderTime> reminderTimes = const [
-        ReminderTime(hour: 21, minute: 0),
-        ReminderTime(hour: 22, minute: 0)
+        const ReminderTime(hour: 21, minute: 0),
+        const ReminderTime(hour: 22, minute: 0)
       ],
       bool isOnReminder = false,
       int? todayPillNumber,
@@ -224,8 +224,8 @@ class _$_InitialSettingModel extends _InitialSettingModel {
       {this.fromMenstruation = 23,
       this.durationMenstruation = 4,
       this.reminderTimes = const [
-        ReminderTime(hour: 21, minute: 0),
-        ReminderTime(hour: 22, minute: 0)
+        const ReminderTime(hour: 21, minute: 0),
+        const ReminderTime(hour: 22, minute: 0)
       ],
       this.isOnReminder = false,
       this.todayPillNumber,
@@ -239,8 +239,8 @@ class _$_InitialSettingModel extends _InitialSettingModel {
   @override
   final int durationMenstruation;
   @JsonKey(defaultValue: const [
-    ReminderTime(hour: 21, minute: 0),
-    ReminderTime(hour: 22, minute: 0)
+    const ReminderTime(hour: 21, minute: 0),
+    const ReminderTime(hour: 22, minute: 0)
   ])
   @override
   final List<ReminderTime> reminderTimes;

--- a/lib/entity/setting.dart
+++ b/lib/entity/setting.dart
@@ -65,6 +65,7 @@ abstract class Setting implements _$Setting {
     @Default(true) bool isOnNotifyInNotTakenDuration,
     @Default(PillSheetAppearanceMode.number)
         PillSheetAppearanceMode pillSheetAppearanceMode,
+    @Default(false) bool isAutomaticallyCreatePillSheet,
   }) = _Setting;
 
   factory Setting.fromJson(Map<String, dynamic> json) =>

--- a/lib/entity/setting.freezed.dart
+++ b/lib/entity/setting.freezed.dart
@@ -207,7 +207,8 @@ class _$SettingTearOff {
       @JsonSerializable(explicitToJson: true) required bool isOnReminder,
       bool isOnNotifyInNotTakenDuration = true,
       PillSheetAppearanceMode pillSheetAppearanceMode =
-          PillSheetAppearanceMode.number}) {
+          PillSheetAppearanceMode.number,
+      bool isAutomaticallyCreatePillSheet = false}) {
     return _Setting(
       pillSheetTypeRawPath: pillSheetTypeRawPath,
       pillNumberForFromMenstruation: pillNumberForFromMenstruation,
@@ -216,6 +217,7 @@ class _$SettingTearOff {
       isOnReminder: isOnReminder,
       isOnNotifyInNotTakenDuration: isOnNotifyInNotTakenDuration,
       pillSheetAppearanceMode: pillSheetAppearanceMode,
+      isAutomaticallyCreatePillSheet: isAutomaticallyCreatePillSheet,
     );
   }
 
@@ -238,6 +240,7 @@ mixin _$Setting {
   bool get isOnNotifyInNotTakenDuration => throw _privateConstructorUsedError;
   PillSheetAppearanceMode get pillSheetAppearanceMode =>
       throw _privateConstructorUsedError;
+  bool get isAutomaticallyCreatePillSheet => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -255,7 +258,8 @@ abstract class $SettingCopyWith<$Res> {
       List<ReminderTime> reminderTimes,
       @JsonSerializable(explicitToJson: true) bool isOnReminder,
       bool isOnNotifyInNotTakenDuration,
-      PillSheetAppearanceMode pillSheetAppearanceMode});
+      PillSheetAppearanceMode pillSheetAppearanceMode,
+      bool isAutomaticallyCreatePillSheet});
 }
 
 /// @nodoc
@@ -275,6 +279,7 @@ class _$SettingCopyWithImpl<$Res> implements $SettingCopyWith<$Res> {
     Object? isOnReminder = freezed,
     Object? isOnNotifyInNotTakenDuration = freezed,
     Object? pillSheetAppearanceMode = freezed,
+    Object? isAutomaticallyCreatePillSheet = freezed,
   }) {
     return _then(_value.copyWith(
       pillSheetTypeRawPath: pillSheetTypeRawPath == freezed
@@ -305,6 +310,10 @@ class _$SettingCopyWithImpl<$Res> implements $SettingCopyWith<$Res> {
           ? _value.pillSheetAppearanceMode
           : pillSheetAppearanceMode // ignore: cast_nullable_to_non_nullable
               as PillSheetAppearanceMode,
+      isAutomaticallyCreatePillSheet: isAutomaticallyCreatePillSheet == freezed
+          ? _value.isAutomaticallyCreatePillSheet
+          : isAutomaticallyCreatePillSheet // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -321,7 +330,8 @@ abstract class _$SettingCopyWith<$Res> implements $SettingCopyWith<$Res> {
       List<ReminderTime> reminderTimes,
       @JsonSerializable(explicitToJson: true) bool isOnReminder,
       bool isOnNotifyInNotTakenDuration,
-      PillSheetAppearanceMode pillSheetAppearanceMode});
+      PillSheetAppearanceMode pillSheetAppearanceMode,
+      bool isAutomaticallyCreatePillSheet});
 }
 
 /// @nodoc
@@ -342,6 +352,7 @@ class __$SettingCopyWithImpl<$Res> extends _$SettingCopyWithImpl<$Res>
     Object? isOnReminder = freezed,
     Object? isOnNotifyInNotTakenDuration = freezed,
     Object? pillSheetAppearanceMode = freezed,
+    Object? isAutomaticallyCreatePillSheet = freezed,
   }) {
     return _then(_Setting(
       pillSheetTypeRawPath: pillSheetTypeRawPath == freezed
@@ -372,6 +383,10 @@ class __$SettingCopyWithImpl<$Res> extends _$SettingCopyWithImpl<$Res>
           ? _value.pillSheetAppearanceMode
           : pillSheetAppearanceMode // ignore: cast_nullable_to_non_nullable
               as PillSheetAppearanceMode,
+      isAutomaticallyCreatePillSheet: isAutomaticallyCreatePillSheet == freezed
+          ? _value.isAutomaticallyCreatePillSheet
+          : isAutomaticallyCreatePillSheet // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -387,7 +402,8 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
       this.reminderTimes = const [],
       @JsonSerializable(explicitToJson: true) required this.isOnReminder,
       this.isOnNotifyInNotTakenDuration = true,
-      this.pillSheetAppearanceMode = PillSheetAppearanceMode.number})
+      this.pillSheetAppearanceMode = PillSheetAppearanceMode.number,
+      this.isAutomaticallyCreatePillSheet = false})
       : super._();
 
   factory _$_Setting.fromJson(Map<String, dynamic> json) =>
@@ -411,10 +427,13 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
   @JsonKey(defaultValue: PillSheetAppearanceMode.number)
   @override
   final PillSheetAppearanceMode pillSheetAppearanceMode;
+  @JsonKey(defaultValue: false)
+  @override
+  final bool isAutomaticallyCreatePillSheet;
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'Setting(pillSheetTypeRawPath: $pillSheetTypeRawPath, pillNumberForFromMenstruation: $pillNumberForFromMenstruation, durationMenstruation: $durationMenstruation, reminderTimes: $reminderTimes, isOnReminder: $isOnReminder, isOnNotifyInNotTakenDuration: $isOnNotifyInNotTakenDuration, pillSheetAppearanceMode: $pillSheetAppearanceMode)';
+    return 'Setting(pillSheetTypeRawPath: $pillSheetTypeRawPath, pillNumberForFromMenstruation: $pillNumberForFromMenstruation, durationMenstruation: $durationMenstruation, reminderTimes: $reminderTimes, isOnReminder: $isOnReminder, isOnNotifyInNotTakenDuration: $isOnNotifyInNotTakenDuration, pillSheetAppearanceMode: $pillSheetAppearanceMode, isAutomaticallyCreatePillSheet: $isAutomaticallyCreatePillSheet)';
   }
 
   @override
@@ -431,7 +450,9 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
       ..add(DiagnosticsProperty(
           'isOnNotifyInNotTakenDuration', isOnNotifyInNotTakenDuration))
       ..add(DiagnosticsProperty(
-          'pillSheetAppearanceMode', pillSheetAppearanceMode));
+          'pillSheetAppearanceMode', pillSheetAppearanceMode))
+      ..add(DiagnosticsProperty(
+          'isAutomaticallyCreatePillSheet', isAutomaticallyCreatePillSheet));
   }
 
   @override
@@ -463,7 +484,12 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
             (identical(
                     other.pillSheetAppearanceMode, pillSheetAppearanceMode) ||
                 const DeepCollectionEquality().equals(
-                    other.pillSheetAppearanceMode, pillSheetAppearanceMode)));
+                    other.pillSheetAppearanceMode, pillSheetAppearanceMode)) &&
+            (identical(other.isAutomaticallyCreatePillSheet,
+                    isAutomaticallyCreatePillSheet) ||
+                const DeepCollectionEquality().equals(
+                    other.isAutomaticallyCreatePillSheet,
+                    isAutomaticallyCreatePillSheet)));
   }
 
   @override
@@ -475,7 +501,8 @@ class _$_Setting extends _Setting with DiagnosticableTreeMixin {
       const DeepCollectionEquality().hash(reminderTimes) ^
       const DeepCollectionEquality().hash(isOnReminder) ^
       const DeepCollectionEquality().hash(isOnNotifyInNotTakenDuration) ^
-      const DeepCollectionEquality().hash(pillSheetAppearanceMode);
+      const DeepCollectionEquality().hash(pillSheetAppearanceMode) ^
+      const DeepCollectionEquality().hash(isAutomaticallyCreatePillSheet);
 
   @JsonKey(ignore: true)
   @override
@@ -496,7 +523,8 @@ abstract class _Setting extends Setting {
       List<ReminderTime> reminderTimes,
       @JsonSerializable(explicitToJson: true) required bool isOnReminder,
       bool isOnNotifyInNotTakenDuration,
-      PillSheetAppearanceMode pillSheetAppearanceMode}) = _$_Setting;
+      PillSheetAppearanceMode pillSheetAppearanceMode,
+      bool isAutomaticallyCreatePillSheet}) = _$_Setting;
   _Setting._() : super._();
 
   factory _Setting.fromJson(Map<String, dynamic> json) = _$_Setting.fromJson;
@@ -517,6 +545,8 @@ abstract class _Setting extends Setting {
   @override
   PillSheetAppearanceMode get pillSheetAppearanceMode =>
       throw _privateConstructorUsedError;
+  @override
+  bool get isAutomaticallyCreatePillSheet => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
   _$SettingCopyWith<_Setting> get copyWith =>

--- a/lib/entity/setting.g.dart
+++ b/lib/entity/setting.g.dart
@@ -35,6 +35,8 @@ _$_Setting _$_$_SettingFromJson(Map<String, dynamic> json) {
             _$PillSheetAppearanceModeEnumMap,
             json['pillSheetAppearanceMode']) ??
         PillSheetAppearanceMode.number,
+    isAutomaticallyCreatePillSheet:
+        json['isAutomaticallyCreatePillSheet'] as bool? ?? false,
   );
 }
 
@@ -48,6 +50,7 @@ Map<String, dynamic> _$_$_SettingToJson(_$_Setting instance) =>
       'isOnNotifyInNotTakenDuration': instance.isOnNotifyInNotTakenDuration,
       'pillSheetAppearanceMode':
           _$PillSheetAppearanceModeEnumMap[instance.pillSheetAppearanceMode],
+      'isAutomaticallyCreatePillSheet': instance.isAutomaticallyCreatePillSheet,
     };
 
 K _$enumDecode<K, V>(


### PR DESCRIPTION
## What
設定画面にピルシートの自動作成のtoggleを追加

## Checked
- [x] trial試したことないユーザーにはトライアル開始モーダルが出る
- [x] trialとpremiumではないユーザーに対しては課金導線が出る
- [x] premium or trialのユーザーはswitchの操作ができる
- [x] DBにデータが反映されている
  - [x] 統合テストはしてないが、backendの動作は[こっち](https://github.com/bannzai/PilllBackend/pull/96)で確認済み

### Screenshot

<img width="320px" src="https://user-images.githubusercontent.com/10897361/126650817-f54c8ce0-86b6-4f36-a85f-f61ad6f77d8a.png" />