### PR TITLE
:bug: missing before number

### DIFF
--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_date_component.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_date_component.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
@@ -99,7 +101,7 @@ extension PillSheetModifiedHistoryDateEffectivePillNumber
     if (before == (after - 1)) {
       return "$after番";
     }
-    return "$before-$after番";
+    return "${max(before, 1)}-$after番";
   }
 
   static String autoTaken(AutomaticallyRecordedLastTakenDateValue value) {


### PR DESCRIPTION
## Abstract
以下の手順で再現する不具合を見つけた
ピルシートの 破棄=>作成=>番号変更=>飲んだ=>履歴が 0-x の表記になる
原因が最後に飲んだ日を出しているが、最後に飲んだ日がない状態で複数服用した場合に左側の値に0が入るため