### PR TITLE
:recycle: Replace to PageView

### DIFF
--- a/lib/components/organisms/calendar/weekly/weekly_calendar.dart
+++ b/lib/components/organisms/calendar/weekly/weekly_calendar.dart
@@ -27,41 +27,44 @@ class CalendarWeekdayLine extends StatelessWidget {
   }) : super(key: key);
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        Row(
-          children: Weekday.values.map((weekday) {
-            final date = calendarState.buildDate(weekday);
-            final isOutOfBoundsInLine = !calendarState.dateRange.inRange(date);
-            if (isOutOfBoundsInLine) {
-              return Expanded(child: Container());
-            }
+    return Container(
+      child: Stack(
+        children: [
+          Row(
+            children: Weekday.values.map((weekday) {
+              final date = calendarState.buildDate(weekday);
+              final isOutOfBoundsInLine =
+                  !calendarState.dateRange.inRange(date);
+              if (isOutOfBoundsInLine) {
+                return Expanded(child: Container());
+              }
 
-            if (calendarState.isGrayoutTile(date)) {
-              return CalendarDayTile.grayout(
+              if (calendarState.isGrayoutTile(date)) {
+                return CalendarDayTile.grayout(
+                  weekday: weekday,
+                  shouldShowMenstruationMark:
+                      calendarState.hasMenstruationMark(date),
+                  contentAlignment: calendarState.contentAlignment,
+                  date: date,
+                );
+              }
+              return CalendarDayTile(
+                isToday: isSameDay(today(), date),
                 weekday: weekday,
+                date: date,
+                shouldShowDiaryMark: calendarState.hasDiaryMark(
+                    calendarState.diariesForMonth, date),
                 shouldShowMenstruationMark:
                     calendarState.hasMenstruationMark(date),
                 contentAlignment: calendarState.contentAlignment,
-                date: date,
+                onTap: (date) => onTap(calendarState, date),
               );
-            }
-            return CalendarDayTile(
-              isToday: isSameDay(today(), date),
-              weekday: weekday,
-              date: date,
-              shouldShowDiaryMark: calendarState.hasDiaryMark(
-                  calendarState.diariesForMonth, date),
-              shouldShowMenstruationMark:
-                  calendarState.hasMenstruationMark(date),
-              contentAlignment: calendarState.contentAlignment,
-              onTap: (date) => onTap(calendarState, date),
-            );
-          }).toList(),
-        ),
-        ..._bands(context, calendarState.allBandModels, calendarState,
-            horizontalPadding)
-      ],
+            }).toList(),
+          ),
+          ..._bands(context, calendarState.allBandModels, calendarState,
+              horizontalPadding)
+        ],
+      ),
     );
   }
 

--- a/lib/domain/calendar/calendar_page.dart
+++ b/lib/domain/calendar/calendar_page.dart
@@ -21,16 +21,16 @@ class CalendarPage extends HookWidget {
     final state = useProvider(calendarPageStateProvider.state);
     homeKey.currentState?.diaries = state.diariesForMonth;
 
+    if (state.shouldShowIndicator) {
+      return ScaffoldIndicator();
+    }
+
     final pageController =
         usePageController(initialPage: state.currentCalendarIndex);
     pageController.addListener(() {
       final index = (pageController.page ?? pageController.initialPage).round();
       store.updateCurrentCalendarIndex(index);
     });
-
-    if (state.shouldShowIndicator) {
-      return ScaffoldIndicator();
-    }
 
     return Scaffold(
       backgroundColor: PilllColors.background,

--- a/lib/domain/calendar/calendar_page.dart
+++ b/lib/domain/calendar/calendar_page.dart
@@ -23,6 +23,10 @@ class CalendarPage extends HookWidget {
 
     final pageController =
         usePageController(initialPage: state.currentCalendarIndex);
+    pageController.addListener(() {
+      final index = (pageController.page ?? pageController.initialPage).round();
+      store.updateCurrentCalendarIndex(index);
+    });
 
     if (state.shouldShowIndicator) {
       return ScaffoldIndicator();

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -24,7 +24,6 @@ import 'package:pilll/entity/weekday.dart';
 import 'package:pilll/domain/menstruation/menstruation_store.dart';
 import 'package:pilll/util/datetime/day.dart';
 import 'package:pilll/util/formatter/date_time_formatter.dart';
-import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 const double _horizontalPadding = 10;
 
@@ -41,13 +40,13 @@ class MenstruationPage extends HookWidget {
   Scaffold build(BuildContext context) {
     final store = useProvider(menstruationsStoreProvider);
     final state = useProvider(menstruationsStoreProvider.state);
-    final ItemPositionsListener itemPositionsListener =
-        ItemPositionsListener.create();
-    itemPositionsListener.itemPositions.addListener(() {
-      final index = itemPositionsListener.itemPositions.value.last.index;
+
+    final pageController =
+        usePageController(initialPage: state.currentCalendarIndex);
+    pageController.addListener(() {
+      final index = (pageController.page ?? pageController.initialPage).round();
       store.updateCurrentCalendarIndex(index);
     });
-    final ItemScrollController itemScrollController = ItemScrollController();
 
     return Scaffold(
       backgroundColor: PilllColors.background,
@@ -68,9 +67,9 @@ class MenstruationPage extends HookWidget {
               Column(
                 children: [
                   MenstruationCalendarHeader(
-                      itemScrollController: itemScrollController,
-                      state: state,
-                      itemPositionsListener: itemPositionsListener),
+                    pageController: pageController,
+                    state: state,
+                  ),
                   Expanded(
                     child: MenstruationCardList(store: store),
                   ),
@@ -198,14 +197,12 @@ class MenstruationCardList extends StatelessWidget {
 class MenstruationCalendarHeader extends StatelessWidget {
   const MenstruationCalendarHeader({
     Key? key,
-    required this.itemScrollController,
     required this.state,
-    required this.itemPositionsListener,
+    required this.pageController,
   }) : super(key: key);
 
-  final ItemScrollController itemScrollController;
   final MenstruationState state;
-  final ItemPositionsListener itemPositionsListener;
+  final PageController pageController;
 
   @override
   Widget build(BuildContext context) {
@@ -222,12 +219,9 @@ class MenstruationCalendarHeader extends StatelessWidget {
             _WeekdayLine(),
             LimitedBox(
               maxHeight: MenstruationPageConst.tileHeight,
-              child: ScrollablePositionedList.builder(
-                itemScrollController: itemScrollController,
-                initialScrollIndex: state.currentCalendarIndex,
+              child: PageView.builder(
                 physics: PageScrollPhysics(),
                 scrollDirection: Axis.horizontal,
-                itemPositionsListener: itemPositionsListener,
                 itemBuilder: (context, index) {
                   final days = state.calendarDataSource[index];
                   return Container(
@@ -257,7 +251,6 @@ class MenstruationCalendarHeader extends StatelessWidget {
                     ),
                   );
                 },
-                itemCount: state.calendarDataSource.length,
               ),
             ),
           ],

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -7,6 +7,7 @@ import 'package:pilll/analytics.dart';
 import 'package:pilll/components/atoms/buttons.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/components/molecules/indicator.dart';
 import 'package:pilll/components/molecules/shadow_container.dart';
 import 'package:pilll/components/organisms/calendar/monthly/monthly_calendar_layout.dart';
 import 'package:pilll/components/organisms/calendar/band/calendar_band_model.dart';
@@ -37,9 +38,13 @@ abstract class MenstruationPageConst {
 
 class MenstruationPage extends HookWidget {
   @override
-  Scaffold build(BuildContext context) {
+  Widget build(BuildContext context) {
     final store = useProvider(menstruationsStoreProvider);
     final state = useProvider(menstruationsStoreProvider.state);
+
+    if (state.isNotYetLoaded) {
+      return ScaffoldIndicator();
+    }
 
     final pageController =
         usePageController(initialPage: state.currentCalendarIndex);
@@ -220,6 +225,7 @@ class MenstruationCalendarHeader extends StatelessWidget {
             LimitedBox(
               maxHeight: MenstruationPageConst.tileHeight,
               child: PageView.builder(
+                controller: pageController,
                 physics: PageScrollPhysics(),
                 scrollDirection: Axis.horizontal,
                 itemBuilder: (context, index) {

--- a/lib/domain/menstruation/menstruation_state.dart
+++ b/lib/domain/menstruation/menstruation_state.dart
@@ -55,6 +55,7 @@ abstract class MenstruationState implements _$MenstruationState {
 
 List<List<DateTime>> _calendarDataSource() {
   final base = today();
+
   var begin = base.subtract(Duration(days: 90));
   final beginWeekdayOffset = WeekdayFunctions.weekdayFromDate(begin).index;
   begin = begin.subtract(Duration(days: beginWeekdayOffset));

--- a/lib/domain/menstruation/menstruation_store.dart
+++ b/lib/domain/menstruation/menstruation_store.dart
@@ -72,8 +72,7 @@ class MenstruationStore extends StateNotifier<MenstruationState> {
   StreamSubscription? _userCanceller;
   void _subscribe() {
     _menstruationCanceller?.cancel();
-    _menstruationCanceller =
-        menstruationService.streamAll().listen((entities) {
+    _menstruationCanceller = menstruationService.streamAll().listen((entities) {
       state = state.copyWith(entities: entities);
     });
     _diaryCanceller?.cancel();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -688,13 +688,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.13.1"
-  scrollable_positioned_list:
-    dependency: "direct main"
-    description:
-      name: scrollable_positioned_list
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.0-nullsafety.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   dotted_border: ^2.0.0-nullsafety.0
   in_app_review: ^2.0.1
   version: ^2.0.0-nullsafety
+  scrollable_positioned_list: ^0.2.0-nullsafety.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,6 @@ dependencies:
   dotted_border: ^2.0.0-nullsafety.0
   in_app_review: ^2.0.1
   version: ^2.0.0-nullsafety
-  scrollable_positioned_list: ^0.2.0-nullsafety.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Abstract
カレンダーのページング処理をFlutter純正のPageViewに置き換える

## Why
特にAndroidの方でinitial pageがおかしいと問い合わせが多かったので対処した