### PR TITLE
:bug: Bugfix appearance pill sheet appearance

### DIFF
--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -136,28 +136,43 @@ class RecordPagePillSheet extends StatelessWidget {
       return true;
     }();
 
+    if (setting.pillNumberForFromMenstruation == 0 ||
+        setting.durationMenstruation == 0) {
+      if (isDateMode) {
+        return PlainPillDate(date: date);
+      } else {
+        return PlainPillNumber(pillNumber: pillNumberIntoPillSheet);
+      }
+    }
+
     final pillSheetTypes =
         pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
     final passedCount =
         passedTotalCount(pillSheetTypes: pillSheetTypes, pageIndex: pageIndex);
-    final serializedPillNumberIntoGroup = passedCount + pillNumberIntoPillSheet;
+
+    final int pillNumberForFromMenstruationIntoPillSheet;
+    if (passedCount == 0) {
+      pillNumberForFromMenstruationIntoPillSheet =
+          setting.pillNumberForFromMenstruation;
+    } else {
+      pillNumberForFromMenstruationIntoPillSheet =
+          setting.pillNumberForFromMenstruation % passedCount;
+    }
     final menstruationNumbers =
         List.generate(setting.durationMenstruation, (index) {
-      return setting.pillNumberForFromMenstruation + index;
+      return pillNumberForFromMenstruationIntoPillSheet + index;
     });
     final isContainedMenstruationDuration =
-        menstruationNumbers.contains(serializedPillNumberIntoGroup);
+        menstruationNumbers.contains(pillNumberIntoPillSheet);
 
     if (isDateMode) {
-      if (isContainedMenstruationDuration &&
-          setting.pillNumberForFromMenstruation != 0) {
+      if (isContainedMenstruationDuration) {
         return MenstruationPillDate(date: date);
       } else {
         return PlainPillDate(date: date);
       }
     } else {
-      if (isContainedMenstruationDuration &&
-          setting.pillNumberForFromMenstruation != 0) {
+      if (isContainedMenstruationDuration) {
         return MenstruationPillNumber(pillNumber: pillNumberIntoPillSheet);
       } else {
         return PlainPillNumber(pillNumber: pillNumberIntoPillSheet);

--- a/lib/domain/settings/today_pill_number/setting_today_pill_number_pill_sheet_list.dart
+++ b/lib/domain/settings/today_pill_number/setting_today_pill_number_pill_sheet_list.dart
@@ -48,7 +48,7 @@ class SettingTodayPillNumberPillSheetList extends HookWidget {
                           selectedTodayPillNumberIntoPillSheet(pageIndex),
                       markSelected: (pageIndex, number) {
                         analytics.logEvent(
-                            name: "selected_today_number_initial_setting",
+                            name: "selected_today_number_setting",
                             parameters: {
                               "pill_number": number,
                               "page": pageIndex,


### PR DESCRIPTION
## Abstract
- [x] ピルシート画面の生理表示がずれる問題を修正
- [x] 今日飲む番号を変更で2,3番ずれてしまう問題を修正
  - ピルシートが複数枚になったことにより、飲み始めた日付だけを調整する関数だと機能が不足していたので、最後に飲んだ日をそれぞれのシートで良い感じに計算するように修正