### PR TITLE
Write lastLoginVersion to stats

### DIFF
--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -187,9 +187,12 @@ class UserService {
 
   Future<void> saveStats() async {
     final store = await SharedPreferences.getInstance();
+
+    final lastLoginVersion =
+        await PackageInfo.fromPlatform().then((value) => value.version);
     String? beginingVersion = store.getString(StringKey.beginingVersionKey);
     if (beginingVersion == null) {
-      final v = await PackageInfo.fromPlatform().then((value) => value.version);
+      final v = lastLoginVersion;
       await store.setString(StringKey.beginingVersionKey, v);
       beginingVersion = v;
     }
@@ -202,6 +205,7 @@ class UserService {
       "stats": {
         "lastLoginAt": now,
         "beginingVersion": beginingVersion,
+        "lastLoginVersion": lastLoginVersion,
         "timeZoneName": timeZoneName,
         "timeZoneOffset":
             "${timeZoneOffset.isNegative ? "-" : "+"}${timeZoneOffset.inHours}",


### PR DESCRIPTION
## Abstract
Userが最後にログインしたバージョンを起動時に記録する

## Why
PillSheet => PillSheetGroupの移行のために、PillSheetのデータが変更されるたびにPillSheetGroupを裏側で作って記録していた。これは下位バージョンのユーザーがPillSheetGroupをアップデート後に速やかに使えるようにするため。あとBackendのスクリプト自体がPillSheetGroupがある前提で書き換えているので必要なことだった。

ただ、アップデート後のユーザーに対してまでこのスクリプトを実行する必要がないため、今回のリリースから記録される lastLoginVersion を元に PillSheet => PillSheetGroupのスクリプトを実行するかどうかを決めるようにする

ref: https://github.com/bannzai/PilllBackend/pull/116