### PR TITLE
Avoid duplicated alert on RecordPage

### DIFF
--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -25,6 +25,13 @@ class RecordPage extends HookWidget {
     final state = useProvider(recordPageStoreProvider.state);
     final store = useProvider(recordPageStoreProvider);
 
+    final pillSheetGroup = state.pillSheetGroup;
+    final activedPillSheet = pillSheetGroup?.activedPillSheet;
+    final settingEntity = state.setting;
+    if (settingEntity == null || !state.firstLoadIsEnded) {
+      return Indicator();
+    }
+
     Future.microtask(() async {
       if (state.shouldShowMigrateInfo) {
         _showMigrateInfoDialog(context, store);
@@ -37,13 +44,6 @@ class RecordPage extends HookWidget {
         });
       }
     });
-
-    final pillSheetGroup = state.pillSheetGroup;
-    final activedPillSheet = pillSheetGroup?.activedPillSheet;
-    final settingEntity = state.setting;
-    if (settingEntity == null || !state.firstLoadIsEnded) {
-      return Indicator();
-    }
 
     return UniversalErrorPage(
       error: state.exception,

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -36,9 +36,8 @@ class RecordPage extends HookWidget {
       if (state.shouldShowMigrateInfo) {
         _showMigrateInfoDialog(context, store);
       } else if (state.shouldShowPremiumFunctionSurvey) {
-        await Navigator.of(context)
-            .push(PremiumFunctionSurveyPageRoutes.route());
         await store.setTrueIsAlreadyShowPremiumFunctionSurvey();
+        Navigator.of(context).push(PremiumFunctionSurveyPageRoutes.route());
       } else if (state.shouldShowTrial) {
         showPremiumTrialModalWhenLaunchApp(context, () {
           showPremiumTrialCompleteModalPreDialog(context);

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -36,8 +36,9 @@ class RecordPage extends HookWidget {
       if (state.shouldShowMigrateInfo) {
         _showMigrateInfoDialog(context, store);
       } else if (state.shouldShowPremiumFunctionSurvey) {
+        await Navigator.of(context)
+            .push(PremiumFunctionSurveyPageRoutes.route());
         await store.setTrueIsAlreadyShowPremiumFunctionSurvey();
-        Navigator.of(context).push(PremiumFunctionSurveyPageRoutes.route());
       } else if (state.shouldShowTrial) {
         showPremiumTrialModalWhenLaunchApp(context, () {
           showPremiumTrialCompleteModalPreDialog(context);

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -24,28 +24,18 @@ class RecordPage extends HookWidget {
   Widget build(BuildContext context) {
     final state = useProvider(recordPageStoreProvider.state);
     final store = useProvider(recordPageStoreProvider);
-    Future.delayed(Duration(seconds: 1)).then((_) {
-      if (!state.shouldShowMigrateInfo) {
-        return;
-      }
-      _showMigrateInfoDialog(context, store);
-    });
-
-    Future.delayed(Duration(seconds: 1)).then((_) {
-      if (!state.shouldShowTrial) {
-        return;
-      }
-      showPremiumTrialModalWhenLaunchApp(context, () {
-        showPremiumTrialCompleteModalPreDialog(context);
-      });
-    });
 
     Future.microtask(() async {
-      if (!state.shouldShowPremiumFunctionSurvey) {
-        return;
+      if (state.shouldShowMigrateInfo) {
+        _showMigrateInfoDialog(context, store);
+      } else if (state.shouldShowPremiumFunctionSurvey) {
+        await store.setTrueIsAlreadyShowPremiumFunctionSurvey();
+        Navigator.of(context).push(PremiumFunctionSurveyPageRoutes.route());
+      } else if (state.shouldShowTrial) {
+        showPremiumTrialModalWhenLaunchApp(context, () {
+          showPremiumTrialCompleteModalPreDialog(context);
+        });
       }
-      await store.setTrueIsAlreadyShowPremiumFunctionSurvey();
-      Navigator.of(context).push(PremiumFunctionSurveyPageRoutes.route());
     });
 
     final pillSheetGroup = state.pillSheetGroup;

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -40,7 +40,7 @@ class RecordPage extends HookWidget {
       });
     });
 
-    Future.delayed(Duration(seconds: 1)).then((_) async {
+    Future.microtask(() async {
       if (!state.shouldShowPremiumFunctionSurvey) {
         return;
       }

--- a/lib/domain/record/record_page_store.dart
+++ b/lib/domain/record/record_page_store.dart
@@ -68,6 +68,7 @@ class RecordPageStore extends StateNotifier<RecordPageState> {
           isTrial: user.isTrial,
           hasDiscountEntitlement: user.hasDiscountEntitlement,
           discountEntitlementDeadlineDate: user.discountEntitlementDeadlineDate,
+          trialDeadlineDate: user.trialDeadlineDate,
         );
       }),
       Future(() async {


### PR DESCRIPTION
## Abstract
起動時のアラートがダブる時があるので制御を入れる

## TODO
~そもそもStreamの処理が非同期できているので制御できないことに気づいた。いい機会だしStreamに全部統一していこう~
