### PR TITLE
Fix functions for PillSheetGroup

### DIFF
--- a/lib/components/organisms/calendar/utility.dart
+++ b/lib/components/organisms/calendar/utility.dart
@@ -29,14 +29,14 @@ List<DateRange> scheduledOrInTheMiddleMenstruationDateRanges(
       final pillSheet = pillSheetGroup.pillSheets[pageIndex];
       final pillSheetTypes =
           pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
-      final pastedCount = pastedTotalCount(
+      final passedCount = passedTotalCount(
           pillSheetTypes: pillSheetTypes, pageIndex: pageIndex);
-      final serializedPillNumber = pastedCount + pillSheet.typeInfo.totalCount;
+      final serializedPillNumber = passedCount + pillSheet.typeInfo.totalCount;
       if (serializedPillNumber < setting.pillNumberForFromMenstruation) {
         continue;
       }
 
-      final diff = setting.pillNumberForFromMenstruation - pastedCount;
+      final diff = setting.pillNumberForFromMenstruation - passedCount;
       final begin =
           pillSheet.beginingDate.add(Duration(days: (diff - 1) + offset));
       final end = begin.add(Duration(days: (setting.durationMenstruation - 1)));

--- a/lib/components/organisms/calendar/utility.dart
+++ b/lib/components/organisms/calendar/utility.dart
@@ -15,6 +15,9 @@ List<DateRange> scheduledOrInTheMiddleMenstruationDateRanges(
   if (pillSheetGroup.pillSheets.isEmpty) {
     return [];
   }
+  if (setting.pillNumberForFromMenstruation == 0) {
+    return [];
+  }
   assert(maxPageCount > 0);
 
   final List<DateRange> dateRanges = [];

--- a/lib/components/organisms/calendar/utility.dart
+++ b/lib/components/organisms/calendar/utility.dart
@@ -17,7 +17,8 @@ List<DateRange> scheduledOrInTheMiddleMenstruationDateRanges(
   }
   assert(maxPageCount > 0);
 
-  return List.generate(maxPageCount, (groupPageIndex) {
+  final count = maxPageCount / pillSheetGroup.pillSheets.length;
+  return List.generate(count.toInt(), (groupPageIndex) {
     return pillSheetGroup.pillSheets.asMap().keys.map((pageIndex) {
       final pillSheet = pillSheetGroup.pillSheets[pageIndex];
       final pillSheetTypes =
@@ -53,7 +54,9 @@ List<DateRange> nextPillSheetDateRanges(
     return [];
   }
   assert(maxPageCount > 0);
-  return List.generate(maxPageCount, (groupPageIndex) {
+
+  final count = maxPageCount / pillSheetGroup.pillSheets.length;
+  return List.generate(count.toInt(), (groupPageIndex) {
     return pillSheetGroup.pillSheets.map((pillSheet) {
       final offset = groupPageIndex * pillSheetGroup.totalPillCountIntoGroup;
       final begin = pillSheet.scheduledLastTakenDate.add(Duration(days: 1));

--- a/lib/components/template/setting_menstruation/setting_menstruation_dynamic_description.dart
+++ b/lib/components/template/setting_menstruation/setting_menstruation_dynamic_description.dart
@@ -49,7 +49,7 @@ class SettingMenstruationDynamicDescription extends StatelessWidget {
                 onTap: () => _showFromModalSheet(context),
                 child: _from(),
               ),
-              Text(" 番目ごとに",
+              Text(" 番ごとに",
                   style: FontType.assisting.merge(TextColorStyle.main)),
             ],
           ),

--- a/lib/components/template/setting_pill_sheet_group/setting_pill_sheet_group.dart
+++ b/lib/components/template/setting_pill_sheet_group/setting_pill_sheet_group.dart
@@ -41,7 +41,7 @@ class SettingPillSheetGroup extends StatelessWidget {
             .values
             .expand((element) => element)
             .toList(),
-        if (pillSheetTypes.length >= 6) ...[
+        if (pillSheetTypes.length < 6) ...[
           SizedBox(height: 24),
           PillSheetTypeAddButton(
               onAdd: (pillSheetType) => onAdd(pillSheetType)),

--- a/lib/components/template/setting_pill_sheet_group/setting_pill_sheet_group.dart
+++ b/lib/components/template/setting_pill_sheet_group/setting_pill_sheet_group.dart
@@ -41,8 +41,11 @@ class SettingPillSheetGroup extends StatelessWidget {
             .values
             .expand((element) => element)
             .toList(),
-        SizedBox(height: 24),
-        PillSheetTypeAddButton(onAdd: (pillSheetType) => onAdd(pillSheetType)),
+        if (pillSheetTypes.length >= 6) ...[
+          SizedBox(height: 24),
+          PillSheetTypeAddButton(
+              onAdd: (pillSheetType) => onAdd(pillSheetType)),
+        ],
         SizedBox(height: 80),
       ],
     );

--- a/lib/domain/initial_setting/initial_setting_state.dart
+++ b/lib/domain/initial_setting/initial_setting_state.dart
@@ -94,19 +94,19 @@ abstract class InitialSettingState implements _$InitialSettingState {
     if (pageIndex <= todayPillNumber.pageIndex) {
       // Left side from todayPillNumber.pageIndex
       // Or current pageIndex == todayPillNumber.pageIndex
-      final pastedTotalCountElement = pillSheetTypes
+      final passedTotalCountElement = pillSheetTypes
           .sublist(0, todayPillNumber.pageIndex - pageIndex)
           .map((e) => e.totalCount);
-      final int pastedTotalCount;
-      if (pastedTotalCountElement.isEmpty) {
-        pastedTotalCount = 0;
+      final int passedTotalCount;
+      if (passedTotalCountElement.isEmpty) {
+        passedTotalCount = 0;
       } else {
-        pastedTotalCount =
-            pastedTotalCountElement.reduce((value, element) => value + element);
+        passedTotalCount =
+            passedTotalCountElement.reduce((value, element) => value + element);
       }
 
       return today().subtract(
-          Duration(days: pastedTotalCount + (pillNumberIntoPillSheet - 1)));
+          Duration(days: passedTotalCount + (pillNumberIntoPillSheet - 1)));
     } else {
       // Right Side from todayPillNumber.pageIndex
       final beforePillSheetType = pillSheetTypes[pageIndex - 1];

--- a/lib/domain/initial_setting/initial_setting_state.dart
+++ b/lib/domain/initial_setting/initial_setting_state.dart
@@ -107,10 +107,14 @@ abstract class InitialSettingState implements _$InitialSettingState {
               (todayPillNumber.pillNumberIntoPillSheet - 1)));
     } else {
       // Right Side from todayPillNumber.pageIndex
+      final beforePillSheetBeginingDate = _beginingDate(
+        pageIndex: pageIndex - 1,
+        todayPillNumber: todayPillNumber,
+        pillSheetTypes: pillSheetTypes,
+      );
       final beforePillSheetType = pillSheetTypes[pageIndex - 1];
-      return today().add(Duration(
-          days: beforePillSheetType.totalCount -
-              (todayPillNumber.pillNumberIntoPillSheet - 1)));
+      return beforePillSheetBeginingDate
+          .add(Duration(days: beforePillSheetType.totalCount));
     }
   }
 

--- a/lib/domain/initial_setting/initial_setting_state.dart
+++ b/lib/domain/initial_setting/initial_setting_state.dart
@@ -22,7 +22,7 @@ abstract class InitialSettingState implements _$InitialSettingState {
     @Default([])
         List<PillSheetType> pillSheetTypes,
     InitialSettingTodayPillNumber? todayPillNumber,
-    @Default(23)
+    @Default(0)
         int fromMenstruation,
     @Default(4)
         int durationMenstruation,

--- a/lib/domain/initial_setting/initial_setting_state.dart
+++ b/lib/domain/initial_setting/initial_setting_state.dart
@@ -88,9 +88,6 @@ abstract class InitialSettingState implements _$InitialSettingState {
     required InitialSettingTodayPillNumber todayPillNumber,
     required List<PillSheetType> pillSheetTypes,
   }) {
-    // Avoid broken type inherence
-    // todayPillNumber.pillNumberIntoPillSheet interpreted as dynamic
-    final int pillNumberIntoPillSheet = todayPillNumber.pillNumberIntoPillSheet;
     if (pageIndex <= todayPillNumber.pageIndex) {
       // Left side from todayPillNumber.pageIndex
       // Or current pageIndex == todayPillNumber.pageIndex
@@ -105,14 +102,15 @@ abstract class InitialSettingState implements _$InitialSettingState {
             passedTotalCountElement.reduce((value, element) => value + element);
       }
 
-      return today().subtract(
-          Duration(days: passedTotalCount + (pillNumberIntoPillSheet - 1)));
+      return today().subtract(Duration(
+          days: passedTotalCount +
+              (todayPillNumber.pillNumberIntoPillSheet - 1)));
     } else {
       // Right Side from todayPillNumber.pageIndex
       final beforePillSheetType = pillSheetTypes[pageIndex - 1];
       return today().add(Duration(
-          days:
-              beforePillSheetType.totalCount - (pillNumberIntoPillSheet - 1)));
+          days: beforePillSheetType.totalCount -
+              (todayPillNumber.pillNumberIntoPillSheet - 1)));
     }
   }
 

--- a/lib/domain/initial_setting/initial_setting_state.dart
+++ b/lib/domain/initial_setting/initial_setting_state.dart
@@ -10,8 +10,8 @@ part 'initial_setting_state.freezed.dart';
 abstract class InitialSettingTodayPillNumber
     implements _$InitialSettingTodayPillNumber {
   factory InitialSettingTodayPillNumber({
-    @Default(0) pageIndex,
-    @Default(0) pillNumberIntoPillSheet,
+    @Default(0) int pageIndex,
+    @Default(0) int pillNumberIntoPillSheet,
   }) = _InitialSettingTodayPillNumber;
 }
 

--- a/lib/domain/initial_setting/initial_setting_state.freezed.dart
+++ b/lib/domain/initial_setting/initial_setting_state.freezed.dart
@@ -17,7 +17,7 @@ class _$InitialSettingTodayPillNumberTearOff {
   const _$InitialSettingTodayPillNumberTearOff();
 
   _InitialSettingTodayPillNumber call(
-      {dynamic pageIndex = 0, dynamic pillNumberIntoPillSheet = 0}) {
+      {int pageIndex = 0, int pillNumberIntoPillSheet = 0}) {
     return _InitialSettingTodayPillNumber(
       pageIndex: pageIndex,
       pillNumberIntoPillSheet: pillNumberIntoPillSheet,
@@ -30,8 +30,8 @@ const $InitialSettingTodayPillNumber = _$InitialSettingTodayPillNumberTearOff();
 
 /// @nodoc
 mixin _$InitialSettingTodayPillNumber {
-  dynamic get pageIndex => throw _privateConstructorUsedError;
-  dynamic get pillNumberIntoPillSheet => throw _privateConstructorUsedError;
+  int get pageIndex => throw _privateConstructorUsedError;
+  int get pillNumberIntoPillSheet => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $InitialSettingTodayPillNumberCopyWith<InitialSettingTodayPillNumber>
@@ -44,7 +44,7 @@ abstract class $InitialSettingTodayPillNumberCopyWith<$Res> {
           InitialSettingTodayPillNumber value,
           $Res Function(InitialSettingTodayPillNumber) then) =
       _$InitialSettingTodayPillNumberCopyWithImpl<$Res>;
-  $Res call({dynamic pageIndex, dynamic pillNumberIntoPillSheet});
+  $Res call({int pageIndex, int pillNumberIntoPillSheet});
 }
 
 /// @nodoc
@@ -65,11 +65,11 @@ class _$InitialSettingTodayPillNumberCopyWithImpl<$Res>
       pageIndex: pageIndex == freezed
           ? _value.pageIndex
           : pageIndex // ignore: cast_nullable_to_non_nullable
-              as dynamic,
+              as int,
       pillNumberIntoPillSheet: pillNumberIntoPillSheet == freezed
           ? _value.pillNumberIntoPillSheet
           : pillNumberIntoPillSheet // ignore: cast_nullable_to_non_nullable
-              as dynamic,
+              as int,
     ));
   }
 }
@@ -82,7 +82,7 @@ abstract class _$InitialSettingTodayPillNumberCopyWith<$Res>
           $Res Function(_InitialSettingTodayPillNumber) then) =
       __$InitialSettingTodayPillNumberCopyWithImpl<$Res>;
   @override
-  $Res call({dynamic pageIndex, dynamic pillNumberIntoPillSheet});
+  $Res call({int pageIndex, int pillNumberIntoPillSheet});
 }
 
 /// @nodoc
@@ -104,10 +104,14 @@ class __$InitialSettingTodayPillNumberCopyWithImpl<$Res>
     Object? pillNumberIntoPillSheet = freezed,
   }) {
     return _then(_InitialSettingTodayPillNumber(
-      pageIndex: pageIndex == freezed ? _value.pageIndex : pageIndex,
+      pageIndex: pageIndex == freezed
+          ? _value.pageIndex
+          : pageIndex // ignore: cast_nullable_to_non_nullable
+              as int,
       pillNumberIntoPillSheet: pillNumberIntoPillSheet == freezed
           ? _value.pillNumberIntoPillSheet
-          : pillNumberIntoPillSheet,
+          : pillNumberIntoPillSheet // ignore: cast_nullable_to_non_nullable
+              as int,
     ));
   }
 }
@@ -121,10 +125,10 @@ class _$_InitialSettingTodayPillNumber
 
   @JsonKey(defaultValue: 0)
   @override
-  final dynamic pageIndex;
+  final int pageIndex;
   @JsonKey(defaultValue: 0)
   @override
-  final dynamic pillNumberIntoPillSheet;
+  final int pillNumberIntoPillSheet;
 
   @override
   String toString() {
@@ -160,13 +164,13 @@ class _$_InitialSettingTodayPillNumber
 abstract class _InitialSettingTodayPillNumber
     implements InitialSettingTodayPillNumber {
   factory _InitialSettingTodayPillNumber(
-      {dynamic pageIndex,
-      dynamic pillNumberIntoPillSheet}) = _$_InitialSettingTodayPillNumber;
+      {int pageIndex,
+      int pillNumberIntoPillSheet}) = _$_InitialSettingTodayPillNumber;
 
   @override
-  dynamic get pageIndex => throw _privateConstructorUsedError;
+  int get pageIndex => throw _privateConstructorUsedError;
   @override
-  dynamic get pillNumberIntoPillSheet => throw _privateConstructorUsedError;
+  int get pillNumberIntoPillSheet => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
   _$InitialSettingTodayPillNumberCopyWith<_InitialSettingTodayPillNumber>

--- a/lib/domain/initial_setting/initial_setting_state.freezed.dart
+++ b/lib/domain/initial_setting/initial_setting_state.freezed.dart
@@ -180,7 +180,7 @@ class _$InitialSettingStateTearOff {
   _InitialSettingState call(
       {List<PillSheetType> pillSheetTypes = const [],
       InitialSettingTodayPillNumber? todayPillNumber,
-      int fromMenstruation = 23,
+      int fromMenstruation = 0,
       int durationMenstruation = 4,
       List<ReminderTime> reminderTimes = const [
         const ReminderTime(hour: 21, minute: 0),
@@ -395,7 +395,7 @@ class _$_InitialSettingState extends _InitialSettingState {
   _$_InitialSettingState(
       {this.pillSheetTypes = const [],
       this.todayPillNumber,
-      this.fromMenstruation = 23,
+      this.fromMenstruation = 0,
       this.durationMenstruation = 4,
       this.reminderTimes = const [
         const ReminderTime(hour: 21, minute: 0),
@@ -411,7 +411,7 @@ class _$_InitialSettingState extends _InitialSettingState {
   final List<PillSheetType> pillSheetTypes;
   @override
   final InitialSettingTodayPillNumber? todayPillNumber;
-  @JsonKey(defaultValue: 23)
+  @JsonKey(defaultValue: 0)
   @override
   final int fromMenstruation;
   @JsonKey(defaultValue: 4)

--- a/lib/domain/initial_setting/initial_setting_store.dart
+++ b/lib/domain/initial_setting/initial_setting_store.dart
@@ -140,7 +140,7 @@ class InitialSettingStateStore extends StateNotifier<InitialSettingState> {
     required int pageIndex,
     required int fromMenstruation,
   }) {
-    final offset = pastedTotalCount(
+    final offset = passedTotalCount(
         pillSheetTypes: state.pillSheetTypes, pageIndex: pageIndex);
     state = state.copyWith(fromMenstruation: fromMenstruation + offset);
   }
@@ -158,12 +158,12 @@ class InitialSettingStateStore extends StateNotifier<InitialSettingState> {
   }
 
   int? retrieveMenstruationSelectedPillNumber(int pageIndex) {
-    final _pastedTotalCount = pastedTotalCount(
+    final _passedTotalCount = passedTotalCount(
         pillSheetTypes: state.pillSheetTypes, pageIndex: pageIndex);
-    if (_pastedTotalCount >= state.fromMenstruation) {
+    if (_passedTotalCount >= state.fromMenstruation) {
       return state.fromMenstruation;
     }
-    final diff = state.fromMenstruation - _pastedTotalCount;
+    final diff = state.fromMenstruation - _passedTotalCount;
     if (diff > state.pillSheetTypes[pageIndex].totalCount) {
       return null;
     }

--- a/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
+++ b/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
@@ -40,7 +40,7 @@ class InitialSettingPillSheetGroupPage extends HookWidget {
                     SizedBox(height: 24),
                     Text(
                       "処方されるピルシートについて\n教えてください",
-                      style: FontType.title.merge(TextColorStyle.main),
+                      style: FontType.sBigTitle.merge(TextColorStyle.main),
                       textAlign: TextAlign.center,
                     ),
                     SizedBox(height: 6),

--- a/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
+++ b/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
@@ -39,7 +39,7 @@ class InitialSettingPillSheetGroupPage extends HookWidget {
                   children: [
                     SizedBox(height: 24),
                     Text(
-                      "処方されるピルシートについて\n教えてください",
+                      "処方されるピルについて\n教えてください",
                       style: FontType.sBigTitle.merge(TextColorStyle.main),
                       textAlign: TextAlign.center,
                     ),

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -149,13 +149,15 @@ class RecordPagePillSheet extends StatelessWidget {
         menstruationNumbers.contains(serializedPillNumberIntoGroup);
 
     if (isDateMode) {
-      if (isContainedMenstruationDuration) {
+      if (isContainedMenstruationDuration &&
+          setting.pillNumberForFromMenstruation != 0) {
         return MenstruationPillDate(date: date);
       } else {
         return PlainPillDate(date: date);
       }
     } else {
-      if (isContainedMenstruationDuration) {
+      if (isContainedMenstruationDuration &&
+          setting.pillNumberForFromMenstruation != 0) {
         return MenstruationPillNumber(pillNumber: pillNumberIntoPillSheet);
       } else {
         return PlainPillNumber(pillNumber: pillNumberIntoPillSheet);

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -138,9 +138,9 @@ class RecordPagePillSheet extends StatelessWidget {
 
     final pillSheetTypes =
         pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
-    final pastedCount =
-        pastedTotalCount(pillSheetTypes: pillSheetTypes, pageIndex: pageIndex);
-    final serializedPillNumberIntoGroup = pastedCount + pillNumberIntoPillSheet;
+    final passedCount =
+        passedTotalCount(pillSheetTypes: pillSheetTypes, pageIndex: pageIndex);
+    final serializedPillNumberIntoGroup = passedCount + pillNumberIntoPillSheet;
     final menstruationNumbers =
         List.generate(setting.durationMenstruation, (index) {
       return setting.pillNumberForFromMenstruation + index;

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -140,17 +140,13 @@ class RecordPagePillSheet extends StatelessWidget {
         pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
     final pastedCount =
         pastedTotalCount(pillSheetTypes: pillSheetTypes, pageIndex: pageIndex);
+    final serializedPillNumberIntoGroup = pastedCount + pillNumberIntoPillSheet;
     final menstruationNumbers =
         List.generate(setting.durationMenstruation, (index) {
-      if (pastedCount == 0) {
-        return setting.pillNumberForFromMenstruation + index;
-      }
-      final number =
-          (setting.pillNumberForFromMenstruation + index) % pastedCount;
-      return number == 0 ? pastedCount : number;
+      return setting.pillNumberForFromMenstruation + index;
     });
     final isContainedMenstruationDuration =
-        menstruationNumbers.contains(pillNumberIntoPillSheet);
+        menstruationNumbers.contains(serializedPillNumberIntoGroup);
 
     if (isDateMode) {
       if (isContainedMenstruationDuration) {

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet_list.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet_list.dart
@@ -36,8 +36,11 @@ class RecordPagePillSheetList extends HookWidget {
       children: [
         Container(
           height: PillSheetViewLayout.calcHeight(
-              pillSheetGroup
-                  .pillSheets.first.pillSheetType.numberOfLineInPillSheet,
+              PillSheetViewLayout.mostLargePillSheetType(pillSheetGroup
+                      .pillSheets
+                      .map((e) => e.pillSheetType)
+                      .toList())
+                  .numberOfLineInPillSheet,
               false),
           child: PageView(
             clipBehavior: Clip.none,

--- a/lib/domain/record/record_page_store.dart
+++ b/lib/domain/record/record_page_store.dart
@@ -155,7 +155,7 @@ class RecordPageStore extends StateNotifier<RecordPageState> {
       batch,
       setting.pillSheetTypes.asMap().keys.map((pageIndex) {
         final pillSheetType = setting.pillSheetTypes[pageIndex];
-        final offset = pastedTotalCount(
+        final offset = passedTotalCount(
             pillSheetTypes: setting.pillSheetTypes, pageIndex: pageIndex);
         return PillSheet(
           typeInfo: pillSheetType.typeInfo,

--- a/lib/domain/settings/menstruation/setting_menstruation_store.dart
+++ b/lib/domain/settings/menstruation/setting_menstruation_store.dart
@@ -22,7 +22,7 @@ class SettingMenstruationStateStore
     required int pageIndex,
     required int fromMenstruation,
   }) {
-    final offset = pastedTotalCount(
+    final offset = passedTotalCount(
         pillSheetTypes: setting.pillSheetTypes, pageIndex: pageIndex);
     return _settingService.update(setting.copyWith(
         pillNumberForFromMenstruation: fromMenstruation + offset));
@@ -48,12 +48,12 @@ class SettingMenstruationStateStore
     Setting setting,
     int pageIndex,
   ) {
-    final _pastedTotalCount = pastedTotalCount(
+    final _passedTotalCount = passedTotalCount(
         pillSheetTypes: setting.pillSheetTypes, pageIndex: pageIndex);
-    if (_pastedTotalCount >= setting.pillNumberForFromMenstruation) {
+    if (_passedTotalCount >= setting.pillNumberForFromMenstruation) {
       return setting.pillNumberForFromMenstruation;
     }
-    final diff = setting.pillNumberForFromMenstruation - _pastedTotalCount;
+    final diff = setting.pillNumberForFromMenstruation - _passedTotalCount;
     if (diff > setting.pillSheetTypes[pageIndex].totalCount) {
       return null;
     }

--- a/lib/domain/settings/today_pill_number/setting_today_pill_number_store.dart
+++ b/lib/domain/settings/today_pill_number/setting_today_pill_number_store.dart
@@ -69,7 +69,7 @@ class SettingTodayPillNumberStateStore
 
     final pillSheetTypes =
         pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
-    final nextSerializedPillNumber = pastedTotalCount(
+    final nextSerializedPillNumber = passedTotalCount(
           pillSheetTypes: pillSheetTypes,
           pageIndex: state.selectedPillSheetPageIndex,
         ) +
@@ -107,11 +107,11 @@ class SettingTodayPillNumberStateStore
   }) {
     final pillSheetTypes =
         pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
-    final _pastedTotalCount = pastedTotalCount(
+    final _passedTotalCount = passedTotalCount(
         pillSheetTypes: pillSheetTypes, pageIndex: activedPillSheet.groupIndex);
-    if (_pastedTotalCount >= activedPillSheet.todayPillNumber) {
+    if (_passedTotalCount >= activedPillSheet.todayPillNumber) {
       return activedPillSheet.todayPillNumber;
     }
-    return activedPillSheet.todayPillNumber - _pastedTotalCount;
+    return activedPillSheet.todayPillNumber - _passedTotalCount;
   }
 }

--- a/lib/entity/pill_sheet_group.dart
+++ b/lib/entity/pill_sheet_group.dart
@@ -64,7 +64,7 @@ abstract class PillSheetGroup implements _$PillSheetGroup {
         .reduce((value, element) => value + element);
   }
 
-  List<PillSheet> get pastedPillSheet {
+  List<PillSheet> get passedPillSheet {
     final activedPillSheet = this.activedPillSheet;
     if (activedPillSheet == null) {
       return pillSheets;
@@ -81,11 +81,11 @@ abstract class PillSheetGroup implements _$PillSheetGroup {
       return null;
     }
 
-    if (pastedPillSheet.isNotEmpty) {
-      final pastedPillCount = pastedPillSheet
+    if (passedPillSheet.isNotEmpty) {
+      final passedPillCount = passedPillSheet
           .map((pillSheet) => pillSheet.pillSheetType.totalCount)
           .reduce((value, element) => value + element);
-      return pastedPillCount + activedPillSheet.todayPillNumber;
+      return passedPillCount + activedPillSheet.todayPillNumber;
     } else {
       // Group has only one PillSheet
       return activedPillSheet.todayPillNumber;
@@ -115,13 +115,13 @@ abstract class PillSheetGroup implements _$PillSheetGroup {
     if (latestTakenPillSheet == null) {
       return 0;
     }
-    if (pastedPillSheet.isEmpty) {
+    if (passedPillSheet.isEmpty) {
       return 0;
     }
-    final pastedPillCount = pastedPillSheet
+    final passedPillCount = passedPillSheet
         .map((pillSheet) => pillSheet.pillSheetType.totalCount)
         .reduce((value, element) => value + element);
-    return pastedPillCount + latestTakenPillSheet.lastTakenPillNumber;
+    return passedPillCount + latestTakenPillSheet.lastTakenPillNumber;
   }
 
   bool get isDeactived => activedPillSheet == null;

--- a/lib/entity/pill_sheet_type.dart
+++ b/lib/entity/pill_sheet_type.dart
@@ -165,14 +165,14 @@ extension PillSheetTypeFunctions on PillSheetType {
       (totalCount / Weekday.values.length).ceil();
 }
 
-int pastedTotalCount(
+int passedTotalCount(
     {required List<PillSheetType> pillSheetTypes, required int pageIndex}) {
   if (pageIndex == 0) {
     return 0;
   }
-  final pasted = pillSheetTypes.sublist(0, pageIndex);
-  final pastedTotalCount = pasted
+  final passed = pillSheetTypes.sublist(0, pageIndex);
+  final passedTotalCount = passed
       .map((e) => e.totalCount)
       .reduce((value, element) => value + element);
-  return pastedTotalCount;
+  return passedTotalCount;
 }


### PR DESCRIPTION
## Abstract
- 初期設定の生理の初期値を `-` にする(0)
- 生理期間の計算式を記録画面のものと統合する
- ピルシートが複数枚並んだ時の高さの計算方法を統一
- ピルシートグループに含められるピルシートの数は6枚までにする
- 初期設定からのグループ作成時に、今日飲むピルシートよりも右側のシートの開始日の計算がおかしかったので修正