### PR TITLE
Fix menstruation range

### DIFF
--- a/lib/components/organisms/setting/setting_menstruation_page.dart
+++ b/lib/components/organisms/setting/setting_menstruation_page.dart
@@ -14,7 +14,7 @@ import 'package:flutter/widgets.dart';
 
 abstract class SettingMenstruationPageConstants {
   static final List<String> durationList =
-      List<String>.generate(7, (index) => (index + 1).toString());
+      List<String>.generate(7 + 1, (index) => (index).toString());
 }
 
 class SettingMenstruationPageModel {
@@ -235,15 +235,15 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
                 child: CupertinoPicker(
                   itemExtent: 40,
                   children: List.generate(
-                          this.widget.pillSheetTotalCount, (index) => index + 1)
+                          this.widget.pillSheetTotalCount + 1, (index) => index)
                       .map((number) => number.toString())
                       .map(_pickerItem)
                       .toList(),
                   onSelectedItemChanged: (index) {
-                    keepSelectedFromMenstruation = index + 1;
+                    keepSelectedFromMenstruation = index;
                   },
                   scrollController: FixedExtentScrollController(
-                      initialItem: keepSelectedFromMenstruation - 1),
+                      initialItem: keepSelectedFromMenstruation),
                 ),
               ),
             ),
@@ -289,10 +289,10 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
                       .map(_pickerItem)
                       .toList(),
                   onSelectedItemChanged: (index) {
-                    keepSelectedDurationMenstruation = index + 1;
+                    keepSelectedDurationMenstruation = index;
                   },
                   scrollController: FixedExtentScrollController(
-                      initialItem: keepSelectedDurationMenstruation - 1),
+                      initialItem: keepSelectedDurationMenstruation),
                 ),
               ),
             ),

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -129,8 +129,7 @@ class MenstruationRecordButton extends StatelessWidget {
           throw FormatException("生理記録前にデータの読み込みに失敗しました。再読み込みしてから再度お試しください");
         }
 
-        if (setting.durationMenstruation == 0 &&
-            setting.pillNumberForFromMenstruation == 0) {
+        if (setting.durationMenstruation == 0) {
           return showMenstruationEditPageForCreate(context);
         }
         showModalBottomSheet(

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -124,6 +124,15 @@ class MenstruationRecordButton extends StatelessWidget {
           return;
         }
 
+        final setting = state.setting;
+        if (setting == null) {
+          throw FormatException("生理記録前にデータの読み込みに失敗しました。再読み込みしてから再度お試しください");
+        }
+
+        if (setting.durationMenstruation == 0 &&
+            setting.pillNumberForFromMenstruation == 0) {
+          return showMenstruationEditPageForCreate(context);
+        }
         showModalBottomSheet(
           context: context,
           builder: (_) =>

--- a/lib/domain/menstruation_edit/menstruation_edit_store.dart
+++ b/lib/domain/menstruation_edit/menstruation_edit_store.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/entity/menstruation.dart';
 import 'package:pilll/entity/setting.dart';
@@ -116,7 +118,8 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
       }
 
       final begin = date;
-      final end = date.add(Duration(days: setting.durationMenstruation - 1));
+      final end =
+          date.add(Duration(days: max(setting.durationMenstruation - 1, 0)));
       late final Menstruation menstruation;
       final initialMenstruation = this.initialMenstruation;
       if (initialMenstruation != null) {

--- a/lib/domain/menstruation_edit/menstruation_edit_store.dart
+++ b/lib/domain/menstruation_edit/menstruation_edit_store.dart
@@ -1,5 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/entity/menstruation.dart';
+import 'package:pilll/entity/setting.dart';
 import 'package:pilll/service/menstruation.dart';
 import 'package:pilll/service/setting.dart';
 import 'package:pilll/domain/menstruation_edit/menstruation_edit_state.dart';
@@ -107,29 +108,31 @@ class MenstruationEditStore extends StateNotifier<MenstruationEditState> {
     state = state.copyWith(invalidMessage: null);
 
     if (menstruation == null) {
+      final Setting setting;
       try {
-        final setting = await settingService.fetch();
-        final begin = date;
-        final end = date.add(Duration(days: setting.durationMenstruation - 1));
-        late final Menstruation menstruation;
-        final initialMenstruation = this.initialMenstruation;
-        if (initialMenstruation != null) {
-          menstruation = initialMenstruation.copyWith(
-            beginDate: date,
-            endDate: end,
-          );
-        } else {
-          menstruation = Menstruation(
-            beginDate: begin,
-            endDate: end,
-            createdAt: now(),
-          );
-        }
-        state = state.copyWith(menstruation: menstruation);
-        return;
+        setting = await settingService.fetch();
       } catch (error) {
         throw error;
       }
+
+      final begin = date;
+      final end = date.add(Duration(days: setting.durationMenstruation - 1));
+      late final Menstruation menstruation;
+      final initialMenstruation = this.initialMenstruation;
+      if (initialMenstruation != null) {
+        menstruation = initialMenstruation.copyWith(
+          beginDate: date,
+          endDate: end,
+        );
+      } else {
+        menstruation = Menstruation(
+          beginDate: begin,
+          endDate: end,
+          createdAt: now(),
+        );
+      }
+      state = state.copyWith(menstruation: menstruation);
+      return;
     }
 
     if (isSameDay(menstruation.beginDate, date) &&


### PR DESCRIPTION
## What
生理予定日の始まりと期間の指定に `0` を追加する

## Checked
- [x] 設定からの生理予定日の設定画面の始まりに0が指定できる
- [x] 設定からの生理予定日の設定画面の期間に0が指定できる
- [x] 初期設定の生理予定日の設定画面の始まりに0が指定できる
- [x] 初期設定の生理予定日の設定画面の期間に0が指定できる
- [x] 課金ユーザーでPrimary Colorの日付が無い
- [x] 生理予定日のカレンダーに生理予定日の帯が表示されない
- [x] カレンダータブのカレンダーに生理予定日の帯が表示されない
- [x] 生理記録を押したときに生理期間追加のモーダルが直接出る(仕様変更
  * 今日から生理と昨日から生理のボタンが機能しないから
  - [x] 生理記録ができる