### PR TITLE
Fix menstruation settings

### DIFF
--- a/lib/components/organisms/setting/setting_menstruation_page.dart
+++ b/lib/components/organisms/setting/setting_menstruation_page.dart
@@ -14,7 +14,7 @@ import 'package:flutter/widgets.dart';
 
 abstract class SettingMenstruationPageConstants {
   static final List<String> durationList =
-      List<String>.generate(7 + 1, (index) => (index).toString());
+      List<String>.generate(7, (index) => (index + 1).toString());
 }
 
 class SettingMenstruationPageModel {
@@ -235,15 +235,15 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
                 child: CupertinoPicker(
                   itemExtent: 40,
                   children: List.generate(
-                          this.widget.pillSheetTotalCount + 1, (index) => index)
+                          this.widget.pillSheetTotalCount, (index) => index + 1)
                       .map((number) => number.toString())
                       .map(_pickerItem)
                       .toList(),
                   onSelectedItemChanged: (index) {
-                    keepSelectedFromMenstruation = index;
+                    keepSelectedFromMenstruation = index + 1;
                   },
                   scrollController: FixedExtentScrollController(
-                      initialItem: keepSelectedFromMenstruation),
+                      initialItem: keepSelectedFromMenstruation - 1),
                 ),
               ),
             ),
@@ -289,10 +289,10 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
                       .map(_pickerItem)
                       .toList(),
                   onSelectedItemChanged: (index) {
-                    keepSelectedDurationMenstruation = index;
+                    keepSelectedDurationMenstruation = index + 1;
                   },
                   scrollController: FixedExtentScrollController(
-                      initialItem: keepSelectedDurationMenstruation),
+                      initialItem: keepSelectedDurationMenstruation - 1),
                 ),
               ),
             ),

--- a/lib/components/organisms/setting/setting_menstruation_page.dart
+++ b/lib/components/organisms/setting/setting_menstruation_page.dart
@@ -13,8 +13,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 abstract class SettingMenstruationPageConstants {
-  static final List<String> durationList =
-      List<String>.generate(7, (index) => (index + 1).toString());
+  static final List<String> durationList = [
+    "-",
+    ...List<String>.generate(7, (index) => (index + 1).toString())
+  ];
 }
 
 class SettingMenstruationPageModel {
@@ -165,6 +167,13 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
   }
 
   Widget _from() {
+    final from = this.widget.model.selectedFromMenstruation;
+    final String fromString;
+    if (from == 0) {
+      fromString = "-";
+    } else {
+      fromString = from.toString();
+    }
     return Container(
       width: 48,
       height: 48,
@@ -176,13 +185,20 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
         ),
       ),
       child: Center(
-        child: Text(this.widget.model.selectedFromMenstruation.toString(),
+        child: Text(fromString,
             style: FontType.inputNumber.merge(TextColorStyle.gray)),
       ),
     );
   }
 
   Widget _duration() {
+    final duration = this.widget.model.selectedDurationMenstruation;
+    final String durationString;
+    if (duration == 0) {
+      durationString = "-";
+    } else {
+      durationString = duration.toString();
+    }
     return Container(
       width: 48,
       height: 48,
@@ -194,7 +210,7 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
         ),
       ),
       child: Center(
-        child: Text(this.widget.model.selectedDurationMenstruation.toString(),
+        child: Text(durationString,
             style: FontType.inputNumber.merge(TextColorStyle.gray)),
       ),
     );
@@ -234,16 +250,18 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
                 },
                 child: CupertinoPicker(
                   itemExtent: 40,
-                  children: List.generate(
-                          this.widget.pillSheetTotalCount, (index) => index + 1)
-                      .map((number) => number.toString())
-                      .map(_pickerItem)
-                      .toList(),
+                  children: List.generate(this.widget.pillSheetTotalCount + 1,
+                      (index) {
+                    if (index == 0) {
+                      return "-";
+                    }
+                    return "$index";
+                  }).map(_pickerItem).toList(),
                   onSelectedItemChanged: (index) {
-                    keepSelectedFromMenstruation = index + 1;
+                    keepSelectedFromMenstruation = index;
                   },
                   scrollController: FixedExtentScrollController(
-                      initialItem: keepSelectedFromMenstruation - 1),
+                      initialItem: keepSelectedFromMenstruation),
                 ),
               ),
             ),
@@ -289,10 +307,10 @@ class _SettingMenstruationPageState extends State<SettingMenstruationPage> {
                       .map(_pickerItem)
                       .toList(),
                   onSelectedItemChanged: (index) {
-                    keepSelectedDurationMenstruation = index + 1;
+                    keepSelectedDurationMenstruation = index;
                   },
                   scrollController: FixedExtentScrollController(
-                      initialItem: keepSelectedDurationMenstruation - 1),
+                      initialItem: keepSelectedDurationMenstruation),
                 ),
               ),
             ),

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -185,34 +185,21 @@ class MenstruationCardList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final cardState = store.cardState();
+    final historyCardState = store.historyCardState();
     return Container(
       color: PilllColors.background,
-      child: ListView.builder(
-        padding: EdgeInsets.only(top: 16),
-        itemCount: store.cardCount,
+      child: ListView(
+        padding: EdgeInsets.only(top: 16, left: 16, right: 16),
         scrollDirection: Axis.vertical,
-        itemBuilder: (context, index) {
-          final body = () {
-            switch (index) {
-              case 0:
-                final cardState = store.cardState();
-                if (cardState == null) {
-                  return Container();
-                }
-                return MenstruationCard(cardState);
-              case 1:
-                final cardState = store.historyCardState();
-                if (cardState == null) {
-                  return Container();
-                }
-                return MenstruationHistoryCard(state: cardState);
-            }
-          };
-
-          return Padding(
-              padding: EdgeInsets.only(left: 16, right: 16, bottom: 24),
-              child: body());
-        },
+        children: [
+          if (cardState != null) ...[
+            MenstruationCard(cardState),
+            SizedBox(height: 24),
+          ],
+          if (historyCardState != null)
+            MenstruationHistoryCard(state: historyCardState),
+        ],
       ),
     );
   }

--- a/lib/domain/menstruation/menstruation_store.dart
+++ b/lib/domain/menstruation/menstruation_store.dart
@@ -138,18 +138,6 @@ class MenstruationStore extends StateNotifier<MenstruationState> {
     return menstruationService.create(menstruation);
   }
 
-  int get cardCount {
-    final card = cardState();
-    if (card == null) {
-      return 0;
-    }
-    final historyCard = historyCardState();
-    if (historyCard == null) {
-      return [card].length;
-    }
-    return [card, historyCard].length;
-  }
-
   MenstruationCardState? cardState() {
     final latestMenstruation = state.latestMenstruation;
     if (latestMenstruation != null &&

--- a/lib/domain/menstruation/menstruation_store.dart
+++ b/lib/domain/menstruation/menstruation_store.dart
@@ -149,6 +149,9 @@ class MenstruationStore extends StateNotifier<MenstruationState> {
     if (latestPillSheet == null || setting == null) {
       return null;
     }
+    if (setting.pillNumberForFromMenstruation == 0) {
+      return null;
+    }
 
     final menstruationDateRanges = scheduledMenstruationDateRanges(
         latestPillSheet, setting, state.entities, 12);

--- a/lib/domain/menstruation/menstruation_store.dart
+++ b/lib/domain/menstruation/menstruation_store.dart
@@ -149,7 +149,8 @@ class MenstruationStore extends StateNotifier<MenstruationState> {
     if (latestPillSheet == null || setting == null) {
       return null;
     }
-    if (setting.pillNumberForFromMenstruation == 0) {
+    if (setting.pillNumberForFromMenstruation == 0 ||
+        setting.durationMenstruation == 0) {
       return null;
     }
 


### PR DESCRIPTION
## What
- 生理開始予定日と生理期間の指定で `0` を使用していたがこれを `-` に変更
  - 内部的には数字の0扱い。とりあえずの突貫対応
- ~生理開始予定日が `-` の場合は生理ページの生理予定日のカードを表示しない~
  - 生理開始予定日 or 生理期間が `-` の場合は生理予定日のカードを表示しない
  - 生理期間が `-` の場合もカレンダー上に表示できるものが無いと気づいたので、難しく考えずに生理予定日のカードごと隠すことにした

## Links
ref: https://github.com/bannzai/Pilll/pull/322