### PR TITLE
Fix appearance history row for across pillsheet taken action

### DIFF
--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_taken_pill_action.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_taken_pill_action.dart
@@ -12,20 +12,23 @@ import 'package:pilll/util/formatter/date_time_formatter.dart';
 class PillSheetModifiedHistoryTakenPillAction extends StatelessWidget {
   final DateTime estimatedEventCausingDate;
   final TakenPillValue? value;
+  final PillSheet? beforePillSheet;
   final PillSheet? afterPillSheet;
 
   const PillSheetModifiedHistoryTakenPillAction({
     Key? key,
     required this.estimatedEventCausingDate,
     required this.value,
+    required this.beforePillSheet,
     required this.afterPillSheet,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     final value = this.value;
+    final beforePillSheet = this.beforePillSheet;
     final afterPillSheet = this.afterPillSheet;
-    if (value == null || afterPillSheet == null) {
+    if (value == null || afterPillSheet == null || beforePillSheet == null) {
       return Container();
     }
     final time = DateTimeFormatter.hourAndMinute(estimatedEventCausingDate);
@@ -71,7 +74,10 @@ class PillSheetModifiedHistoryTakenPillAction extends StatelessWidget {
                           .takenMark,
                       padding: EdgeInsets.only(left: 8),
                       child: TakenPillActionOList(
-                          value: value, afterPillSheet: afterPillSheet),
+                        value: value,
+                        beforePillSheet: beforePillSheet,
+                        afterPillSheet: afterPillSheet,
+                      ),
                     ),
                   ],
                 ),

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/taken_pill_action_o_list.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/taken_pill_action_o_list.dart
@@ -20,6 +20,9 @@ class TakenPillActionOList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (beforePillSheet.groupIndex != afterPillSheet.groupIndex) {
+      return SvgPicture.asset("images/dots.svg");
+    }
     final count = max(
         value.afterLastTakenPillNumber - (value.beforeLastTakenPillNumber), 1);
     return Container(

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/taken_pill_action_o_list.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/taken_pill_action_o_list.dart
@@ -8,11 +8,13 @@ import 'package:pilll/entity/pill_sheet_modified_history_value.dart';
 
 class TakenPillActionOList extends StatelessWidget {
   final TakenPillValue value;
+  final PillSheet beforePillSheet;
   final PillSheet afterPillSheet;
 
   const TakenPillActionOList({
     Key? key,
     required this.value,
+    required this.beforePillSheet,
     required this.afterPillSheet,
   }) : super(key: key);
 

--- a/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_list.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_list.dart
@@ -117,6 +117,7 @@ class CalendarPillSheetModifiedHistoryList extends StatelessWidget {
                         estimatedEventCausingDate:
                             history.estimatedEventCausingDate,
                         value: history.value.takenPill,
+                        beforePillSheet: history.before,
                         afterPillSheet: history.after,
                       );
                     case PillSheetModifiedActionType.revertTakenPill:


### PR DESCRIPTION
## Abstract
ピルシートを跨いだ時の服用のアクションについての服用履歴の見た目を `...` にする。跨がない場合は :o: が並んでいる

## Why
ピルシートを跨いだ時のことを考慮してなくて表示される番号がおかしいことが発覚 & 考慮する場合についてもグループのデータのスナップショットをとっておくのは量的に現実的じゃないので表記を変更することにした。
ref: https://github.com/bannzai/Pilll/pull/397