### PR TITLE
Fix implementation quick record

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -62,9 +62,11 @@ extension AppDelegate {
                 isCompleted = true
                 completionHandler()
             }
+
             UIApplication.shared.applicationIconBadgeNumber = 0
 
             super.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandlerWrapper)
+
             if !isCompleted {
                 completionHandlerWrapper()
             }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -12,7 +12,6 @@ import Flutter
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             self.migrateFrom_1_3_2()
         }
-        swizzleNotificationCenterDelegateMethod()
         configureNotificationActionableButtons()
         UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: ["repeat_notification_for_taken_pill", "remind_notification_for_taken_pill"])
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["repeat_notification_for_taken_pill", "remind_notification_for_taken_pill"])
@@ -42,16 +41,6 @@ extension AppDelegate {
             call(method: "salvagedOldStartTakenDate", arguments: ["salvagedOldStartTakenDate": salvagedValue, "salvagedOldLastTakenDate": lastTakenDate])
         }
     }
-    func swizzleNotificationCenterDelegateMethod() {
-        guard let fromMethod = class_getInstanceMethod(type(of: self), #selector(AppDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:))) else {
-            fatalError()
-        }
-        guard let toMethod = class_getInstanceMethod(type(of: self), #selector(AppDelegate.userNotificationCenter_methodSwizzling(_:didReceive:withCompletionHandler:))) else {
-            fatalError()
-        }
-        
-        method_exchangeImplementations(fromMethod, toMethod)
-    }
 
     func configureNotificationActionableButtons() {
         let recordAction = UNNotificationAction(identifier: "RECORD_PILL",
@@ -65,7 +54,8 @@ extension AppDelegate {
         UNUserNotificationCenter.current().setNotificationCategories([category])
     }
 
-    @objc func userNotificationCenter_methodSwizzling(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+
+    override func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         func end() {
             var isCompleted: Bool = false
             let completionHandlerWrapper = {
@@ -92,7 +82,7 @@ extension AppDelegate {
             }
         }
     }
-   
+
     enum Category: String {
         case pillReminder = "PILL_REMINDER"
     }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -63,6 +63,8 @@ extension AppDelegate {
                 completionHandler()
             }
             UIApplication.shared.applicationIconBadgeNumber = 0
+
+            super.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandlerWrapper)
             if !isCompleted {
                 completionHandlerWrapper()
             }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -63,7 +63,6 @@ extension AppDelegate {
                 completionHandler()
             }
             UIApplication.shared.applicationIconBadgeNumber = 0
-            userNotificationCenter_methodSwizzling(center, didReceive: response, withCompletionHandler: completionHandlerWrapper)
             if !isCompleted {
                 completionHandlerWrapper()
             }


### PR DESCRIPTION
## Abstract
QuickRecordの実装をMethod Swizzleを使用したものではなくクラスのoverrideを用いることにした

## Why
Quick Recordが実行できないから

### Memo
少しコードを追ったのでメモ

- [FlutterAppDelegateでLifeCycleDelegateという役割にDelegateしている。](https://github.com/flutter/engine/blob/master/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm#L106-L118)
- [FlutterPluginAppLifeCycleDelegateでは(おそらく)外部のプラグイン・ライブラリからのネイティブアプリのDelegateイベントのフックの仲介役として機能としている](https://github.com/flutter/engine/blob/master/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm#L299-L311)
- [FlutterFire](https://github.com/flutter/engine/blob/master/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm#L299-L311)のiOSの実装を見ると、必要な処理を行なった後に元々のUNUserNotificationCenter.current.delegateにイベントをForwardingしている
  - https://github.com/FirebaseExtended/flutterfire/blob/master/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m#L220-L260
  - https://github.com/FirebaseExtended/flutterfire/blob/master/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m#L321-L346