### PR TITLE
:Remove unnecessary option

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -55,16 +55,14 @@ extension AppDelegate {
 
     func configureNotificationActionableButtons() {
         let recordAction = UNNotificationAction(identifier: "RECORD_PILL",
-                                                title: "飲んだ",
-                                                options: UNNotificationActionOptions(rawValue: 0))
+                                                title: "飲んだ")
         let category =
             UNNotificationCategory(identifier: Category.pillReminder.rawValue,
                                    actions: [recordAction],
                                    intentIdentifiers: [],
                                    hiddenPreviewsBodyPlaceholder: "",
                                    options: .customDismissAction)
-        let notificationCenter = UNUserNotificationCenter.current()
-        notificationCenter.setNotificationCategories([category])
+        UNUserNotificationCenter.current().setNotificationCategories([category])
     }
 
     @objc func userNotificationCenter_methodSwizzling(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
@@ -86,6 +84,7 @@ extension AppDelegate {
                 }
             }
         }
+
         switch extractCategory(userInfo: response.notification.request.content.userInfo) {
         case nil:
             return


### PR DESCRIPTION
## Abstract
UNNotificationCategoryに設定するOptionを .none の意味を含めて .init(rawValue: 0) にしていたが(公式サンプルがそうなっていた)、もともとのデフォルトの引数が [] になっていたのでそれを使うことにした

## Why
クイックレコードが効かないユーザーが出てきているので原因調査

なお手元では不具合の再現はしないので、直っているかは不明