### PR TITLE
Remove connectivity

### DIFF
--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -1,4 +1,3 @@
-import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:pilll/analytics.dart';
 import 'package:pilll/entrypoint.dart';
 import 'package:pilll/service/auth.dart';

--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -92,14 +92,6 @@ class RootState extends State<Root> {
   }
 
   _auth() async {
-    final connectivityResult = await (Connectivity().checkConnectivity());
-    if (connectivityResult == ConnectivityResult.none) {
-      setState(() {
-        _error = FormatException(
-            "インターネットへの接続がされていません。通信環境をお確かめください。接続後「画面を再読み込み」の項目をタップしてください");
-      });
-      return;
-    }
     // No UI thread blocking
     final user = await callSignin();
     if (user != null) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -162,48 +162,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
-  connectivity_plus:
-    dependency: "direct main"
-    description:
-      name: connectivity_plus
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
-  connectivity_plus_linux:
-    dependency: transitive
-    description:
-      name: connectivity_plus_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
-  connectivity_plus_macos:
-    dependency: transitive
-    description:
-      name: connectivity_plus_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
-  connectivity_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: connectivity_plus_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
-  connectivity_plus_web:
-    dependency: transitive
-    description:
-      name: connectivity_plus_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0+1"
-  connectivity_plus_windows:
-    dependency: transitive
-    description:
-      name: connectivity_plus_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   convert:
     dependency: transitive
     description:
@@ -232,13 +190,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
-  dbus:
-    dependency: transitive
-    description:
-      name: dbus
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.6"
   dotted_border:
     dependency: "direct main"
     description:
@@ -604,13 +555,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.0.10"
-  nm:
-    dependency: transitive
-    description:
-      name: nm
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.0"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,6 @@ dependencies:
   sign_in_with_apple: ^3.0.0
   google_sign_in: ^5.0.4
   purchases_flutter: ^3.2.2
-  connectivity_plus: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Abstract
https://github.com/bannzai/Pilll/pull/338 で導入したConnectivityの使用をやめる。理由はユーザーのフィードバックで起動時に接続がされていそうだが、ConnectionResult.none な状態に陥る場面がありそうだから。

接続されていない(or接続が弱い)かったらIndicatorが出続けている状態にはなるが、まだそちらの方が推測できそうだし提供者側としても状況がわかりやすい