### PR TITLE
Fix taken method for straddle pill sheet

### DIFF
--- a/lib/components/organisms/calendar/utility.dart
+++ b/lib/components/organisms/calendar/utility.dart
@@ -96,7 +96,7 @@ List<DateRange> nextPillSheetDateRanges(
   return List.generate(count.toInt(), (groupPageIndex) {
     return pillSheetGroup.pillSheets.map((pillSheet) {
       final offset = groupPageIndex * pillSheetGroup.totalPillCountIntoGroup;
-      final begin = pillSheet.scheduledLastTakenDate.add(Duration(days: 1));
+      final begin = pillSheet.estimatedLastTakenDate.add(Duration(days: 1));
       final end = begin.add(Duration(days: Weekday.values.length - 1));
       return DateRange(
           begin.add(Duration(days: offset)), end.add(Duration(days: offset)));

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_taken_pill_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_taken_pill_action.dart
@@ -28,7 +28,7 @@ class PillSheetModifiedHistoryTakenPillAction extends StatelessWidget {
     if (value == null || afterPillSheet == null) {
       return Container();
     }
-    final time = DateTimeFormatter.hourAndMinute(value.afterLastTakenDate);
+    final time = DateTimeFormatter.hourAndMinute(estimatedEventCausingDate);
     return GestureDetector(
       onTap: () {
         analytics.logEvent(name: "tapped_history_taken_action");

--- a/lib/domain/record/components/button/record_page_button.dart
+++ b/lib/domain/record/components/button/record_page_button.dart
@@ -12,7 +12,7 @@ class RecordPageButton extends StatelessWidget {
   }) : super(key: key);
 
   Widget build(BuildContext context) {
-    if (currentPillSheet.allTaken)
+    if (currentPillSheet.isAllTaken)
       return CancelButton(currentPillSheet);
     else
       return TakenButton(

--- a/lib/domain/record/util/take.dart
+++ b/lib/domain/record/util/take.dart
@@ -74,9 +74,9 @@ Future<PillSheetGroup?> take({
     if (pillSheet.allTaken) {
       return pillSheet;
     }
-    if (takenDate.isAfter(pillSheet.scheduledLastTakenDate)) {
+    if (takenDate.isAfter(pillSheet.estimatedLastTakenDate)) {
       return pillSheet.copyWith(
-          lastTakenDate: pillSheet.scheduledLastTakenDate);
+          lastTakenDate: pillSheet.estimatedLastTakenDate);
     } else {
       return pillSheet.copyWith(lastTakenDate: takenDate);
     }

--- a/lib/domain/record/util/take.dart
+++ b/lib/domain/record/util/take.dart
@@ -74,6 +74,9 @@ Future<PillSheetGroup?> take({
     if (pillSheet.allTaken) {
       return pillSheet;
     }
+
+    // takenDateよりも予測するピルシートが大きい場合はactivedPillSheetじゃないPillSheetと判断。
+    // そのピルシートの最終日で予測する最終服用日を記録する
     if (takenDate.isAfter(pillSheet.estimatedLastTakenDate)) {
       return pillSheet.copyWith(
           lastTakenDate: pillSheet.estimatedLastTakenDate);

--- a/lib/domain/record/util/take.dart
+++ b/lib/domain/record/util/take.dart
@@ -71,7 +71,7 @@ Future<PillSheetGroup?> take({
     if (pillSheet.groupIndex > activedPillSheet.groupIndex) {
       return pillSheet;
     }
-    if (pillSheet.isAllTaken) {
+    if (pillSheet.isEnded) {
       return pillSheet;
     }
 

--- a/lib/domain/record/util/take.dart
+++ b/lib/domain/record/util/take.dart
@@ -71,7 +71,7 @@ Future<PillSheetGroup?> take({
     if (pillSheet.groupIndex > activedPillSheet.groupIndex) {
       return pillSheet;
     }
-    if (pillSheet.allTaken) {
+    if (pillSheet.isAllTaken) {
       return pillSheet;
     }
 

--- a/lib/entity/pill_sheet.dart
+++ b/lib/entity/pill_sheet.dart
@@ -104,6 +104,8 @@ abstract class PillSheet implements _$PillSheet {
     return DateRange(begin, end).inRange(n);
   }
 
-  DateTime get scheduledLastTakenDate =>
-      beginingDate.add(Duration(days: pillSheetType.totalCount - 1));
+  DateTime get scheduledLastTakenDate => beginingDate
+      .add(Duration(days: pillSheetType.totalCount))
+      .date()
+      .subtract(Duration(seconds: 1));
 }

--- a/lib/entity/pill_sheet.dart
+++ b/lib/entity/pill_sheet.dart
@@ -90,7 +90,7 @@ abstract class PillSheet implements _$PillSheet {
       ? 0
       : lastTakenDate!.date().difference(beginingDate.date()).inDays + 1;
 
-  bool get allTaken => todayPillNumber == lastTakenPillNumber;
+  bool get allTaken => typeInfo.totalCount == lastTakenPillNumber;
   bool get isReached =>
       beginingDate.date().toUtc().millisecondsSinceEpoch <
       now().toUtc().millisecondsSinceEpoch;

--- a/lib/entity/pill_sheet.dart
+++ b/lib/entity/pill_sheet.dart
@@ -105,7 +105,7 @@ abstract class PillSheet implements _$PillSheet {
   }
 
   DateTime get scheduledLastTakenDate => beginingDate
-      .add(Duration(days: pillSheetType.totalCount))
+      .add(Duration(days: pillSheetType.totalCount - 1))
       .date()
       .add(Duration(days: 1))
       .subtract(Duration(seconds: 1));

--- a/lib/entity/pill_sheet.dart
+++ b/lib/entity/pill_sheet.dart
@@ -90,7 +90,7 @@ abstract class PillSheet implements _$PillSheet {
       ? 0
       : lastTakenDate!.date().difference(beginingDate.date()).inDays + 1;
 
-  bool get allTaken => typeInfo.totalCount == lastTakenPillNumber;
+  bool get isAllTaken => todayPillNumber == lastTakenPillNumber;
   bool get isReached =>
       beginingDate.date().toUtc().millisecondsSinceEpoch <
       now().toUtc().millisecondsSinceEpoch;

--- a/lib/entity/pill_sheet.dart
+++ b/lib/entity/pill_sheet.dart
@@ -104,7 +104,7 @@ abstract class PillSheet implements _$PillSheet {
     return DateRange(begin, end).inRange(n);
   }
 
-  DateTime get scheduledLastTakenDate => beginingDate
+  DateTime get estimatedLastTakenDate => beginingDate
       .add(Duration(days: pillSheetType.totalCount - 1))
       .date()
       .add(Duration(days: 1))

--- a/lib/entity/pill_sheet.dart
+++ b/lib/entity/pill_sheet.dart
@@ -91,6 +91,7 @@ abstract class PillSheet implements _$PillSheet {
       : lastTakenDate!.date().difference(beginingDate.date()).inDays + 1;
 
   bool get isAllTaken => todayPillNumber == lastTakenPillNumber;
+  bool get isEnded => typeInfo.totalCount == lastTakenPillNumber;
   bool get isReached =>
       beginingDate.date().toUtc().millisecondsSinceEpoch <
       now().toUtc().millisecondsSinceEpoch;

--- a/lib/entity/pill_sheet.dart
+++ b/lib/entity/pill_sheet.dart
@@ -107,5 +107,6 @@ abstract class PillSheet implements _$PillSheet {
   DateTime get scheduledLastTakenDate => beginingDate
       .add(Duration(days: pillSheetType.totalCount))
       .date()
+      .add(Duration(days: 1))
       .subtract(Duration(seconds: 1));
 }

--- a/test/domain/record/record_page_state_test.dart
+++ b/test/domain/record/record_page_state_test.dart
@@ -109,7 +109,7 @@ void main() {
       );
 
       await waitForResetStoreState();
-      expect(state.pillSheetGroup?.pillSheets.first.allTaken, isTrue);
+      expect(state.pillSheetGroup?.pillSheets.first.isAllTaken, isTrue);
       expect(
           store.markFor(pillNumberIntoPillSheet: 1, pillSheet: pillSheetEntity),
           PillMarkType.done);
@@ -184,7 +184,7 @@ void main() {
       );
 
       await waitForResetStoreState();
-      expect(state.pillSheetGroup?.pillSheets.first.allTaken, isFalse);
+      expect(state.pillSheetGroup?.pillSheets.first.isAllTaken, isFalse);
       expect(
           store.markFor(pillNumberIntoPillSheet: 1, pillSheet: pillSheetEntity),
           PillMarkType.done);
@@ -261,7 +261,7 @@ void main() {
       );
 
       await waitForResetStoreState();
-      expect(state.pillSheetGroup?.pillSheets.first.allTaken, isTrue);
+      expect(state.pillSheetGroup?.pillSheets.first.isAllTaken, isTrue);
       for (int i = 1; i <= pillSheetEntity.pillSheetType.totalCount; i++) {
         expect(
             store.shouldPillMarkAnimation(
@@ -333,7 +333,7 @@ void main() {
       );
 
       await waitForResetStoreState();
-      expect(state.pillSheetGroup?.pillSheets.first.allTaken, isFalse);
+      expect(state.pillSheetGroup?.pillSheets.first.isAllTaken, isFalse);
       expect(
           store.shouldPillMarkAnimation(
             pillNumberIntoPillSheet: 3,

--- a/test/domain/record/record_page_store_test.dart
+++ b/test/domain/record/record_page_store_test.dart
@@ -457,7 +457,7 @@ void main() {
     test("group has two pill sheet for first pillSheet.isFill pattern",
         () async {
       var mockTodayRepository = MockTodayService();
-      final _today = DateTime.parse("2020-09-19");
+      final _today = DateTime.parse("2022-05-29");
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.today()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
@@ -474,9 +474,9 @@ void main() {
       final pillSheet = PillSheet(
         id: "sheet_id",
         typeInfo: PillSheetType.pillsheet_28_0.typeInfo,
-        beginingDate: _today.subtract(Duration(days: 28)),
+        beginingDate: DateTime.parse("2022-05-01"),
         groupIndex: 0,
-        lastTakenDate: _today.subtract(Duration(days: 1)),
+        lastTakenDate: DateTime.parse("2022-05-28"),
       );
       final pillSheet2 = PillSheet(
         id: "sheet_id_2",
@@ -608,7 +608,8 @@ void main() {
       );
       final pillSheetService = MockPillSheetService();
       when(pillSheetService.update(batch, [
-        pillSheet.copyWith(lastTakenDate: DateTime.parse("2020-09-18")),
+        pillSheet.copyWith(
+            lastTakenDate: DateTime.parse("2020-09-18 23:59:59")),
         pillSheet2.copyWith(lastTakenDate: _today)
       ])).thenReturn(null);
 
@@ -625,7 +626,8 @@ void main() {
         id: "group_id",
         pillSheetIDs: ["sheet_id", "sheet_id_2"],
         pillSheets: [
-          pillSheet.copyWith(lastTakenDate: DateTime.parse("2020-09-18")),
+          pillSheet.copyWith(
+              lastTakenDate: DateTime.parse("2020-09-18 23:59:59")),
           pillSheet2.copyWith(lastTakenDate: _today),
         ],
         createdAt: _today,

--- a/test/entity/pill_sheet_test.dart
+++ b/test/entity/pill_sheet_test.dart
@@ -241,4 +241,20 @@ void main() {
       expect(model.isReached, false);
     });
   });
+  group("#estimatedLastTakenDate", () {
+    test("spec", () {
+      var sheetType = PillSheetType.pillsheet_21;
+      var pillSheet = PillSheet(
+        beginingDate: DateTime.parse("2022-05-01"),
+        typeInfo: PillSheetTypeInfo(
+          dosingPeriod: sheetType.dosingPeriod,
+          name: sheetType.fullName,
+          totalCount: sheetType.totalCount,
+          pillSheetTypeReferencePath: sheetType.rawPath,
+        ),
+      );
+      expect(pillSheet.estimatedLastTakenDate,
+          DateTime.parse("2022-05-29").subtract(Duration(seconds: 1)));
+    });
+  });
 }


### PR DESCRIPTION
## Abstract
履歴の服用時刻がピルシートを始めた時刻 + 日付になるパターンがあったので修正。
再現方法はピルシートを作って、番号を28番に変更して、服用記録をつけるとできる

## How
- afterLastTakenDateを表示する必要もないか。と思いestimatedEventCausedDateを表示するようにした
- 計算式がbeginDate + totalCountという形式だったが、上記の場合はbeginDate + totalCount + (1 day - 1 second) の状態で計算が正しいと思い修正した