### PR TITLE
Adjustment UI for account cooperation screen

### DIFF
--- a/lib/domain/settings/components/rows/account_link.dart
+++ b/lib/domain/settings/components/rows/account_link.dart
@@ -29,7 +29,7 @@ class AccountLinkRow extends StatelessWidget {
         children: [
           SvgPicture.asset("images/checkmark_green.svg"),
           SizedBox(width: 6),
-          Text("登録済み",
+          Text("連携済み",
               style: FontType.assisting.merge(TextColorStyle.darkGray)),
         ],
       );

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pilll/analytics.dart';
 import 'package:pilll/auth/apple.dart';
 import 'package:pilll/auth/google.dart';

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:pilll/analytics.dart';
-import 'package:pilll/auth/apple.dart';
-import 'package:pilll/auth/google.dart';
 import 'package:pilll/components/atoms/buttons.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
@@ -13,8 +10,6 @@ import 'package:pilll/domain/demography/demography_page.dart';
 import 'package:pilll/domain/settings/setting_account_list/components/delete_user_button.dart';
 import 'package:pilll/domain/settings/setting_account_list/setting_account_cooperation_list_page_store.dart';
 import 'package:pilll/entity/link_account_type.dart';
-import 'package:pilll/entity/user_error.dart';
-import 'package:pilll/error/error_alert.dart';
 import 'package:pilll/error/universal_error_page.dart';
 import 'package:pilll/signin/signin_sheet.dart';
 import 'package:pilll/signin/signin_sheet_state.dart';

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -101,15 +101,6 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
       },
     );
   }
-
-  String _logEventSuffix(LinkAccountType accountType) {
-    switch (accountType) {
-      case LinkAccountType.apple:
-        return "apple";
-      case LinkAccountType.google:
-        return "google";
-    }
-  }
 }
 
 extension SettingAccountCooperationListPageRoute

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/analytics.dart';
 import 'package:pilll/auth/apple.dart';
 import 'package:pilll/auth/google.dart';
+import 'package:pilll/components/atoms/buttons.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
@@ -201,8 +203,34 @@ class SettingAccountCooperationRow extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
       title: Text(accountType.providerName, style: FontType.listRow),
+      trailing: _trailing(),
       horizontalTitleGap: 4,
       onTap: () => onTap(),
     );
+  }
+
+  Widget _trailing() {
+    if (isLinked()) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SvgPicture.asset("images/checkmark_green.svg"),
+          SizedBox(width: 6),
+          Text("連携済み",
+              style: FontType.assisting.merge(TextColorStyle.darkGray)),
+        ],
+      );
+    } else {
+      return SizedBox(
+        height: 40,
+        width: 88,
+        child: SmallAppOutlinedButton(
+          onPressed: () {
+            // TODO:
+          },
+          text: "連携する",
+        ),
+      );
+    }
   }
 }

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -201,38 +201,10 @@ class SettingAccountCooperationRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: _icon(),
       title: Text(_title, style: FontType.listRow),
       horizontalTitleGap: 4,
       onTap: () => onTap(),
     );
-  }
-
-  Widget _icon() {
-    switch (accountType) {
-      case LinkAccountType.apple:
-        return Container(
-          padding: EdgeInsets.all(6),
-          decoration: BoxDecoration(
-            color: PilllColors.appleBlack,
-            borderRadius: BorderRadius.circular(12),
-          ),
-          width: 24,
-          height: 24,
-          child: SvgPicture.asset("images/apple_icon.svg"),
-        );
-      case LinkAccountType.google:
-        return Container(
-          padding: EdgeInsets.all(6),
-          child: SvgPicture.asset("images/google_icon.svg"),
-          width: 24,
-          height: 24,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: PilllColors.shadow, width: 0.5),
-          ),
-        );
-    }
   }
 
   String get _title {

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -111,58 +111,6 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
     }
   }
 
-  Future<void> _link(
-    BuildContext context,
-    SettingAccountCooperationListPageStore store,
-    LinkAccountType accountType,
-  ) async {
-    final String eventSuffix = _logEventSuffix(accountType);
-    analytics.logEvent(
-      name: "link_event_$eventSuffix",
-    );
-    HUD.of(context).show();
-    try {
-      final bool isDetermined;
-      switch (accountType) {
-        case LinkAccountType.apple:
-          isDetermined = await _handleApple(store);
-          break;
-        case LinkAccountType.google:
-          isDetermined = await _handleGoogle(store);
-          break;
-      }
-      HUD.of(context).hide();
-      analytics.logEvent(
-        name: "did_end_link_event_$eventSuffix",
-      );
-      if (!isDetermined) {
-        return;
-      }
-    } catch (error) {
-      analytics.logEvent(
-          name: "did_failure_link_event_$eventSuffix",
-          parameters: {"errot_type": error.runtimeType.toString()});
-
-      HUD.of(context).hide();
-      if (error is UserDisplayedError) {
-        showErrorAlertWithError(context, error);
-      } else {
-        UniversalErrorPage.of(context).showError(error);
-      }
-      return;
-    }
-
-    final snackBarDuration = Duration(seconds: 1);
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        duration: snackBarDuration,
-        content: Text("${accountType.providerName}で登録しました"),
-      ),
-    );
-    await Future.delayed(snackBarDuration);
-    showDemographyPageIfNeeded(context);
-  }
-
   Future<bool> _handleApple(
       SettingAccountCooperationListPageStore store) async {
     switch (await store.linkApple()) {

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -122,11 +122,15 @@ class SettingAccountCooperationRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      title: Text(accountType.providerName, style: FontType.listRow),
-      trailing: _trailing(),
-      horizontalTitleGap: 4,
-      onTap: () => onTap(),
-    );
+        title: Text(accountType.providerName, style: FontType.listRow),
+        trailing: _trailing(),
+        horizontalTitleGap: 4,
+        onTap: () {
+          if (isLinked()) {
+            return;
+          }
+          onTap();
+        });
   }
 
   Widget _trailing() {
@@ -146,7 +150,7 @@ class SettingAccountCooperationRow extends StatelessWidget {
         width: 88,
         child: SmallAppOutlinedButton(
           onPressed: () {
-            // TODO:
+            onTap();
           },
           text: "連携する",
         ),

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -16,6 +16,8 @@ import 'package:pilll/entity/link_account_type.dart';
 import 'package:pilll/entity/user_error.dart';
 import 'package:pilll/error/error_alert.dart';
 import 'package:pilll/error/universal_error_page.dart';
+import 'package:pilll/signin/signin_sheet.dart';
+import 'package:pilll/signin/signin_sheet_state.dart';
 
 class SettingAccountCooperationListPage extends HookConsumerWidget {
   @override
@@ -52,22 +54,22 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
                     SettingAccountCooperationRow(
                       accountType: LinkAccountType.apple,
                       isLinked: () => state.isLinkedApple,
-                      onTap: () async {
+                      onTap: () {
                         if (state.isLinkedApple) {
                           return;
                         }
-                        await _linkApple(context, store);
+                        _showSigninSheet(context);
                       },
                     ),
                     Divider(indent: 16),
                     SettingAccountCooperationRow(
                       accountType: LinkAccountType.google,
                       isLinked: () => state.isLinkedGoogle,
-                      onTap: () async {
+                      onTap: () {
                         if (state.isLinkedGoogle) {
                           return;
                         }
-                        await _linkGoogle(context, store);
+                        _showSigninSheet(context);
                       },
                     ),
                     Divider(indent: 16),
@@ -79,6 +81,24 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
           },
         ),
       ),
+    );
+  }
+
+  _showSigninSheet(BuildContext context) {
+    showSigninSheet(
+      context,
+      SigninSheetStateContext.setting,
+      (accountType) async {
+        final snackBarDuration = Duration(seconds: 1);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            duration: snackBarDuration,
+            content: Text("${accountType.providerName}で登録しました"),
+          ),
+        );
+        await Future.delayed(snackBarDuration);
+        showDemographyPageIfNeeded(context);
+      },
     );
   }
 

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -110,26 +110,6 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
         return "google";
     }
   }
-
-  Future<bool> _handleApple(
-      SettingAccountCooperationListPageStore store) async {
-    switch (await store.linkApple()) {
-      case SigninWithAppleState.cancel:
-        return false;
-      case SigninWithAppleState.determined:
-        return true;
-    }
-  }
-
-  Future<bool> _handleGoogle(
-      SettingAccountCooperationListPageStore store) async {
-    switch (await store.linkGoogle()) {
-      case SigninWithGoogleState.cancel:
-        return false;
-      case SigninWithGoogleState.determined:
-        return true;
-    }
-  }
 }
 
 extension SettingAccountCooperationListPageRoute

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -200,18 +200,9 @@ class SettingAccountCooperationRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      title: Text(_title, style: FontType.listRow),
+      title: Text(accountType.providerName, style: FontType.listRow),
       horizontalTitleGap: 4,
       onTap: () => onTap(),
     );
-  }
-
-  String get _title {
-    final linked = isLinked();
-    final providerName = accountType.providerName;
-    if (!linked) {
-      return providerName;
-    }
-    return "$providerName で登録済み";
   }
 }

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -111,20 +111,6 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
     }
   }
 
-  Future<void> _linkApple(
-    BuildContext context,
-    SettingAccountCooperationListPageStore store,
-  ) async {
-    return _link(context, store, LinkAccountType.apple);
-  }
-
-  Future<void> _linkGoogle(
-    BuildContext context,
-    SettingAccountCooperationListPageStore store,
-  ) async {
-    return _link(context, store, LinkAccountType.google);
-  }
-
   Future<void> _link(
     BuildContext context,
     SettingAccountCooperationListPageStore store,

--- a/lib/entity/link_account_type.dart
+++ b/lib/entity/link_account_type.dart
@@ -4,7 +4,7 @@ extension LinkAccountTypeExtension on LinkAccountType {
   String get providerName {
     switch (this) {
       case LinkAccountType.apple:
-        return "Apple";
+        return "Apple ID";
       case LinkAccountType.google:
         return "Google アカウント";
     }

--- a/lib/signin/signin_sheet.dart
+++ b/lib/signin/signin_sheet.dart
@@ -21,11 +21,11 @@ abstract class SigninSheetConst {
 
 class SigninSheet extends HookConsumerWidget {
   final SigninSheetStateContext stateContext;
-  final Function(LinkAccountType) callback;
+  final Function(LinkAccountType) onSignIn;
 
   SigninSheet({
     required this.stateContext,
-    required this.callback,
+    required this.onSignIn,
   });
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -96,7 +96,7 @@ class SigninSheet extends HookConsumerWidget {
           switch (signinState) {
             case SigninWithAppleState.determined:
               Navigator.of(context).pop();
-              callback(LinkAccountType.apple);
+              onSignIn(LinkAccountType.apple);
               return;
             case SigninWithAppleState.cancel:
               return;
@@ -157,7 +157,7 @@ class SigninSheet extends HookConsumerWidget {
           switch (signinState) {
             case SigninWithGoogleState.determined:
               Navigator.of(context).pop();
-              callback(LinkAccountType.google);
+              onSignIn(LinkAccountType.google);
               break;
             case SigninWithGoogleState.cancel:
               return;
@@ -197,13 +197,13 @@ class SigninSheet extends HookConsumerWidget {
 }
 
 showSigninSheet(BuildContext context, SigninSheetStateContext stateContext,
-    Function(LinkAccountType) callback) {
+    Function(LinkAccountType) onSignIn) {
   analytics.setCurrentScreen(screenName: "SigninSheet");
   showModalBottomSheet(
     context: context,
     builder: (context) => SigninSheet(
       stateContext: stateContext,
-      callback: callback,
+      onSignIn: onSignIn,
     ),
     backgroundColor: Colors.transparent,
   );

--- a/lib/signin/signin_sheet_state.dart
+++ b/lib/signin/signin_sheet_state.dart
@@ -3,7 +3,7 @@ import 'package:pilll/entity/link_account_type.dart';
 
 part 'signin_sheet_state.freezed.dart';
 
-enum SigninSheetStateContext { initialSetting, recordPage, premium }
+enum SigninSheetStateContext { initialSetting, recordPage, premium, setting }
 
 @freezed
 class SigninSheetState with _$SigninSheetState {
@@ -22,6 +22,8 @@ class SigninSheetState with _$SigninSheetState {
         return false;
       case SigninSheetStateContext.premium:
         return false;
+      case SigninSheetStateContext.setting:
+        return false;
     }
   }
 
@@ -33,6 +35,8 @@ class SigninSheetState with _$SigninSheetState {
         return "アカウント登録";
       case SigninSheetStateContext.premium:
         return "プレミアム登録の前に…";
+      case SigninSheetStateContext.setting:
+        return "アカウント登録";
     }
   }
 
@@ -44,6 +48,8 @@ class SigninSheetState with _$SigninSheetState {
         return "アカウント登録するとデータの引き継ぎが可能になります";
       case SigninSheetStateContext.premium:
         return "アカウント情報を保持するため、アカウント登録をお願いします";
+      case SigninSheetStateContext.setting:
+        return "アカウント登録するとデータの引き継ぎが可能になります";
     }
   }
 
@@ -55,6 +61,8 @@ class SigninSheetState with _$SigninSheetState {
         return LinkAccountType.apple.providerName + "で登録";
       case SigninSheetStateContext.premium:
         return LinkAccountType.apple.providerName + "で登録";
+      case SigninSheetStateContext.setting:
+        return LinkAccountType.apple.providerName + "で登録";
     }
   }
 
@@ -65,6 +73,8 @@ class SigninSheetState with _$SigninSheetState {
       case SigninSheetStateContext.recordPage:
         return LinkAccountType.google.providerName + "で登録";
       case SigninSheetStateContext.premium:
+        return LinkAccountType.google.providerName + "で登録";
+      case SigninSheetStateContext.setting:
         return LinkAccountType.google.providerName + "で登録";
     }
   }


### PR DESCRIPTION
## Abstract
- 設定画面からのアカウント設定画面のUIを調整
  - Apple ロゴのアイコンを消した
- サインイン前は共通のシートを出すようにした
- サインイン周りの文言を統一した

HIG 的に オフィシャルなアイコンのみの使用はOK。ただその場合は文言(サインインとか)つけるな。文言をつけるようならHIGで提案しているようなボタンの見た目で文言も統一。という方針と汲み取ってアイコンを消した。`Apple ID` の項目をタップした後は、元々違う場所で使っ値えた、ボタン形式のUIが出るボトムシートが出るようにした

## Why
リジェクトされた
```
Your app offers Sign in with Apple as a login option but does not use the appropriate Sign in with Apple button design, placement, and/or user interface elements. Specifically:
- There should be no text associated with the buttons for any login option if your app uses the Apple logo as a button for Sign in with Apple.
Next Steps
Please revise the Sign in with Apple buttons in your app so that they are compliant with the App Store Review Guidelines and the Sign in With Apple Human Interface Guidelines.
Resources
For information on implementing Sign in with Apple in your app:
- Review Displaying Sign in with Apple Buttons if your sign in process happens in a browser.
- Review the Sign in with Apple Human Interface Guidelines for an overview of design and formatting recommendations for Sign in with Apple.

developer.apple.comdeveloper.apple.com
Introduction - Sign in with Apple - Human Interface Guidelines - Apple Developer
Learn about designing apps for Sign in with Apple.
```