### PR TITLE
All button use async/await

### DIFF
--- a/lib/components/atoms/button.dart
+++ b/lib/components/atoms/button.dart
@@ -9,10 +9,4 @@ abstract class ButtonTextStyle {
     fontSize: FontSize.sLarge,
     color: PilllColors.white,
   );
-  static final TextStyle alert = TextStyle(
-    fontFamily: FontFamily.japanese,
-    fontWeight: FontWeight.w600,
-    fontSize: FontSize.normal,
-    color: PilllColors.primary,
-  );
 }

--- a/lib/components/atoms/buttons.dart
+++ b/lib/components/atoms/buttons.dart
@@ -189,7 +189,15 @@ class AlertButton extends StatelessWidget {
 
   Widget build(BuildContext context) {
     return TextButton(
-      child: Text(text, style: ButtonTextStyle.alert),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontFamily: FontFamily.japanese,
+          fontWeight: FontWeight.w600,
+          fontSize: FontSize.normal,
+          color: PilllColors.primary,
+        ),
+      ),
       onPressed: onPressed,
     );
   }

--- a/lib/components/atoms/buttons.dart
+++ b/lib/components/atoms/buttons.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:pilll/components/atoms/button.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
@@ -6,7 +8,7 @@ import 'package:flutter/material.dart';
 
 class PrimaryButton extends StatelessWidget {
   final String text;
-  final Function()? onPressed;
+  final Future<void> Function()? onPressed;
 
   const PrimaryButton({
     Key? key,
@@ -15,6 +17,7 @@ class PrimaryButton extends StatelessWidget {
   }) : super(key: key);
 
   Widget build(BuildContext context) {
+    var isProcessing = false;
     return ConstrainedBox(
       constraints: BoxConstraints(maxHeight: 44, minHeight: 44, minWidth: 180),
       child: ElevatedButton(
@@ -26,7 +29,14 @@ class PrimaryButton extends StatelessWidget {
           }
           return PilllColors.secondary;
         })),
-        onPressed: onPressed,
+        onPressed: () async {
+          if (isProcessing) {
+            return;
+          }
+          isProcessing = true;
+          await onPressed?.call();
+          isProcessing = false;
+        },
       ),
     );
   }

--- a/lib/components/atoms/buttons.dart
+++ b/lib/components/atoms/buttons.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:pilll/components/atoms/button.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
@@ -34,8 +32,14 @@ class PrimaryButton extends StatelessWidget {
             return;
           }
           isProcessing = true;
-          await onPressed?.call();
-          isProcessing = false;
+
+          try {
+            await onPressed?.call();
+          } catch (error) {
+            rethrow;
+          } finally {
+            isProcessing = false;
+          }
         },
       ),
     );
@@ -44,7 +48,7 @@ class PrimaryButton extends StatelessWidget {
 
 class SecondaryButton extends StatelessWidget {
   final String text;
-  final Function() onPressed;
+  final Future<void> Function() onPressed;
 
   const SecondaryButton({
     Key? key,
@@ -53,12 +57,26 @@ class SecondaryButton extends StatelessWidget {
   }) : super(key: key);
 
   Widget build(BuildContext context) {
+    var isProcessing = false;
     return SizedBox(
       height: 44,
       child: TextButton(
         style: TextButton.styleFrom(backgroundColor: Colors.transparent),
         child: Text(text, style: TextColorStyle.primary),
-        onPressed: onPressed,
+        onPressed: () async {
+          if (isProcessing) {
+            return;
+          }
+          isProcessing = true;
+
+          try {
+            await onPressed.call();
+          } catch (error) {
+            rethrow;
+          } finally {
+            isProcessing = false;
+          }
+        },
       ),
     );
   }
@@ -75,6 +93,7 @@ class TertiaryButton extends StatelessWidget {
   }) : super(key: key);
 
   Widget build(BuildContext context) {
+    var isProcessing = false;
     return SizedBox(
       width: 180,
       height: 44,
@@ -82,7 +101,19 @@ class TertiaryButton extends StatelessWidget {
         style: TextButton.styleFrom(backgroundColor: PilllColors.gray),
         child:
             Text(text, style: ButtonTextStyle.main.merge(TextColorStyle.white)),
-        onPressed: onPressed,
+        onPressed: () async {
+          if (isProcessing) {
+            return;
+          }
+          isProcessing = true;
+          try {
+            await onPressed.call();
+          } catch (error) {
+            rethrow;
+          } finally {
+            isProcessing = false;
+          }
+        },
       ),
     );
   }
@@ -90,7 +121,7 @@ class TertiaryButton extends StatelessWidget {
 
 class InconspicuousButton extends StatelessWidget {
   final String text;
-  final Function() onPressed;
+  final Future<void> Function() onPressed;
 
   const InconspicuousButton({
     Key? key,
@@ -99,13 +130,26 @@ class InconspicuousButton extends StatelessWidget {
   }) : super(key: key);
 
   Widget build(BuildContext context) {
+    var isProcessing = false;
     return SizedBox(
       width: 180,
       height: 44,
       child: TextButton(
         style: TextButton.styleFrom(backgroundColor: Colors.transparent),
         child: Text(text, style: TextColorStyle.gray),
-        onPressed: onPressed,
+        onPressed: () async {
+          if (isProcessing) {
+            return;
+          }
+          isProcessing = true;
+          try {
+            await onPressed.call();
+          } catch (error) {
+            rethrow;
+          } finally {
+            isProcessing = false;
+          }
+        },
       ),
     );
   }
@@ -113,7 +157,7 @@ class InconspicuousButton extends StatelessWidget {
 
 class SmallAppOutlinedButton extends StatelessWidget {
   final String text;
-  final VoidCallback? onPressed;
+  final Future<void> Function()? onPressed;
 
   const SmallAppOutlinedButton({
     Key? key,
@@ -122,6 +166,7 @@ class SmallAppOutlinedButton extends StatelessWidget {
   }) : super(key: key);
 
   Widget build(BuildContext context) {
+    var isProcessing = false;
     return OutlinedButton(
       child: Container(
         padding: EdgeInsets.only(top: 8.5, bottom: 8.5),
@@ -144,14 +189,26 @@ class SmallAppOutlinedButton extends StatelessWidget {
         ),
         side: BorderSide(color: PilllColors.secondary),
       ),
-      onPressed: onPressed,
+      onPressed: () async {
+        if (isProcessing) {
+          return;
+        }
+        isProcessing = true;
+        try {
+          await onPressed?.call();
+        } catch (error) {
+          rethrow;
+        } finally {
+          isProcessing = false;
+        }
+      },
     );
   }
 }
 
 class AppOutlinedButton extends StatelessWidget {
   final String text;
-  final VoidCallback? onPressed;
+  final Future<void> Function()? onPressed;
 
   const AppOutlinedButton({
     Key? key,
@@ -160,6 +217,7 @@ class AppOutlinedButton extends StatelessWidget {
   }) : super(key: key);
 
   Widget build(BuildContext context) {
+    var isProcessing = false;
     return OutlinedButton(
       child: Container(
         padding: EdgeInsets.only(top: 12, bottom: 12),
@@ -182,14 +240,26 @@ class AppOutlinedButton extends StatelessWidget {
         ),
         side: BorderSide(color: PilllColors.secondary),
       ),
-      onPressed: onPressed,
+      onPressed: () async {
+        if (isProcessing) {
+          return;
+        }
+        isProcessing = true;
+        try {
+          await onPressed?.call();
+        } catch (error) {
+          rethrow;
+        } finally {
+          isProcessing = false;
+        }
+      },
     );
   }
 }
 
 class AlertButton extends StatelessWidget {
   final String text;
-  final VoidCallback? onPressed;
+  final Future<void> Function()? onPressed;
 
   const AlertButton({
     Key? key,

--- a/lib/components/page/ok_dialog.dart
+++ b/lib/components/page/ok_dialog.dart
@@ -7,7 +7,7 @@ import 'package:pilll/components/atoms/text_color.dart';
 class OKDialog extends StatelessWidget {
   final String title;
   final String message;
-  final VoidCallback? ok;
+  final Future<void> Function()? ok;
 
   const OKDialog({
     Key? key,
@@ -38,7 +38,7 @@ class OKDialog extends StatelessWidget {
       actions: <Widget>[
         AlertButton(
           text: "OK",
-          onPressed: () {
+          onPressed: () async {
             final ok = this.ok;
             if (ok != null) {
               ok();
@@ -56,7 +56,7 @@ Future<void> showOKDialog(
   BuildContext context, {
   required String title,
   required String message,
-  VoidCallback? ok,
+  Future<void> Function()? ok,
 }) async {
   return showDialog(
     context: context,

--- a/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_more_button.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_more_button.dart
@@ -22,7 +22,7 @@ class PillSheetModifiedHistoryMoreButton extends StatelessWidget {
       children: [
         AlertButton(
             text: "もっと見る",
-            onPressed: () {
+            onPressed: () async {
               analytics.logEvent(name: "pill_sheet_modified_history_more");
               if (state.isPremium || state.isTrial) {
                 Navigator.of(context)

--- a/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart
+++ b/lib/domain/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart
@@ -148,7 +148,7 @@ class CalendarPillSheetModifiedHistoryCard extends StatelessWidget {
                                       width: 204,
                                       child: AppOutlinedButton(
                                         text: "くわしくみる",
-                                        onPressed: () {
+                                        onPressed: () async {
                                           if (state.trialDeadlineDate == null) {
                                             showPremiumTrialModal(context, () {
                                               showPremiumTrialCompleteModalPreDialog(

--- a/lib/domain/diary/confirm_diary_sheet.dart
+++ b/lib/domain/diary/confirm_diary_sheet.dart
@@ -87,16 +87,18 @@ class ConfirmDiarySheet extends HookConsumerWidget {
                     actions: [
                       AlertButton(
                         text: "キャンセル",
-                        onPressed: () {
+                        onPressed: () async {
                           Navigator.of(context).pop();
                         },
                       ),
                       AlertButton(
                         text: "削除する",
-                        onPressed: () {
+                        onPressed: () async {
                           int counter = 0;
-                          store.delete().then((value) => Navigator.popUntil(
-                              context, (route) => counter++ >= 1));
+                          await store.delete();
+
+                          Navigator.popUntil(
+                              context, (route) => counter++ >= 1);
                           Navigator.of(context).pop();
                         },
                       ),

--- a/lib/domain/diary/post_diary_page.dart
+++ b/lib/domain/diary/post_diary_page.dart
@@ -269,7 +269,7 @@ class PostDiaryPage extends HookConsumerWidget {
             Spacer(),
             AlertButton(
               text: '完了',
-              onPressed: () {
+              onPressed: () async {
                 analytics.logEvent(name: "post_diary_done_button_pressed");
                 focusNode.unfocus();
               },

--- a/lib/domain/initial_setting/menstruation/initial_setting_menstruation_page.dart
+++ b/lib/domain/initial_setting/menstruation/initial_setting_menstruation_page.dart
@@ -31,7 +31,7 @@ class InitialSettingMenstruationPage extends HookConsumerWidget {
         },
       ),
       doneButton: PrimaryButton(
-        onPressed: () {
+        onPressed: () async {
           analytics.logEvent(name: "done_on_initial_setting_menstruation");
           Navigator.of(context)
               .push(InitialSettingReminderTimesPageRoute.route());

--- a/lib/domain/initial_setting/migrate_info.dart
+++ b/lib/domain/initial_setting/migrate_info.dart
@@ -93,7 +93,7 @@ class MigrateInfo extends StatelessWidget {
                   child: Container(
                       width: 230,
                       child: PrimaryButton(
-                          onPressed: () => onClose(), text: "閉じる")),
+                          onPressed: () async => onClose(), text: "閉じる")),
                 ),
                 SizedBox(height: 32),
               ],

--- a/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
+++ b/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
@@ -152,7 +152,7 @@ class InitialSettingPillSheetGroupPageBody extends StatelessWidget {
             SvgPicture.asset("images/empty_pill_sheet_type.svg"),
             SizedBox(height: 24),
             PrimaryButton(
-                onPressed: () {
+                onPressed: () async {
                   showSettingPillSheetGroupSelectPillSheetTypePage(
                     context: context,
                     pillSheetType: null,

--- a/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
+++ b/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
@@ -105,7 +105,7 @@ class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
                           SizedBox(height: 20),
                           AlertButton(
                             text: "すでにアカウントをお持ちの方はこちら",
-                            onPressed: () {
+                            onPressed: () async {
                               analytics.logEvent(
                                   name: "pressed_initial_setting_signin");
                               showSigninSheet(

--- a/lib/domain/initial_setting/today_pill_number/initial_setting_select_today_pill_number_page.dart
+++ b/lib/domain/initial_setting/today_pill_number/initial_setting_select_today_pill_number_page.dart
@@ -67,7 +67,7 @@ class InitialSettingSelectTodayPillNumberPage extends HookConsumerWidget {
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
                       InconspicuousButton(
-                        onPressed: () {
+                        onPressed: () async {
                           store.unsetTodayPillNumber();
                           analytics.logEvent(
                               name: "unknown_number_initial_setting");

--- a/lib/domain/initial_setting/today_pill_number/initial_setting_select_today_pill_number_page.dart
+++ b/lib/domain/initial_setting/today_pill_number/initial_setting_select_today_pill_number_page.dart
@@ -81,7 +81,7 @@ class InitialSettingSelectTodayPillNumberPage extends HookConsumerWidget {
                         text: "次へ",
                         onPressed: state.todayPillNumber == null
                             ? null
-                            : () {
+                            : () async {
                                 analytics.logEvent(
                                     name: "done_today_number_initial_setting");
                                 Navigator.of(context).push(

--- a/lib/domain/menstruation/menstruation_history_card.dart
+++ b/lib/domain/menstruation/menstruation_history_card.dart
@@ -73,7 +73,7 @@ class MenstruationHistoryCardMoreButton extends StatelessWidget {
         if (!state.moreButtonIsHidden)
           AlertButton(
               text: "もっと見る",
-              onPressed: () {
+              onPressed: () async {
                 analytics.logEvent(name: "menstruation_more_button_pressed");
                 if (state.isPremium || state.isTrial) {
                   Navigator.of(context).push(MenstruationListPageRoute.route());

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -107,7 +107,7 @@ class MenstruationRecordButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PrimaryButton(
-      onPressed: () {
+      onPressed: () async {
         analytics.logEvent(name: "pressed_menstruation_record");
         final latestMenstruation = state.latestMenstruation;
         if (latestMenstruation != null &&

--- a/lib/domain/menstruation_edit/menstruation_edit_page.dart
+++ b/lib/domain/menstruation_edit/menstruation_edit_page.dart
@@ -69,7 +69,7 @@ class MenstruationEditPage extends HookConsumerWidget {
                                 FontType.sBigTitle.merge(TextColorStyle.main)),
                         Spacer(),
                         AlertButton(
-                          onPressed: () {
+                          onPressed: () async {
                             analytics.logEvent(
                                 name: "pressed_saving_menstruation_edit");
                             if (store.shouldShowDiscardDialog()) {
@@ -81,7 +81,7 @@ class MenstruationEditPage extends HookConsumerWidget {
                                   actions: [
                                     AlertButton(
                                       text: "キャンセル",
-                                      onPressed: () {
+                                      onPressed: () async {
                                         analytics.logEvent(
                                             name:
                                                 "cancelled_delete_menstruation");
@@ -90,13 +90,13 @@ class MenstruationEditPage extends HookConsumerWidget {
                                     ),
                                     AlertButton(
                                       text: "削除する",
-                                      onPressed: () {
-                                        store
-                                            .delete()
-                                            .then((_) => didEndDelete())
-                                            .then((_) => analytics.logEvent(
-                                                name:
-                                                    "pressed_delete_menstruation"));
+                                      onPressed: () async {
+                                        await store.delete();
+                                        didEndDelete();
+
+                                        analytics.logEvent(
+                                            name:
+                                                "pressed_delete_menstruation");
                                         Navigator.of(context).pop();
                                       },
                                     ),

--- a/lib/domain/premium_introduction/premium_complete_dialog.dart
+++ b/lib/domain/premium_introduction/premium_complete_dialog.dart
@@ -43,7 +43,7 @@ class PremiumCompleteDialog extends StatelessWidget {
             ),
             SizedBox(height: 24),
             PrimaryButton(
-              onPressed: () {
+              onPressed: () async {
                 Navigator.of(context).pop();
                 onClose();
               },

--- a/lib/domain/record/components/pill_sheet/components/record_page_rest_duration_dialog.dart
+++ b/lib/domain/record/components/pill_sheet/components/record_page_rest_duration_dialog.dart
@@ -34,13 +34,13 @@ class RecordPageRestDurationDialog extends StatelessWidget {
       ),
       actions: <Widget>[
         AppOutlinedButton(
-          onPressed: () => onDone(),
+          onPressed: () async => onDone(),
           text: "休薬する",
         ),
         Center(
           child: AlertButton(
             text: "閉じる",
-            onPressed: () {
+            onPressed: () async {
               Navigator.of(context).pop();
             },
           ),

--- a/lib/domain/record/components/supports/components/rest_duration/invalid_already_taken_pill_dialog.dart
+++ b/lib/domain/record/components/supports/components/rest_duration/invalid_already_taken_pill_dialog.dart
@@ -50,7 +50,7 @@ class InvalidAlreadyTakenPillDialog extends StatelessWidget {
       ),
       actions: [
         AppOutlinedButton(
-          onPressed: () {
+          onPressed: () async {
             analytics.logEvent(name: "invalid_already_taken_pill_faq");
             launch(
                 "https://pilll.wraptas.site/467128e667ae4d6cbff4d61ee370cce5");
@@ -60,7 +60,7 @@ class InvalidAlreadyTakenPillDialog extends StatelessWidget {
         Center(
           child: AlertButton(
             text: "閉じる",
-            onPressed: () {
+            onPressed: () async {
               analytics.logEvent(name: "invalid_already_taken_pill_close");
               Navigator.of(context).pop();
             },

--- a/lib/domain/record/components/supports/components/rest_duration/invalid_insufficient_rest_duration_dialog.dart
+++ b/lib/domain/record/components/supports/components/rest_duration/invalid_insufficient_rest_duration_dialog.dart
@@ -50,7 +50,7 @@ class InvalidInsufficientRestDurationDialog extends StatelessWidget {
       ),
       actions: [
         AppOutlinedButton(
-          onPressed: () {
+          onPressed: () async {
             analytics.logEvent(name: "invalid_insufficient_rest_duration_faq");
             launch(
                 "https://pilll.wraptas.site/467128e667ae4d6cbff4d61ee370cce5");
@@ -60,7 +60,7 @@ class InvalidInsufficientRestDurationDialog extends StatelessWidget {
         Center(
           child: AlertButton(
             text: "閉じる",
-            onPressed: () {
+            onPressed: () async {
               analytics.logEvent(
                   name: "invalid_insufficient_rest_duration_close");
               Navigator.of(context).pop();

--- a/lib/domain/settings/components/rows/pill_sheet_remove.dart
+++ b/lib/domain/settings/components/rows/pill_sheet_remove.dart
@@ -46,13 +46,13 @@ class PillSheetRemoveRow extends HookConsumerWidget {
               actions: [
                 AlertButton(
                   text: "キャンセル",
-                  onPressed: () {
+                  onPressed: () async {
                     Navigator.of(context).pop();
                   },
                 ),
                 AlertButton(
                   text: "破棄する",
-                  onPressed: () {
+                  onPressed: () async {
                     store.deletePillSheet().catchError((error) {
                       showErrorAlert(context,
                           message:

--- a/lib/domain/settings/setting_account_list/components/delete_user_button.dart
+++ b/lib/domain/settings/setting_account_list/components/delete_user_button.dart
@@ -98,7 +98,7 @@ class DeleteUserButton extends StatelessWidget {
 }
 
 class _CompletedDialog extends StatelessWidget {
-  final VoidCallback onClose;
+  final Future<void> Function() onClose;
 
   const _CompletedDialog({Key? key, required this.onClose}) : super(key: key);
   @override
@@ -133,9 +133,9 @@ class _CompletedDialog extends StatelessWidget {
             ),
             SizedBox(height: 24),
             PrimaryButton(
-              onPressed: () {
+              onPressed: () async {
                 Navigator.of(context).pop();
-                onClose();
+                await onClose();
               },
               text: "OK",
             ),

--- a/lib/domain/settings/setting_account_list/components/delete_user_button.dart
+++ b/lib/domain/settings/setting_account_list/components/delete_user_button.dart
@@ -18,7 +18,7 @@ class DeleteUserButton extends StatelessWidget {
     return Container(
       padding: EdgeInsets.only(top: 54),
       child: AlertButton(
-        onPressed: () {
+        onPressed: () async {
           showDiscardDialog(
             context,
             title: "ユーザー情報が削除されます",
@@ -26,7 +26,7 @@ class DeleteUserButton extends StatelessWidget {
             actions: [
               AlertButton(
                 text: "キャンセル",
-                onPressed: () {
+                onPressed: () async {
                   Navigator.of(context).pop();
                 },
               ),
@@ -66,7 +66,7 @@ class DeleteUserButton extends StatelessWidget {
           actions: [
             AlertButton(
               text: "キャンセル",
-              onPressed: () {
+              onPressed: () async {
                 Navigator.of(context).pop();
               },
             ),

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -49,7 +49,7 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
                     SettingAccountCooperationRow(
                       accountType: LinkAccountType.apple,
                       isLinked: () => state.isLinkedApple,
-                      onTap: () {
+                      onTap: () async {
                         if (state.isLinkedApple) {
                           return;
                         }
@@ -60,7 +60,7 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
                     SettingAccountCooperationRow(
                       accountType: LinkAccountType.google,
                       isLinked: () => state.isLinkedGoogle,
-                      onTap: () {
+                      onTap: () async {
                         if (state.isLinkedGoogle) {
                           return;
                         }
@@ -111,7 +111,7 @@ extension SettingAccountCooperationListPageRoute
 class SettingAccountCooperationRow extends StatelessWidget {
   final LinkAccountType accountType;
   final bool Function() isLinked;
-  final Function() onTap;
+  final Future<void> Function() onTap;
 
   SettingAccountCooperationRow({
     required this.accountType,
@@ -125,11 +125,11 @@ class SettingAccountCooperationRow extends StatelessWidget {
         title: Text(accountType.providerName, style: FontType.listRow),
         trailing: _trailing(),
         horizontalTitleGap: 4,
-        onTap: () {
+        onTap: () async {
           if (isLinked()) {
             return;
           }
-          onTap();
+          await onTap();
         });
   }
 
@@ -149,7 +149,7 @@ class SettingAccountCooperationRow extends StatelessWidget {
         height: 40,
         width: 88,
         child: SmallAppOutlinedButton(
-          onPressed: () {
+          onPressed: () async {
             onTap();
           },
           text: "連携する",

--- a/lib/domain/settings/setting_page.dart
+++ b/lib/domain/settings/setting_page.dart
@@ -251,7 +251,7 @@ class SettingPage extends HookConsumerWidget {
 ''', actions: [
             AlertButton(
               text: "キャンセル",
-              onPressed: () {
+              onPressed: () async {
                 Navigator.of(context).pop();
               },
             ),
@@ -278,7 +278,7 @@ class SettingPage extends HookConsumerWidget {
             actions: [
               AlertButton(
                 text: "キャンセル",
-                onPressed: () {
+                onPressed: () async {
                   Navigator.of(context).pop();
                 },
               ),

--- a/lib/domain/settings/today_pill_number/setting_today_pill_number_page.dart
+++ b/lib/domain/settings/today_pill_number/setting_today_pill_number_page.dart
@@ -84,8 +84,8 @@ class SettingTodayPillNumberPage extends HookConsumerWidget {
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
                       PrimaryButton(
-                        onPressed: () {
-                          store.modifiyTodayPillNumber(
+                        onPressed: () async {
+                          await store.modifiyTodayPillNumber(
                             pillSheetGroup: pillSheetGroup,
                             activedPillSheet: activedPillSheet,
                           );

--- a/lib/error/error_alert.dart
+++ b/lib/error/error_alert.dart
@@ -27,13 +27,13 @@ class ErrorAlert extends StatelessWidget {
         if (faq != null)
           AlertButton(
             text: "FAQを見る",
-            onPressed: () {
+            onPressed: () async {
               launch(faq);
             },
           ),
         AlertButton(
           text: "閉じる",
-          onPressed: () {
+          onPressed: () async {
             Navigator.of(context).pop();
           },
         ),


### PR DESCRIPTION
## Abstract
- buttons.dart に宣言されているButtonをすべてasyncで受け取るようにして、await中はbuttonのタップイベントを受け取らないようにした
- おまけ: ButtonStyleに不要なものがあったので削除

## Why
ちょいちょいpopしすぎ。例外が飛んできていた。その要因としてはDBの書き込み処理の後にpopをするような流れの場合に、ユーザーが処理の完了を待たずにタップしてしまった場合を考えた
Buttonは今のところ主要な部分はラップしているのでローカルでフラグを持って早期リターンするようにした

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した