### PR TITLE
Revert ":art: fix spacing"

### DIFF
--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -79,7 +79,7 @@ class RecordPage extends HookWidget {
                 child: Column(
                   children: [
                     NotificationBar(state),
-                    SizedBox(height: 12),
+                    SizedBox(height: 37),
                     _content(context, setting, state, store),
                   ],
                 ),


### PR DESCRIPTION
This reverts commit 6418700d34dd44cda857e5afa882acb729ae04c4.

# Conflicts:
#	lib/domain/record/record_page.dart