### PR TITLE
:bug: Bugfix calculated before pill number when user pill taken

### DIFF
--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_date_component.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_date_component.dart
@@ -110,7 +110,7 @@ extension PillSheetModifiedHistoryDateEffectivePillNumber
     if (before == (after - 1)) {
       return "$after番";
     }
-    return "$before-$after番";
+    return "${before + 1}-$after番";
   }
 
   static String revert(RevertTakenPillValue value) {

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_date_component.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_date_component.dart
@@ -101,7 +101,7 @@ extension PillSheetModifiedHistoryDateEffectivePillNumber
     if (before == (after - 1)) {
       return "$after番";
     }
-    return "${max(before, 1)}-$after番";
+    return "${before + 1}-$after番";
   }
 
   static String autoTaken(AutomaticallyRecordedLastTakenDateValue value) {


### PR DESCRIPTION
## Abstract
複数錠服用した時の左側の値が最後に飲んだピル番号になっていた。最後に飲んだピル番号はすでに服用済みになるので、本来であれば最後に飲んだ日+1を表示してあげるのが正しい