### PR TITLE
Remove unnecessary logic for removing app badge

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -86,8 +86,6 @@ extension AppDelegate {
                 completionHandler()
             }
 
-            UIApplication.shared.applicationIconBadgeNumber = 0
-
             super.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandlerWrapper)
 
             if !isCompleted {

--- a/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
+++ b/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
@@ -95,7 +95,7 @@ class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
                             text: "次へ",
                             onPressed: () async {
                               analytics.logEvent(
-                                  name: "next_to_pill_sheet_count");
+                                  name: "next_to_today_pill_number");
                               Navigator.of(context).push(
                                   InitialSettingSelectTodayPillNumberPageRoute
                                       .route());


### PR DESCRIPTION
## Abstract
以前まではクイックレコード時の処理と、通常の服用処理が分かれていたが、現在は共通化されているのでネイティブ側のコードが不要のため削除した。通知からの起動時にバッジをクリアする処理にもなっていたので誤解の元になった