### PR TITLE
Fix pill sheet modified history

### DIFF
--- a/lib/components/atoms/buttons.dart
+++ b/lib/components/atoms/buttons.dart
@@ -1,5 +1,6 @@
 import 'package:pilll/components/atoms/button.dart';
 import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:flutter/material.dart';
 
@@ -92,6 +93,45 @@ class InconspicuousButton extends StatelessWidget {
         child: Text(text, style: TextColorStyle.gray),
         onPressed: onPressed,
       ),
+    );
+  }
+}
+
+class PrimaryOutlinedButton extends StatelessWidget {
+  final String text;
+  final VoidCallback? onPressed;
+
+  const PrimaryOutlinedButton({
+    Key? key,
+    required this.onPressed,
+    required this.text,
+  }) : super(key: key);
+
+  Widget build(BuildContext context) {
+    return OutlinedButton(
+      child: Container(
+        width: 204,
+        padding: EdgeInsets.only(top: 12, bottom: 12),
+        child: Center(
+          child: Text(
+            text,
+            style: TextStyle(
+              color: TextColor.main,
+              fontSize: 16,
+              fontFamily: FontFamily.japanese,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+      ),
+      style: OutlinedButton.styleFrom(
+        primary: PilllColors.secondary,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(6),
+        ),
+        side: BorderSide(color: PilllColors.secondary),
+      ),
+      onPressed: onPressed,
     );
   }
 }

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_automatically_recorded_last_taken_date_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_automatically_recorded_last_taken_date_action.dart
@@ -27,7 +27,6 @@ class PillSheetModifiedHistoryAutomaticallyRecordedLastTakenDateAction
       child: Padding(
         padding: const EdgeInsets.only(top: 4, bottom: 4),
         child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             PillSheetModifiedHistoryDate(
               estimatedEventCausingDate: estimatedEventCausingDate,

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_changed_pill_number_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_changed_pill_number_action.dart
@@ -23,7 +23,6 @@ class PillSheetModifiedHistoryChangedPillNumberAction extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.only(top: 4, bottom: 4),
         child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             PillSheetModifiedHistoryDate(
               estimatedEventCausingDate: estimatedEventCausingDate,

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_changed_pill_number_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_changed_pill_number_action.dart
@@ -41,7 +41,7 @@ class PillSheetModifiedHistoryChangedPillNumberAction extends StatelessWidget {
                       "ピル番号変更",
                       style: TextStyle(
                         color: TextColor.main,
-                        fontSize: 14,
+                        fontSize: 12,
                         fontFamily: FontFamily.japanese,
                         fontWeight: FontWeight.w400,
                       ),

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_created_pill_sheet_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_created_pill_sheet_action.dart
@@ -36,7 +36,7 @@ class PillSheetModifiedHistoryCreatePillSheetAction extends StatelessWidget {
                       "ピルシート追加",
                       style: TextStyle(
                         color: TextColor.main,
-                        fontSize: 14,
+                        fontSize: 12,
                         fontFamily: FontFamily.japanese,
                         fontWeight: FontWeight.w400,
                       ),

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_created_pill_sheet_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_created_pill_sheet_action.dart
@@ -19,7 +19,6 @@ class PillSheetModifiedHistoryCreatePillSheetAction extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.only(top: 4, bottom: 4),
         child: Row(
-          mainAxisAlignment: MainAxisAlignment.start,
           children: [
             PillSheetModifiedHistoryDate(
               estimatedEventCausingDate: estimatedEventCausingDate,

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_date_component.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_date_component.dart
@@ -7,7 +7,7 @@ import 'package:pilll/entity/weekday.dart';
 
 abstract class PillSheetModifiedHistoryTakenActionLayoutWidths {
   static final double leading = 150;
-  static final double trailing = 150;
+  static final double trailing = 140;
   static final double takenTime = 53;
   static final double takenMark = 61;
   static final double actionDescription = 100;

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_date_component.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_date_component.dart
@@ -8,9 +8,8 @@ import 'package:pilll/entity/weekday.dart';
 abstract class PillSheetModifiedHistoryTakenActionLayoutWidths {
   static final double leading = 150;
   static final double trailing = 140;
-  static final double takenTime = 53;
-  static final double takenMark = 61;
-  static final double actionDescription = 100;
+  static final double takenTime = 60;
+  static final double takenMark = 60;
 }
 
 class PillSheetModifiedHistoryDate extends StatelessWidget {
@@ -73,7 +72,7 @@ class PillSheetModifiedHistoryDate extends StatelessWidget {
           ),
           SizedBox(width: 16),
           Container(
-            width: 50,
+            width: 53,
             child: Text(
               "$effectivePillNumber",
               style: TextStyle(

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_date_component.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_date_component.dart
@@ -117,5 +117,5 @@ extension PillSheetModifiedHistoryDateEffectivePillNumber
   }
 
   static String changed(ChangedPillNumberValue value) =>
-      "${value.beforeLastTakenPillNumber}→${value.afterLastTakenPillNumber}番";
+      "${value.beforeTodayPillNumber}→${value.afterTodayPillNumber}番";
 }

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_deleted_pill_sheet_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_deleted_pill_sheet_action.dart
@@ -36,7 +36,7 @@ class PillSheetModifiedHistoryDeletedPillSheetAction extends StatelessWidget {
                       "ピルシート破棄",
                       style: TextStyle(
                         color: TextColor.main,
-                        fontSize: 14,
+                        fontSize: 12,
                         fontFamily: FontFamily.japanese,
                         fontWeight: FontWeight.w400,
                       ),

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_deleted_pill_sheet_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_deleted_pill_sheet_action.dart
@@ -19,7 +19,6 @@ class PillSheetModifiedHistoryDeletedPillSheetAction extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.only(top: 4, bottom: 4),
         child: Row(
-          mainAxisAlignment: MainAxisAlignment.start,
           children: [
             PillSheetModifiedHistoryDate(
               estimatedEventCausingDate: estimatedEventCausingDate,

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_revert_taken_pill_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_revert_taken_pill_action.dart
@@ -39,7 +39,7 @@ class PillSheetModifiedHistoryRevertTakenPillAction extends StatelessWidget {
                       "服用取り消し",
                       style: TextStyle(
                         color: TextColor.main,
-                        fontSize: 14,
+                        fontSize: 12,
                         fontFamily: FontFamily.japanese,
                         fontWeight: FontWeight.w400,
                       ),

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_taken_pill_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_taken_pill_action.dart
@@ -66,11 +66,8 @@ class PillSheetModifiedHistoryTakenPillAction extends StatelessWidget {
                     ),
                     Spacer(),
                     Container(
-                      constraints: BoxConstraints(
-                        maxWidth:
-                            PillSheetModifiedHistoryTakenActionLayoutWidths
-                                .takenMark,
-                      ),
+                      width: PillSheetModifiedHistoryTakenActionLayoutWidths
+                          .takenMark,
                       padding: EdgeInsets.only(left: 8),
                       child: TakenPillActionOList(
                           value: value, afterPillSheet: afterPillSheet),

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_taken_pill_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_taken_pill_action.dart
@@ -55,6 +55,7 @@ class PillSheetModifiedHistoryTakenPillAction extends StatelessWidget {
                       child: Text(
                         time,
                         style: TextStyle(
+                          letterSpacing: 1.5,
                           color: TextColor.main,
                           fontSize: 15,
                           fontFamily: FontFamily.number,

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_taken_pill_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_taken_pill_action.dart
@@ -65,8 +65,11 @@ class PillSheetModifiedHistoryTakenPillAction extends StatelessWidget {
                     ),
                     Spacer(),
                     Container(
-                      width: PillSheetModifiedHistoryTakenActionLayoutWidths
-                          .takenMark,
+                      constraints: BoxConstraints(
+                        maxWidth:
+                            PillSheetModifiedHistoryTakenActionLayoutWidths
+                                .takenMark,
+                      ),
                       padding: EdgeInsets.only(left: 8),
                       child: TakenPillActionOList(
                           value: value, afterPillSheet: afterPillSheet),

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_taken_pill_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_taken_pill_action.dart
@@ -55,7 +55,6 @@ class PillSheetModifiedHistoryTakenPillAction extends StatelessWidget {
                       child: Text(
                         time,
                         style: TextStyle(
-                          decoration: TextDecoration.underline,
                           color: TextColor.main,
                           fontSize: 15,
                           fontFamily: FontFamily.number,

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/taken_pill_action_o_list.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/taken_pill_action_o_list.dart
@@ -24,7 +24,7 @@ class TakenPillActionOList extends StatelessWidget {
       child: Row(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
-          children: List.generate(count, (index) {
+          children: List.generate(min(count, 4), (index) {
             final inRestDuration = _inRestDuration(
                 afterPillSheet, value.afterLastTakenPillNumber, index);
             if (index == 0) {

--- a/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart
@@ -64,7 +64,7 @@ class CalendarPillSheetModifiedHistoryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return AppCard(
       child: Container(
-        padding: EdgeInsets.only(left: 16, top: 16, right: 16, bottom: 32),
+        padding: EdgeInsets.only(left: 16, top: 16, right: 16, bottom: 16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart
@@ -79,8 +79,10 @@ class CalendarPillSheetModifiedHistoryCard extends StatelessWidget {
                     color: TextColor.main,
                   ),
                 ),
-                SizedBox(width: 8),
-                PremiumBadge(),
+                if (!state.isPremium) ...[
+                  SizedBox(width: 8),
+                  PremiumBadge(),
+                ],
               ],
             ),
             SizedBox(height: 16),

--- a/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:pilll/components/atoms/buttons.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/app_card.dart';
@@ -105,47 +106,65 @@ class CalendarPillSheetModifiedHistoryCard extends StatelessWidget {
                 ];
               } else {
                 return [
-                  GestureDetector(
-                    onTap: () {
-                      if (state.trialDeadlineDate == null) {
-                        showPremiumTrialModal(context, () {
-                          showPremiumTrialCompleteModalPreDialog(context);
-                        });
-                      } else {
-                        showPremiumIntroductionSheet(context);
-                      }
-                    },
-                    child: Stack(
-                      children: [
-                        Container(
-                          padding: const EdgeInsets.only(left: 8, right: 8),
-                          child: CalendarPillSheetModifiedHistoryList(
-                            padding: null,
-                            scrollPhysics: NeverScrollableScrollPhysics(),
-                            pillSheetModifiedHistories:
-                                state.pillSheetModifiedHistories,
-                          ),
+                  Stack(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.only(left: 8, right: 8),
+                        child: CalendarPillSheetModifiedHistoryList(
+                          padding: null,
+                          scrollPhysics: NeverScrollableScrollPhysics(),
+                          pillSheetModifiedHistories:
+                              state.pillSheetModifiedHistories,
                         ),
-                        Positioned.fill(
-                          child: ClipRect(
-                            child: Stack(
-                              children: [
-                                BackdropFilter(
-                                  filter:
-                                      ImageFilter.blur(sigmaX: 6, sigmaY: 6),
-                                  child: Container(
-                                    color: Colors.black.withOpacity(0),
-                                  ),
+                      ),
+                      Positioned.fill(
+                        child: ClipRect(
+                          child: Stack(
+                            children: [
+                              BackdropFilter(
+                                filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+                                child: Container(
+                                  color: Colors.black.withOpacity(0),
                                 ),
-                                Center(
-                                    child: Text(lockEmoji,
-                                        style: TextStyle(fontSize: 40))),
-                              ],
-                            ),
+                              ),
+                              Center(
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(lockEmoji,
+                                        style: TextStyle(fontSize: 40)),
+                                    SizedBox(height: 12),
+                                    Text(
+                                      "服用履歴はプレミアム機能です",
+                                      style: TextStyle(
+                                        color: TextColor.main,
+                                        fontSize: 14,
+                                        fontFamily: FontFamily.japanese,
+                                        fontWeight: FontWeight.w400,
+                                      ),
+                                    ),
+                                    SizedBox(height: 15),
+                                    PrimaryOutlinedButton(
+                                      text: "くわしくみる",
+                                      onPressed: () {
+                                        if (state.trialDeadlineDate == null) {
+                                          showPremiumTrialModal(context, () {
+                                            showPremiumTrialCompleteModalPreDialog(
+                                                context);
+                                          });
+                                        } else {
+                                          showPremiumIntroductionSheet(context);
+                                        }
+                                      },
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
                           ),
                         ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
                 ];
               }

--- a/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart
@@ -64,7 +64,7 @@ class CalendarPillSheetModifiedHistoryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return AppCard(
       child: Container(
-        padding: EdgeInsets.only(left: 16, top: 16, right: 16),
+        padding: EdgeInsets.only(left: 16, top: 16, right: 16, bottom: 32),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_list_header.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_list_header.dart
@@ -11,7 +11,7 @@ class PillSheetModifiedHisotiryListHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.only(right: 8),
+      padding: const EdgeInsets.only(right: 12),
       child: Row(
         children: [
           SizedBox(

--- a/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_list_header.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_list_header.dart
@@ -23,8 +23,7 @@ class PillSheetModifiedHisotiryListHeader extends StatelessWidget {
             child: Row(
               children: [
                 Container(
-                  width:
-                      PillSheetModifiedHistoryTakenActionLayoutWidths.takenMark,
+                  width: 55,
                   child: Text(
                     "服用時間",
                     style: TextStyle(
@@ -33,7 +32,7 @@ class PillSheetModifiedHisotiryListHeader extends StatelessWidget {
                       fontSize: 12,
                       fontWeight: FontWeight.w400,
                     ),
-                    textAlign: TextAlign.start,
+                    textAlign: TextAlign.center,
                   ),
                 ),
                 Spacer(),

--- a/lib/domain/modal/release_note.dart
+++ b/lib/domain/modal/release_note.dart
@@ -42,7 +42,7 @@ class ReleaseNote extends StatelessWidget {
                       child: Container(
                         padding: EdgeInsets.only(top: 40, left: 40, right: 40),
                         child: Text(
-                          "通知から服用記録ができるようになりました！",
+                          "服用履歴で\nいつ服用したかが分かる",
                           style: FontType.subTitle.merge(TextColorStyle.black),
                           textAlign: TextAlign.center,
                         ),
@@ -57,7 +57,7 @@ class ReleaseNote extends StatelessWidget {
                     children: [
                       Text(
                         '''
-Apple Watchからも服用記録ができます。
+服用時刻やまとめて服用した日が分かるようになりました。
 その他にも新機能が続々登場！
                         ''',
                         style: FontType.assisting.merge(TextColorStyle.main),
@@ -65,7 +65,6 @@ Apple Watchからも服用記録ができます。
                     ],
                   ),
                 ),
-                SizedBox(height: 20),
                 Container(
                   width: 230,
                   child: SecondaryButton(
@@ -87,7 +86,7 @@ Apple Watchからも服用記録ができます。
 }
 
 showReleaseNotePreDialog(BuildContext context) async {
-  final key = ReleaseNoteKey.version3_1_0;
+  final key = ReleaseNoteKey.version3_2_0;
   final storage = await SharedPreferences.getInstance();
   if (storage.getBool(key) ?? false) {
     return;
@@ -105,7 +104,7 @@ openReleaseNote() async {
   final ChromeSafariBrowser browser = new ChromeSafariBrowser();
   await browser.open(
       url: Uri.parse(
-          "https://pilll.anotion.so/8cfba3bf53f04df08bf45f7265c5e423"),
+          "https://pilll.anotion.so/5dcbbb397703462ba8021412a3ff1b50"),
       options: ChromeSafariBrowserClassOptions(
           android:
               AndroidChromeCustomTabsOptions(addDefaultShareMenuItem: false),

--- a/lib/domain/pill_sheet_modified_history/pill_sheet_modified_history_page.dart
+++ b/lib/domain/pill_sheet_modified_history/pill_sheet_modified_history_page.dart
@@ -27,7 +27,7 @@ class PillSheetModifiedHistoriesPage extends HookWidget {
         ),
         title: Text(
           "服用履歴",
-          style: TextStyle(color: TextColor.black),
+          style: TextStyle(color: TextColor.main),
         ),
         centerTitle: false,
         backgroundColor: PilllColors.white,

--- a/lib/domain/pill_sheet_modified_history/pill_sheet_modified_history_page.dart
+++ b/lib/domain/pill_sheet_modified_history/pill_sheet_modified_history_page.dart
@@ -29,6 +29,7 @@ class PillSheetModifiedHistoriesPage extends HookWidget {
           "服用履歴",
           style: TextStyle(color: TextColor.black),
         ),
+        centerTitle: false,
         backgroundColor: PilllColors.white,
       ),
       body: SafeArea(

--- a/lib/entity/pill_sheet_modified_history_value.dart
+++ b/lib/entity/pill_sheet_modified_history_value.dart
@@ -158,8 +158,8 @@ abstract class ChangedPillNumberValue implements _$ChangedPillNumberValue {
       toJson: NonNullTimestampConverter.dateTimeToTimestamp,
     )
         required DateTime afterBeginingDate,
-    required int beforeLastTakenPillNumber,
-    required int afterLastTakenPillNumber,
+    required int beforeTodayPillNumber,
+    required int afterTodayPillNumber,
   }) = _ChangedPillNumberValue;
 
   factory ChangedPillNumberValue.fromJson(Map<String, dynamic> json) =>

--- a/lib/entity/pill_sheet_modified_history_value.freezed.dart
+++ b/lib/entity/pill_sheet_modified_history_value.freezed.dart
@@ -1667,13 +1667,13 @@ class _$ChangedPillNumberValueTearOff {
           required DateTime beforeBeginingDate,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
           required DateTime afterBeginingDate,
-      required int beforeLastTakenPillNumber,
-      required int afterLastTakenPillNumber}) {
+      required int beforeTodayPillNumber,
+      required int afterTodayPillNumber}) {
     return _ChangedPillNumberValue(
       beforeBeginingDate: beforeBeginingDate,
       afterBeginingDate: afterBeginingDate,
-      beforeLastTakenPillNumber: beforeLastTakenPillNumber,
-      afterLastTakenPillNumber: afterLastTakenPillNumber,
+      beforeTodayPillNumber: beforeTodayPillNumber,
+      afterTodayPillNumber: afterTodayPillNumber,
     );
   }
 
@@ -1695,8 +1695,8 @@ mixin _$ChangedPillNumberValue {
       fromJson: NonNullTimestampConverter.timestampToDateTime,
       toJson: NonNullTimestampConverter.dateTimeToTimestamp)
   DateTime get afterBeginingDate => throw _privateConstructorUsedError;
-  int get beforeLastTakenPillNumber => throw _privateConstructorUsedError;
-  int get afterLastTakenPillNumber => throw _privateConstructorUsedError;
+  int get beforeTodayPillNumber => throw _privateConstructorUsedError;
+  int get afterTodayPillNumber => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -1714,8 +1714,8 @@ abstract class $ChangedPillNumberValueCopyWith<$Res> {
           DateTime beforeBeginingDate,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
           DateTime afterBeginingDate,
-      int beforeLastTakenPillNumber,
-      int afterLastTakenPillNumber});
+      int beforeTodayPillNumber,
+      int afterTodayPillNumber});
 }
 
 /// @nodoc
@@ -1731,8 +1731,8 @@ class _$ChangedPillNumberValueCopyWithImpl<$Res>
   $Res call({
     Object? beforeBeginingDate = freezed,
     Object? afterBeginingDate = freezed,
-    Object? beforeLastTakenPillNumber = freezed,
-    Object? afterLastTakenPillNumber = freezed,
+    Object? beforeTodayPillNumber = freezed,
+    Object? afterTodayPillNumber = freezed,
   }) {
     return _then(_value.copyWith(
       beforeBeginingDate: beforeBeginingDate == freezed
@@ -1743,13 +1743,13 @@ class _$ChangedPillNumberValueCopyWithImpl<$Res>
           ? _value.afterBeginingDate
           : afterBeginingDate // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      beforeLastTakenPillNumber: beforeLastTakenPillNumber == freezed
-          ? _value.beforeLastTakenPillNumber
-          : beforeLastTakenPillNumber // ignore: cast_nullable_to_non_nullable
+      beforeTodayPillNumber: beforeTodayPillNumber == freezed
+          ? _value.beforeTodayPillNumber
+          : beforeTodayPillNumber // ignore: cast_nullable_to_non_nullable
               as int,
-      afterLastTakenPillNumber: afterLastTakenPillNumber == freezed
-          ? _value.afterLastTakenPillNumber
-          : afterLastTakenPillNumber // ignore: cast_nullable_to_non_nullable
+      afterTodayPillNumber: afterTodayPillNumber == freezed
+          ? _value.afterTodayPillNumber
+          : afterTodayPillNumber // ignore: cast_nullable_to_non_nullable
               as int,
     ));
   }
@@ -1767,8 +1767,8 @@ abstract class _$ChangedPillNumberValueCopyWith<$Res>
           DateTime beforeBeginingDate,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
           DateTime afterBeginingDate,
-      int beforeLastTakenPillNumber,
-      int afterLastTakenPillNumber});
+      int beforeTodayPillNumber,
+      int afterTodayPillNumber});
 }
 
 /// @nodoc
@@ -1786,8 +1786,8 @@ class __$ChangedPillNumberValueCopyWithImpl<$Res>
   $Res call({
     Object? beforeBeginingDate = freezed,
     Object? afterBeginingDate = freezed,
-    Object? beforeLastTakenPillNumber = freezed,
-    Object? afterLastTakenPillNumber = freezed,
+    Object? beforeTodayPillNumber = freezed,
+    Object? afterTodayPillNumber = freezed,
   }) {
     return _then(_ChangedPillNumberValue(
       beforeBeginingDate: beforeBeginingDate == freezed
@@ -1798,13 +1798,13 @@ class __$ChangedPillNumberValueCopyWithImpl<$Res>
           ? _value.afterBeginingDate
           : afterBeginingDate // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      beforeLastTakenPillNumber: beforeLastTakenPillNumber == freezed
-          ? _value.beforeLastTakenPillNumber
-          : beforeLastTakenPillNumber // ignore: cast_nullable_to_non_nullable
+      beforeTodayPillNumber: beforeTodayPillNumber == freezed
+          ? _value.beforeTodayPillNumber
+          : beforeTodayPillNumber // ignore: cast_nullable_to_non_nullable
               as int,
-      afterLastTakenPillNumber: afterLastTakenPillNumber == freezed
-          ? _value.afterLastTakenPillNumber
-          : afterLastTakenPillNumber // ignore: cast_nullable_to_non_nullable
+      afterTodayPillNumber: afterTodayPillNumber == freezed
+          ? _value.afterTodayPillNumber
+          : afterTodayPillNumber // ignore: cast_nullable_to_non_nullable
               as int,
     ));
   }
@@ -1819,8 +1819,8 @@ class _$_ChangedPillNumberValue extends _ChangedPillNumberValue {
           required this.beforeBeginingDate,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
           required this.afterBeginingDate,
-      required this.beforeLastTakenPillNumber,
-      required this.afterLastTakenPillNumber})
+      required this.beforeTodayPillNumber,
+      required this.afterTodayPillNumber})
       : super._();
 
   factory _$_ChangedPillNumberValue.fromJson(Map<String, dynamic> json) =>
@@ -1837,13 +1837,13 @@ class _$_ChangedPillNumberValue extends _ChangedPillNumberValue {
       toJson: NonNullTimestampConverter.dateTimeToTimestamp)
   final DateTime afterBeginingDate;
   @override
-  final int beforeLastTakenPillNumber;
+  final int beforeTodayPillNumber;
   @override
-  final int afterLastTakenPillNumber;
+  final int afterTodayPillNumber;
 
   @override
   String toString() {
-    return 'ChangedPillNumberValue(beforeBeginingDate: $beforeBeginingDate, afterBeginingDate: $afterBeginingDate, beforeLastTakenPillNumber: $beforeLastTakenPillNumber, afterLastTakenPillNumber: $afterLastTakenPillNumber)';
+    return 'ChangedPillNumberValue(beforeBeginingDate: $beforeBeginingDate, afterBeginingDate: $afterBeginingDate, beforeTodayPillNumber: $beforeTodayPillNumber, afterTodayPillNumber: $afterTodayPillNumber)';
   }
 
   @override
@@ -1856,15 +1856,12 @@ class _$_ChangedPillNumberValue extends _ChangedPillNumberValue {
             (identical(other.afterBeginingDate, afterBeginingDate) ||
                 const DeepCollectionEquality()
                     .equals(other.afterBeginingDate, afterBeginingDate)) &&
-            (identical(other.beforeLastTakenPillNumber,
-                    beforeLastTakenPillNumber) ||
+            (identical(other.beforeTodayPillNumber, beforeTodayPillNumber) ||
                 const DeepCollectionEquality().equals(
-                    other.beforeLastTakenPillNumber,
-                    beforeLastTakenPillNumber)) &&
-            (identical(
-                    other.afterLastTakenPillNumber, afterLastTakenPillNumber) ||
-                const DeepCollectionEquality().equals(
-                    other.afterLastTakenPillNumber, afterLastTakenPillNumber)));
+                    other.beforeTodayPillNumber, beforeTodayPillNumber)) &&
+            (identical(other.afterTodayPillNumber, afterTodayPillNumber) ||
+                const DeepCollectionEquality()
+                    .equals(other.afterTodayPillNumber, afterTodayPillNumber)));
   }
 
   @override
@@ -1872,8 +1869,8 @@ class _$_ChangedPillNumberValue extends _ChangedPillNumberValue {
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(beforeBeginingDate) ^
       const DeepCollectionEquality().hash(afterBeginingDate) ^
-      const DeepCollectionEquality().hash(beforeLastTakenPillNumber) ^
-      const DeepCollectionEquality().hash(afterLastTakenPillNumber);
+      const DeepCollectionEquality().hash(beforeTodayPillNumber) ^
+      const DeepCollectionEquality().hash(afterTodayPillNumber);
 
   @JsonKey(ignore: true)
   @override
@@ -1893,8 +1890,8 @@ abstract class _ChangedPillNumberValue extends ChangedPillNumberValue {
           required DateTime beforeBeginingDate,
       @JsonKey(fromJson: NonNullTimestampConverter.timestampToDateTime, toJson: NonNullTimestampConverter.dateTimeToTimestamp)
           required DateTime afterBeginingDate,
-      required int beforeLastTakenPillNumber,
-      required int afterLastTakenPillNumber}) = _$_ChangedPillNumberValue;
+      required int beforeTodayPillNumber,
+      required int afterTodayPillNumber}) = _$_ChangedPillNumberValue;
   _ChangedPillNumberValue._() : super._();
 
   factory _ChangedPillNumberValue.fromJson(Map<String, dynamic> json) =
@@ -1911,9 +1908,9 @@ abstract class _ChangedPillNumberValue extends ChangedPillNumberValue {
       toJson: NonNullTimestampConverter.dateTimeToTimestamp)
   DateTime get afterBeginingDate => throw _privateConstructorUsedError;
   @override
-  int get beforeLastTakenPillNumber => throw _privateConstructorUsedError;
+  int get beforeTodayPillNumber => throw _privateConstructorUsedError;
   @override
-  int get afterLastTakenPillNumber => throw _privateConstructorUsedError;
+  int get afterTodayPillNumber => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
   _$ChangedPillNumberValueCopyWith<_ChangedPillNumberValue> get copyWith =>

--- a/lib/entity/pill_sheet_modified_history_value.g.dart
+++ b/lib/entity/pill_sheet_modified_history_value.g.dart
@@ -163,8 +163,8 @@ _$_ChangedPillNumberValue _$_$_ChangedPillNumberValueFromJson(
         json['beforeBeginingDate'] as Timestamp),
     afterBeginingDate: NonNullTimestampConverter.timestampToDateTime(
         json['afterBeginingDate'] as Timestamp),
-    beforeLastTakenPillNumber: json['beforeLastTakenPillNumber'] as int,
-    afterLastTakenPillNumber: json['afterLastTakenPillNumber'] as int,
+    beforeTodayPillNumber: json['beforeTodayPillNumber'] as int,
+    afterTodayPillNumber: json['afterTodayPillNumber'] as int,
   );
 }
 
@@ -175,8 +175,8 @@ Map<String, dynamic> _$_$_ChangedPillNumberValueToJson(
           instance.beforeBeginingDate),
       'afterBeginingDate': NonNullTimestampConverter.dateTimeToTimestamp(
           instance.afterBeginingDate),
-      'beforeLastTakenPillNumber': instance.beforeLastTakenPillNumber,
-      'afterLastTakenPillNumber': instance.afterLastTakenPillNumber,
+      'beforeTodayPillNumber': instance.beforeTodayPillNumber,
+      'afterTodayPillNumber': instance.afterTodayPillNumber,
     };
 
 _$_EndedPillSheetValue _$_$_EndedPillSheetValueFromJson(

--- a/lib/service/pill_sheet_modified_history.dart
+++ b/lib/service/pill_sheet_modified_history.dart
@@ -174,8 +174,7 @@ extension PillSheetModifiedHistoryServiceActionFactory
     required PillSheet after,
   }) {
     final afterID = after.id;
-    final afterLastTakenDate = after.lastTakenDate;
-    if (afterID == null || afterLastTakenDate == null) {
+    if (afterID == null) {
       throw FormatException(
           "unexpected after pill sheet id or lastTakenDate is null id: ${after.id}, lastTakenDate: ${after.lastTakenDate} for changedPillNumber action");
     }
@@ -183,10 +182,11 @@ extension PillSheetModifiedHistoryServiceActionFactory
       actionType: PillSheetModifiedActionType.changedPillNumber,
       value: PillSheetModifiedHistoryValue(
         changedPillNumber: ChangedPillNumberValue(
-            afterBeginingDate: after.beginingDate,
-            beforeBeginingDate: before.beginingDate,
-            afterLastTakenPillNumber: after.lastTakenPillNumber,
-            beforeLastTakenPillNumber: before.lastTakenPillNumber),
+          afterBeginingDate: after.beginingDate,
+          beforeBeginingDate: before.beginingDate,
+          afterLastTakenPillNumber: after.lastTakenPillNumber,
+          beforeLastTakenPillNumber: before.lastTakenPillNumber,
+        ),
       ),
       after: after,
       pillSheetID: afterID,

--- a/lib/service/pill_sheet_modified_history.dart
+++ b/lib/service/pill_sheet_modified_history.dart
@@ -184,8 +184,8 @@ extension PillSheetModifiedHistoryServiceActionFactory
         changedPillNumber: ChangedPillNumberValue(
           afterBeginingDate: after.beginingDate,
           beforeBeginingDate: before.beginingDate,
-          afterLastTakenPillNumber: after.lastTakenPillNumber,
-          beforeLastTakenPillNumber: before.lastTakenPillNumber,
+          afterTodayPillNumber: after.todayPillNumber,
+          beforeTodayPillNumber: before.todayPillNumber,
         ),
       ),
       after: after,

--- a/lib/util/shared_preference/keys.dart
+++ b/lib/util/shared_preference/keys.dart
@@ -25,6 +25,7 @@ extension ReleaseNoteKey on String {
   static final String version2_4_0 = "release_notes_shown_2.4.0";
   static final String version3_0_0 = "release_notes_shown_3.0.0";
   static final String version3_1_0 = "release_notes_shown_3.1.0";
+  static final String version3_2_0 = "release_notes_shown_3.2.0";
 }
 
 extension IntKey on String {


### PR DESCRIPTION
## What
バグ修正
- 記録画面から、まだ未服用のピルシートの場合に番号変更ができなかった
  - 最後に飲んだ日をもとにguardしていたが不要だったので削除
  - 最後に飲んだ日付じゃなくて今日飲んだ日付に変更
- デザイン調整
- Release note 追加