### PR TITLE
BugFix quick record

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -34,6 +34,8 @@ extension AppDelegate {
     }
 }
 
+// MARK: - Avoid bug for flutter app badger
+// ref: https://github.com/g123k/flutter_app_badger/pull/52
 extension UNUserNotificationCenter {
     func swizzle() {
         guard let fromMethod = class_getInstanceMethod(type(of: self), #selector(UNUserNotificationCenter.setNotificationCategories(_:))) else {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -12,10 +12,10 @@ import Flutter
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             self.migrateFrom_1_3_2()
         }
+        swizzleNotificationCenterDelegateMethod()
         configureNotificationActionableButtons()
         UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: ["repeat_notification_for_taken_pill", "remind_notification_for_taken_pill"])
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["repeat_notification_for_taken_pill", "remind_notification_for_taken_pill"])
-        UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
         GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
@@ -55,7 +55,18 @@ extension AppDelegate {
     }
 
 
-    override func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+    func swizzleNotificationCenterDelegateMethod() {
+        guard let fromMethod = class_getInstanceMethod(type(of: self), #selector(AppDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:))) else {
+            fatalError()
+        }
+        guard let toMethod = class_getInstanceMethod(type(of: self), #selector(AppDelegate.userNotificationCenter_methodSwizzling(_:didReceive:withCompletionHandler:))) else {
+            fatalError()
+        }
+
+        method_exchangeImplementations(fromMethod, toMethod)
+    }
+
+    @objc func userNotificationCenter_methodSwizzling(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         func end() {
             var isCompleted: Bool = false
             let completionHandlerWrapper = {
@@ -65,7 +76,7 @@ extension AppDelegate {
 
             UIApplication.shared.applicationIconBadgeNumber = 0
 
-            super.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandlerWrapper)
+            userNotificationCenter_methodSwizzling(center, didReceive: response, withCompletionHandler: completionHandlerWrapper)
 
             if !isCompleted {
                 completionHandlerWrapper()


### PR DESCRIPTION
## Abstract
Quick Recordが依然として機能しない場合があるので修正

再現しやすい手順としては下の通りである
- 何かしらの手順で服用記録する
- 服用記録を取り消す

色々探っていくとFlutterAppBadgerで登録していたプッシュ通知のActionableButtonのCategory達がnilで上書きされるようになっていた
奇しくも先日のFlutterAppBadgerのアプデでOSのバージョンごとによる分岐が入ったため、ライブラリのアプデでも直りそうだが、一旦うまく動いている方法でリリースをする。あとライブラリ自体が大したサイズじゃないので車輪の再発明をしちゃおうかとも思っている。とりあえずこのままいく

ref: https://github.com/g123k/flutter_app_badger/pull/52