### PR TITLE
Fix calculated menstruation durations

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -65,6 +65,35 @@ extension AppDelegate {
         UNUserNotificationCenter.current().setNotificationCategories([category])
     }
 
+    override func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        super.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
+        func end() {
+            var isCompleted: Bool = false
+            let completionHandlerWrapper = {
+                isCompleted = true
+                completionHandler()
+            }
+
+            UIApplication.shared.applicationIconBadgeNumber = 0
+            self.userNotificationCenter_methodSwizzling(center, didReceive: response, withCompletionHandler: completionHandlerWrapper)
+            if !isCompleted {
+                completionHandlerWrapper()
+            }
+        }
+
+        switch extractCategory(userInfo: response.notification.request.content.userInfo) {
+        case nil:
+            return
+        case .pillReminder:
+            switch response.actionIdentifier {
+            case "RECORD_PILL":
+                call(method: "recordPill", arguments: nil)
+                end()
+            default:
+                end()
+            }
+        }
+    }
     @objc func userNotificationCenter_methodSwizzling(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         func end(delay: TimeInterval = 0) {
             var isCompleted: Bool = false

--- a/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
+++ b/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_svg/svg.dart';
 import 'package:pilll/analytics.dart';
 import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/components/page/hud.dart';
 import 'package:pilll/components/template/setting_pill_sheet_group/pill_sheet_group_select_pill_sheet_type_page.dart';
 import 'package:pilll/components/template/setting_pill_sheet_group/setting_pill_sheet_group.dart';
 import 'package:pilll/domain/initial_setting/initial_setting_state.dart';
@@ -23,85 +24,96 @@ class InitialSettingPillSheetGroupPage extends HookWidget {
   Widget build(BuildContext context) {
     final store = useProvider(initialSettingStoreProvider);
     final state = useProvider(initialSettingStoreProvider.state);
-    return Scaffold(
-      backgroundColor: PilllColors.background,
-      appBar: AppBar(
-        title: Text(
-          "1/4",
-          style: TextStyle(color: TextColor.black),
+    if (state.isAccountCooperationDidEnd) {
+      Future(() async {
+        if (await store.canEndInitialSetting()) {
+          AppRouter.signinAccount(context);
+        }
+        store.hideHUD();
+      });
+    }
+    return HUD(
+      shown: state.isLoading,
+      child: Scaffold(
+        backgroundColor: PilllColors.background,
+        appBar: AppBar(
+          title: Text(
+            "1/4",
+            style: TextStyle(color: TextColor.black),
+          ),
+          backgroundColor: PilllColors.white,
         ),
-        backgroundColor: PilllColors.white,
-      ),
-      body: SafeArea(
-        child: Container(
-          padding: EdgeInsets.symmetric(horizontal: 40),
-          child: Stack(
-            children: [
-              SingleChildScrollView(
-                child: Column(
-                  children: [
-                    SizedBox(height: 24),
-                    Text(
-                      "処方されるピルについて\n教えてください",
-                      style: FontType.sBigTitle.merge(TextColorStyle.main),
-                      textAlign: TextAlign.center,
-                    ),
-                    InitialSettingPillSheetGroupPageBody(
-                        state: state, store: store),
-                    SizedBox(height: 100),
-                  ],
-                ),
-              ),
-              Align(
-                alignment: Alignment.bottomCenter,
-                child: Container(
-                  width: MediaQuery.of(context).size.width,
-                  color: PilllColors.background,
+        body: SafeArea(
+          child: Container(
+            padding: EdgeInsets.symmetric(horizontal: 40),
+            child: Stack(
+              children: [
+                SingleChildScrollView(
                   child: Column(
-                    mainAxisSize: MainAxisSize.min,
                     children: [
-                      if (state.pillSheetTypes.isNotEmpty)
-                        PrimaryButton(
-                          text: "次へ",
-                          onPressed: () async {
-                            analytics.logEvent(name: "next_pill_sheet_count");
-                            Navigator.of(context).push(
-                                InitialSettingSelectTodayPillNumberPageRoute
-                                    .route());
-                          },
-                        ),
-                      if (!state.isAccountCooperationDidEnd) ...[
-                        SizedBox(height: 20),
-                        SecondaryButton(
-                          text: "すでにアカウントをお持ちの方はこちら",
-                          onPressed: () {
-                            showSigninSheet(
-                              context,
-                              SigninSheetStateContext.initialSetting,
-                              (accountType) async {
-                                store.showHUD();
-                                if (await store.canEndInitialSetting()) {
-                                  AppRouter.signinAccount(context);
-                                } else {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                      duration: Duration(seconds: 2),
-                                      content: Text(
-                                          "${accountType.providerName}でログインしました"),
-                                    ),
-                                  );
-                                }
-                              },
-                            );
-                          },
-                        ),
-                      ],
-                      SizedBox(height: 35),
+                      SizedBox(height: 24),
+                      Text(
+                        "処方されるピルについて\n教えてください",
+                        style: FontType.sBigTitle.merge(TextColorStyle.main),
+                        textAlign: TextAlign.center,
+                      ),
+                      InitialSettingPillSheetGroupPageBody(
+                          state: state, store: store),
+                      SizedBox(height: 100),
                     ],
                   ),
                 ),
-              ),
-            ],
+                Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Container(
+                    width: MediaQuery.of(context).size.width,
+                    color: PilllColors.background,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (state.pillSheetTypes.isNotEmpty)
+                          PrimaryButton(
+                            text: "次へ",
+                            onPressed: () async {
+                              analytics.logEvent(name: "next_pill_sheet_count");
+                              Navigator.of(context).push(
+                                  InitialSettingSelectTodayPillNumberPageRoute
+                                      .route());
+                            },
+                          ),
+                        if (!state.isAccountCooperationDidEnd) ...[
+                          SizedBox(height: 20),
+                          SecondaryButton(
+                            text: "すでにアカウントをお持ちの方はこちら",
+                            onPressed: () {
+                              showSigninSheet(
+                                context,
+                                SigninSheetStateContext.initialSetting,
+                                (accountType) async {
+                                  store.showHUD();
+                                  if (await store.canEndInitialSetting()) {
+                                    AppRouter.signinAccount(context);
+                                  } else {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                        duration: Duration(seconds: 2),
+                                        content: Text(
+                                            "${accountType.providerName}でログインしました"),
+                                      ),
+                                    );
+                                  }
+                                },
+                              );
+                            },
+                          ),
+                        ],
+                        SizedBox(height: 35),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -145,7 +145,8 @@ class RecordPagePillSheet extends StatelessWidget {
       }
     }
 
-    final containedMenstruationDuration = isContainedMenstruationDuration(
+    final containedMenstruationDuration =
+        RecordPagePillSheet.isContainedMenstruationDuration(
       pillNumberIntoPillSheet: pillNumberIntoPillSheet,
       pillSheetGroup: pillSheetGroup,
       setting: setting,

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -168,6 +168,23 @@ class RecordPagePillSheet extends StatelessWidget {
     }
   }
 
+  /*
+    pillNumberIntoPillSheet の値によって二つの動きをする
+    setting.pillNumberForFromMenstruation < pillSheet.typeInfo.totalCount の場合は単純にこの式の結果を用いる
+    setting.pillNumberForFromMenstruation > pillSheet.typeInfo.totalCount の場合はページ数も考慮して
+      pillSheet.begin < pillNumberForFromMenstruation < pillSheet.typeInfo.totalCount の場合の結果を用いる
+
+    - 想定される使い方は各ピルシートごとに同じ生理の期間開始を設定したい(1つ目の仕様)
+    - ヤーズフレックスのようにどこか1枚だけ生理の開始期間を設定したい(2つ目の仕様)
+
+    なので後者の計算式で下のようになっても許容をすることにする
+
+    28錠タイプが4枚ある場合で46番ごとに生理期間がくる設定をしていると生理期間の始まりが
+      1枚目: なし
+      2枚目: 18番から
+      3枚目: なし
+      4枚目: 8番から
+  */
   static bool isContainedMenstruationDuration({
     required int pillNumberIntoPillSheet,
     required PillSheetGroup pillSheetGroup,

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -145,38 +145,59 @@ class RecordPagePillSheet extends StatelessWidget {
       }
     }
 
-    final pillSheetTypes =
-        pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
-    final passedCount =
-        passedTotalCount(pillSheetTypes: pillSheetTypes, pageIndex: pageIndex);
-
-    final int pillNumberForFromMenstruationIntoPillSheet;
-    if (passedCount == 0) {
-      pillNumberForFromMenstruationIntoPillSheet =
-          setting.pillNumberForFromMenstruation;
-    } else {
-      pillNumberForFromMenstruationIntoPillSheet =
-          setting.pillNumberForFromMenstruation % passedCount;
-    }
-    final menstruationNumbers =
-        List.generate(setting.durationMenstruation, (index) {
-      return pillNumberForFromMenstruationIntoPillSheet + index;
-    });
-    final isContainedMenstruationDuration =
-        menstruationNumbers.contains(pillNumberIntoPillSheet);
+    final containedMenstruationDuration = isContainedMenstruationDuration(
+      pillNumberIntoPillSheet: pillNumberIntoPillSheet,
+      pillSheetGroup: pillSheetGroup,
+      setting: setting,
+      pageIndex: pageIndex,
+    );
 
     if (isDateMode) {
-      if (isContainedMenstruationDuration) {
+      if (containedMenstruationDuration) {
         return MenstruationPillDate(date: date);
       } else {
         return PlainPillDate(date: date);
       }
     } else {
-      if (isContainedMenstruationDuration) {
+      if (containedMenstruationDuration) {
         return MenstruationPillNumber(pillNumber: pillNumberIntoPillSheet);
       } else {
         return PlainPillNumber(pillNumber: pillNumberIntoPillSheet);
       }
     }
   }
+
+  static bool isContainedMenstruationDuration({
+    required int pillNumberIntoPillSheet,
+    required PillSheetGroup pillSheetGroup,
+    required int pageIndex,
+    required Setting setting,
+  }) {
+    final pillSheetTypes =
+        pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
+    final passedCount =
+        passedTotalCount(pillSheetTypes: pillSheetTypes, pageIndex: pageIndex);
+    final serialiedPillNumber = passedCount + pillNumberIntoPillSheet;
+
+    final menstruationRangeList =
+        List.generate(pillSheetGroup.pillSheets.length, (index) {
+      final begin = setting.pillNumberForFromMenstruation * (index + 1);
+      final end = begin + setting.durationMenstruation - 1;
+      return _MenstruationRange(begin, end);
+    });
+
+    final isContainedMenstruationDuration = menstruationRangeList
+        .where((element) => element.contains(serialiedPillNumber))
+        .isNotEmpty;
+    return isContainedMenstruationDuration;
+  }
+}
+
+class _MenstruationRange {
+  final int begin;
+  final int end;
+
+  _MenstruationRange(this.begin, this.end);
+
+  bool contains(int pillNumber) => begin <= pillNumber && pillNumber <= end;
 }

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -191,6 +191,17 @@ class RecordPagePillSheet extends StatelessWidget {
     required int pageIndex,
     required Setting setting,
   }) {
+    final pillSheetTotalCount =
+        pillSheetGroup.pillSheets[pageIndex].typeInfo.totalCount;
+    if (setting.pillNumberForFromMenstruation < pillSheetTotalCount) {
+      final left = setting.pillNumberForFromMenstruation;
+      final right = setting.pillNumberForFromMenstruation +
+          setting.durationMenstruation -
+          1;
+      return left <= pillNumberIntoPillSheet &&
+          pillNumberIntoPillSheet <= right;
+    }
+
     final pillSheetTypes =
         pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
     final passedCount =

--- a/test/domain/record/components/record_page_pill_sheet_test.dart
+++ b/test/domain/record/components/record_page_pill_sheet_test.dart
@@ -77,23 +77,29 @@ void main() {
         durationMenstruation: 3,
         isOnReminder: true,
       );
-      final pageIndex = 0;
-
-      final totalCount = [
+      final pillSheetTypes = [
         PillSheetType.pillsheet_28_0,
         PillSheetType.pillsheet_28_0,
         PillSheetType.pillsheet_28_0
-      ].map((e) => e.totalCount).reduce((value, element) => value + element);
+      ];
 
-      for (int i = 1; i <= totalCount; i++) {
-        expect(
-            RecordPagePillSheet.isContainedMenstruationDuration(
-                pillNumberIntoPillSheet: i,
+      for (int pageIndex = 0; pageIndex < pillSheetTypes.length; pageIndex++) {
+        for (int pillNumberIntoPillSheet = 1;
+            pillNumberIntoPillSheet <= pillSheetTypes[pageIndex].totalCount;
+            pillNumberIntoPillSheet++) {
+          expect(
+              RecordPagePillSheet.isContainedMenstruationDuration(
+                pillNumberIntoPillSheet: pillNumberIntoPillSheet,
                 pillSheetGroup: pillSheetGroup,
                 pageIndex: pageIndex,
-                setting: setting),
-            46 <= i && i <= 48,
-            reason: "print debug informations pillNumberIntoPillSheet is $i");
+                setting: setting,
+              ),
+              (pageIndex == 1 &&
+                  18 <= pillNumberIntoPillSheet &&
+                  pillNumberIntoPillSheet <= 20),
+              reason:
+                  "print debug informations pillNumberIntoPillSheet is $pillNumberIntoPillSheet, pageIndex: $pageIndex");
+        }
       }
     });
   });

--- a/test/domain/record/components/record_page_pill_sheet_test.dart
+++ b/test/domain/record/components/record_page_pill_sheet_test.dart
@@ -159,7 +159,7 @@ void main() {
         }
       }
     });
-    // It is spec. But unknown about this case is correct
+    // 仕様的にはこの内容になるけど、ユーザーの入力としては想定されていない。なので仕様がおかしいとなったらこのテストは守らなくて良い
     test(
         "group has five pill sheet and scheduled menstruation begin No.2 pillSheet",
         () async {

--- a/test/domain/record/components/record_page_pill_sheet_test.dart
+++ b/test/domain/record/components/record_page_pill_sheet_test.dart
@@ -102,6 +102,63 @@ void main() {
         }
       }
     });
+    test(
+        "group has three pill sheet and scheduled menstruation have all sheets",
+        () async {
+      final anyDate = DateTime.parse("2020-09-19");
+      final one = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 0,
+      );
+      final two = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 1,
+      );
+      final three = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 2,
+      );
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ["1", "2", "3"],
+        pillSheets: [one, two, three],
+        createdAt: anyDate,
+      );
+      final setting = Setting(
+        pillSheetTypes: [
+          PillSheetType.pillsheet_28_0,
+          PillSheetType.pillsheet_28_0,
+          PillSheetType.pillsheet_28_0
+        ],
+        pillNumberForFromMenstruation: 22,
+        durationMenstruation: 3,
+        isOnReminder: true,
+      );
+      final pillSheetTypes = [
+        PillSheetType.pillsheet_28_0,
+        PillSheetType.pillsheet_28_0,
+        PillSheetType.pillsheet_28_0
+      ];
+
+      for (int pageIndex = 0; pageIndex < pillSheetTypes.length; pageIndex++) {
+        for (int pillNumberIntoPillSheet = 1;
+            pillNumberIntoPillSheet <= pillSheetTypes[pageIndex].totalCount;
+            pillNumberIntoPillSheet++) {
+          expect(
+              RecordPagePillSheet.isContainedMenstruationDuration(
+                pillNumberIntoPillSheet: pillNumberIntoPillSheet,
+                pillSheetGroup: pillSheetGroup,
+                pageIndex: pageIndex,
+                setting: setting,
+              ),
+              22 <= pillNumberIntoPillSheet && pillNumberIntoPillSheet <= 24,
+              reason:
+                  "print debug informations pillNumberIntoPillSheet is $pillNumberIntoPillSheet, pageIndex: $pageIndex");
+        }
+      }
+    });
     // It is spec. But unknown about this case is correct
     test(
         "group has five pill sheet and scheduled menstruation begin No.2 pillSheet",

--- a/test/domain/record/components/record_page_pill_sheet_test.dart
+++ b/test/domain/record/components/record_page_pill_sheet_test.dart
@@ -241,5 +241,77 @@ void main() {
         }
       }
     });
+    test("for ヤーズフレックス", () async {
+      final anyDate = DateTime.parse("2020-09-19");
+      final one = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 0,
+      );
+      final two = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 1,
+      );
+      final three = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 2,
+      );
+      final four = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 3,
+      );
+      final five = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 4,
+      );
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ["1", "2", "3", "4", "5"],
+        pillSheets: [one, two, three, four, five],
+        createdAt: anyDate,
+      );
+      final setting = Setting(
+        pillSheetTypes: [
+          PillSheetType.pillsheet_28_0,
+          PillSheetType.pillsheet_28_0,
+          PillSheetType.pillsheet_28_0,
+          PillSheetType.pillsheet_28_0,
+          PillSheetType.pillsheet_28_0
+        ],
+        pillNumberForFromMenstruation: 120,
+        durationMenstruation: 3,
+        isOnReminder: true,
+      );
+
+      final pillSheetTypes = [
+        PillSheetType.pillsheet_28_0,
+        PillSheetType.pillsheet_28_0,
+        PillSheetType.pillsheet_28_0,
+        PillSheetType.pillsheet_28_0,
+        PillSheetType.pillsheet_28_0,
+      ];
+
+      for (int pageIndex = 0; pageIndex < pillSheetTypes.length; pageIndex++) {
+        for (int pillNumberIntoPillSheet = 1;
+            pillNumberIntoPillSheet <= pillSheetTypes[pageIndex].totalCount;
+            pillNumberIntoPillSheet++) {
+          expect(
+              RecordPagePillSheet.isContainedMenstruationDuration(
+                pillNumberIntoPillSheet: pillNumberIntoPillSheet,
+                pillSheetGroup: pillSheetGroup,
+                pageIndex: pageIndex,
+                setting: setting,
+              ),
+              pageIndex == 4 &&
+                  8 <= pillNumberIntoPillSheet &&
+                  pillNumberIntoPillSheet <= 10,
+              reason:
+                  "print debug informations pillNumberIntoPillSheet is $pillNumberIntoPillSheet, pageIndex: $pageIndex");
+        }
+      }
+    });
   });
 }

--- a/test/domain/record/components/record_page_pill_sheet_test.dart
+++ b/test/domain/record/components/record_page_pill_sheet_test.dart
@@ -102,5 +102,87 @@ void main() {
         }
       }
     });
+    // It is spec. But unknown about this case is correct
+    test(
+        "group has five pill sheet and scheduled menstruation begin No.2 pillSheet",
+        () async {
+      final anyDate = DateTime.parse("2020-09-19");
+      final one = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 0,
+      );
+      final two = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 1,
+      );
+      final three = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 2,
+      );
+      final four = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 3,
+      );
+      final five = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 4,
+      );
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ["1", "2", "3", "4", "5"],
+        pillSheets: [one, two, three, four, five],
+        createdAt: anyDate,
+      );
+      final setting = Setting(
+        pillSheetTypes: [
+          PillSheetType.pillsheet_28_0,
+          PillSheetType.pillsheet_28_0,
+          PillSheetType.pillsheet_28_0,
+          PillSheetType.pillsheet_28_0,
+          PillSheetType.pillsheet_28_0
+        ],
+        pillNumberForFromMenstruation: 46,
+        durationMenstruation: 3,
+        isOnReminder: true,
+      );
+
+      final pillSheetTypes = [
+        PillSheetType.pillsheet_28_0,
+        PillSheetType.pillsheet_28_0,
+        PillSheetType.pillsheet_28_0,
+        PillSheetType.pillsheet_28_0,
+        PillSheetType.pillsheet_28_0,
+      ];
+
+      for (int pageIndex = 0; pageIndex < pillSheetTypes.length; pageIndex++) {
+        for (int pillNumberIntoPillSheet = 1;
+            pillNumberIntoPillSheet <= pillSheetTypes[pageIndex].totalCount;
+            pillNumberIntoPillSheet++) {
+          final firstMatched = pageIndex == 1 &&
+              18 <= pillNumberIntoPillSheet &&
+              pillNumberIntoPillSheet <= 20;
+          final secondMatched = pageIndex == 3 &&
+              8 <= pillNumberIntoPillSheet &&
+              pillNumberIntoPillSheet <= 10;
+          final thirdPatched = pageIndex == 4 &&
+              26 <= pillNumberIntoPillSheet &&
+              pillNumberIntoPillSheet <= 28;
+          expect(
+              RecordPagePillSheet.isContainedMenstruationDuration(
+                pillNumberIntoPillSheet: pillNumberIntoPillSheet,
+                pillSheetGroup: pillSheetGroup,
+                pageIndex: pageIndex,
+                setting: setting,
+              ),
+              firstMatched || secondMatched || thirdPatched,
+              reason:
+                  "print debug informations pillNumberIntoPillSheet is $pillNumberIntoPillSheet, pageIndex: $pageIndex");
+        }
+      }
+    });
   });
 }

--- a/test/domain/record/components/record_page_pill_sheet_test.dart
+++ b/test/domain/record/components/record_page_pill_sheet_test.dart
@@ -17,6 +17,7 @@ void main() {
       final pillSheet = PillSheet(
         typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
         beginingDate: anyDate,
+        groupIndex: 0,
       );
       final pillSheetGroup = PillSheetGroup(
         pillSheetIDs: ["1"],
@@ -39,6 +40,59 @@ void main() {
                 pageIndex: pageIndex,
                 setting: setting),
             22 <= i && i <= 24,
+            reason: "print debug informations pillNumberIntoPillSheet is $i");
+      }
+    });
+    test(
+        "group has three pill sheet and scheduled menstruation begin No.2 pillSheet",
+        () async {
+      final anyDate = DateTime.parse("2020-09-19");
+      final one = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 0,
+      );
+      final two = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 1,
+      );
+      final three = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+        groupIndex: 2,
+      );
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ["1", "2", "3"],
+        pillSheets: [one, two, three],
+        createdAt: anyDate,
+      );
+      final setting = Setting(
+        pillSheetTypes: [
+          PillSheetType.pillsheet_28_0,
+          PillSheetType.pillsheet_28_0,
+          PillSheetType.pillsheet_28_0
+        ],
+        pillNumberForFromMenstruation: 46,
+        durationMenstruation: 3,
+        isOnReminder: true,
+      );
+      final pageIndex = 0;
+
+      final totalCount = [
+        PillSheetType.pillsheet_28_0,
+        PillSheetType.pillsheet_28_0,
+        PillSheetType.pillsheet_28_0
+      ].map((e) => e.totalCount).reduce((value, element) => value + element);
+
+      for (int i = 1; i <= totalCount; i++) {
+        expect(
+            RecordPagePillSheet.isContainedMenstruationDuration(
+                pillNumberIntoPillSheet: i,
+                pillSheetGroup: pillSheetGroup,
+                pageIndex: pageIndex,
+                setting: setting),
+            46 <= i && i <= 48,
             reason: "print debug informations pillNumberIntoPillSheet is $i");
       }
     });

--- a/test/domain/record/components/record_page_pill_sheet_test.dart
+++ b/test/domain/record/components/record_page_pill_sheet_test.dart
@@ -1,0 +1,46 @@
+import 'package:pilll/domain/record/components/pill_sheet/record_page_pill_sheet.dart';
+import 'package:pilll/entity/pill_sheet.dart';
+import 'package:pilll/entity/pill_sheet_group.dart';
+import 'package:pilll/entity/pill_sheet_type.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pilll/entity/setting.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+  });
+  group("#RecordPagePillSheet.isContainedMenstruationDuration", () {
+    test("group has only one pill sheet", () async {
+      final anyDate = DateTime.parse("2020-09-19");
+      final pillSheet = PillSheet(
+        typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
+        beginingDate: anyDate,
+      );
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ["1"],
+        pillSheets: [pillSheet],
+        createdAt: anyDate,
+      );
+      final setting = Setting(
+        pillSheetTypes: [PillSheetType.pillsheet_28_0],
+        pillNumberForFromMenstruation: 22,
+        durationMenstruation: 3,
+        isOnReminder: true,
+      );
+      final pageIndex = 0;
+
+      for (int i = 1; i <= 28; i++) {
+        expect(
+            RecordPagePillSheet.isContainedMenstruationDuration(
+                pillNumberIntoPillSheet: i,
+                pillSheetGroup: pillSheetGroup,
+                pageIndex: pageIndex,
+                setting: setting),
+            22 <= i && i <= 24,
+            reason: "print debug informations pillNumberIntoPillSheet is $i");
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Abstract
生理番号の計算が間違っていたので修正

## Spec

```
    pillNumberIntoPillSheet の値によって二つの動きをする
    setting.pillNumberForFromMenstruation < pillSheet.typeInfo.totalCount の場合は単純にこの式の結果を用いる
    setting.pillNumberForFromMenstruation > pillSheet.typeInfo.totalCount の場合はページ数も考慮して
      pillSheet.begin < pillNumberForFromMenstruation < pillSheet.typeInfo.totalCount の場合の結果を用いる

    - 想定される使い方は各ピルシートごとに同じ生理の期間開始を設定したい(1つ目の仕様)
    - ヤーズフレックスのようにどこか1枚だけ生理の開始期間を設定したい(2つ目の仕様)

    なので後者の計算式で下のようになっても許容をすることにする

    28錠タイプが4枚ある場合で46番ごとに生理期間がくる設定をしていると生理期間の始まりが
      1枚目: なし
      2枚目: 18番から
      3枚目: なし
      4枚目: 8番から
```