### PR TITLE
Bugfix appearance record buttons

### DIFF
--- a/lib/domain/record/components/header/record_page_header.dart
+++ b/lib/domain/record/components/header/record_page_header.dart
@@ -58,7 +58,7 @@ class RecordPageInformationHeader extends StatelessWidget {
                         name: "tapped_record_information_header");
                     if (activedPillSheet != null &&
                         pillSheetGroup != null &&
-                        !pillSheetGroup.isDeleted) {
+                        !pillSheetGroup.isDeactived) {
                       Navigator.of(context).push(
                         SettingTodayPillNumberPageRoute.route(
                           pillSheetGroup: pillSheetGroup,

--- a/lib/domain/record/components/header/today_taken_pill_number.dart
+++ b/lib/domain/record/components/header/today_taken_pill_number.dart
@@ -44,8 +44,7 @@ class TodayTakenPillNumber extends StatelessWidget {
     final activedPillSheet = this.pillSheetGroup?.activedPillSheet;
     if (pillSheetGroup == null ||
         activedPillSheet == null ||
-        pillSheetGroup.isDeactived ||
-        pillSheetGroup.isDeleted) {
+        pillSheetGroup.isDeactived) {
       return Padding(
           padding: EdgeInsets.only(top: 8),
           child: Text("-",

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -74,7 +74,7 @@ class RecordPage extends HookWidget {
                 ),
               ),
             ),
-            if (currentPillSheet != null)
+            if (currentPillSheet != null && !state.isDeactived)
               Positioned(
                 bottom: 20,
                 child: RecordPageButton(currentPillSheet: currentPillSheet),
@@ -91,13 +91,13 @@ class RecordPage extends HookWidget {
     RecordPageState state,
     RecordPageStore store,
   ) {
-    if (state.pillSheetGroupIsHidden)
+    if (state.isDeactived)
       return RecordPageAddingPillSheet(
         context: context,
         store: store,
         setting: settingEntity,
       );
-    if (!state.pillSheetGroupIsHidden)
+    if (!state.isDeactived)
       return RecordPagePillSheetList(
         state: state,
         store: store,

--- a/lib/domain/record/record_page_state.dart
+++ b/lib/domain/record/record_page_state.dart
@@ -30,7 +30,7 @@ abstract class RecordPageState implements _$RecordPageState {
     return pillSheetGroup?.activedPillSheet?.groupIndex ?? 0;
   }
 
-  bool get pillSheetGroupIsHidden {
+  bool get isDeactived {
     final pillSheetGroup = this.pillSheetGroup;
     return pillSheetGroup == null ||
         pillSheetGroup.isDeactived ||

--- a/lib/domain/record/record_page_state.dart
+++ b/lib/domain/record/record_page_state.dart
@@ -32,9 +32,7 @@ abstract class RecordPageState implements _$RecordPageState {
 
   bool get isDeactived {
     final pillSheetGroup = this.pillSheetGroup;
-    return pillSheetGroup == null ||
-        pillSheetGroup.isDeactived ||
-        pillSheetGroup.isDeleted;
+    return pillSheetGroup == null || pillSheetGroup.isDeactived;
   }
 
   bool get shouldShowTrial {

--- a/lib/domain/settings/setting_page.dart
+++ b/lib/domain/settings/setting_page.dart
@@ -109,7 +109,7 @@ class SettingPage extends HookWidget {
                       _separator(),
                       if (activedPillSheet != null &&
                           pillSheetGroup != null &&
-                          !pillSheetGroup.isDeleted) ...[
+                          !pillSheetGroup.isDeactived) ...[
                         TodayPllNumberRow(
                           setting: setting,
                           pillSheetGroup: pillSheetGroup,

--- a/lib/entity/pill_sheet_group.dart
+++ b/lib/entity/pill_sheet_group.dart
@@ -124,6 +124,6 @@ abstract class PillSheetGroup implements _$PillSheetGroup {
     return passedPillCount + latestTakenPillSheet.lastTakenPillNumber;
   }
 
-  bool get isDeactived => activedPillSheet == null;
   bool get isDeleted => deletedAt != null;
+  bool get isDeactived => activedPillSheet == null || isDeleted;
 }

--- a/lib/entity/pill_sheet_group.dart
+++ b/lib/entity/pill_sheet_group.dart
@@ -124,6 +124,6 @@ abstract class PillSheetGroup implements _$PillSheetGroup {
     return passedPillCount + latestTakenPillSheet.lastTakenPillNumber;
   }
 
-  bool get isDeleted => deletedAt != null;
-  bool get isDeactived => activedPillSheet == null || isDeleted;
+  bool get _isDeleted => deletedAt != null;
+  bool get isDeactived => activedPillSheet == null || _isDeleted;
 }


### PR DESCRIPTION
## Abstract
- ピルシートがない状態で飲んだボタンが表示される

## Why
pillSheetGroup.isDeletedの分岐の入れ忘れ

## How
pillSheetGroup.isDeactivedに統一してそれを各所で使うようにした