### PR TITLE
:recycle: remove condition for shows manual rest duration button

### DIFF
--- a/lib/domain/record/components/supports/record_page_pill_sheet_support_actions.dart
+++ b/lib/domain/record/components/supports/record_page_pill_sheet_support_actions.dart
@@ -31,12 +31,11 @@ class RecordPagePillSheetSupportActions extends StatelessWidget {
         SwitchingAppearanceMode(
             store: store, mode: setting.pillSheetAppearanceMode),
         Spacer(),
-        if (!pillSheetGroup.hasPillSheetRestDuration)
-          ManualRestDurationButton(
-              restDuration: restDuration,
-              activedPillSheet: activedPillSheet,
-              store: store,
-              pillSheetGroup: pillSheetGroup),
+        ManualRestDurationButton(
+            restDuration: restDuration,
+            activedPillSheet: activedPillSheet,
+            store: store,
+            pillSheetGroup: pillSheetGroup),
       ]),
     );
   }

--- a/lib/entity/pill_sheet_group.dart
+++ b/lib/entity/pill_sheet_group.dart
@@ -57,8 +57,6 @@ class PillSheetGroup with _$PillSheetGroup {
 
   bool get _isDeleted => deletedAt != null;
   bool get isDeactived => activedPillSheet == null || _isDeleted;
-  bool get hasPillSheetRestDuration =>
-      pillSheets.map((e) => e.pillSheetType.hasRestDurationType).contains(true);
 
   int get sequentialTodayPillNumber {
     if (pillSheets.isEmpty) {

--- a/lib/entity/pill_sheet_type.dart
+++ b/lib/entity/pill_sheet_type.dart
@@ -161,23 +161,6 @@ extension PillSheetTypeFunctions on PillSheetType {
     }
   }
 
-  bool get hasRestDurationType {
-    switch (this) {
-      case PillSheetType.pillsheet_21:
-        return true;
-      case PillSheetType.pillsheet_28_4:
-        return false;
-      case PillSheetType.pillsheet_28_7:
-        return false;
-      case PillSheetType.pillsheet_28_0:
-        return false;
-      case PillSheetType.pillsheet_24_0:
-        return false;
-      case PillSheetType.pillsheet_21_0:
-        return false;
-    }
-  }
-
   int get numberOfLineInPillSheet =>
       (totalCount / Weekday.values.length).ceil();
 }

--- a/lib/service/auth.dart
+++ b/lib/service/auth.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:pilll/analytics.dart';
 import 'package:pilll/auth/apple.dart';
 import 'package:pilll/auth/google.dart';


### PR DESCRIPTION
## Abstract
「休薬する」ボタンの表示制御を消す。すべてのピルシートタイプで手動での休薬機能を使えるようにする

## Why
ユーザーからの問い合わせが何度か発生した。「休薬ボタンが出ていない」と。
自動での休薬期間があるピルシートだとかえって混乱する可能性がいまだに孕んでいるが、どちらにしてもユーザーが今直感的に理解できない状態で、この仕様をわかりやすく伝える術も無いと思うので一度すべてのピルタイプで使えるようにする。

懸念する課題が出てきたら対処法を考える