### PR TITLE
Fix SignIn method

### DIFF
--- a/lib/domain/home/home_page.dart
+++ b/lib/domain/home/home_page.dart
@@ -43,7 +43,7 @@ class _HomePageState extends State<HomePage>
         vsync: this,
         initialIndex: _selectedIndex);
     _tabController.addListener(_handleTabSelection);
-    signIn().then((user) {
+    cachedUserOrSignInAnonymously().then((user) {
       requestNotificationPermissions();
     });
   }

--- a/lib/domain/home/home_page.dart
+++ b/lib/domain/home/home_page.dart
@@ -1,6 +1,5 @@
 import 'package:pilll/analytics.dart';
 import 'package:pilll/entity/diary.dart';
-import 'package:pilll/service/auth.dart';
 import 'package:pilll/domain/calendar/calendar_page.dart';
 import 'package:pilll/domain/menstruation/menstruation_page.dart';
 import 'package:pilll/domain/record/record_page.dart';

--- a/lib/domain/home/home_page.dart
+++ b/lib/domain/home/home_page.dart
@@ -43,9 +43,8 @@ class _HomePageState extends State<HomePage>
         vsync: this,
         initialIndex: _selectedIndex);
     _tabController.addListener(_handleTabSelection);
-    cachedUserOrSignInAnonymously().then((user) {
-      requestNotificationPermissions();
-    });
+
+    requestNotificationPermissions();
   }
 
   @override

--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -131,7 +131,7 @@ class RootState extends State<Root> {
         screenType = ScreenType.forceUpdate;
       });
     } else {
-      signIn().then((firebaseUser) {
+      cachedUserOrSignInAnonymously().then((firebaseUser) {
         unawaited(
             FirebaseCrashlytics.instance.setUserIdentifier(firebaseUser.uid));
         unawaited(firebaseAnalytics.setUserId(id: firebaseUser.uid));

--- a/lib/global_method_channel.dart
+++ b/lib/global_method_channel.dart
@@ -10,7 +10,6 @@ import 'package:pilll/service/pill_sheet_modified_history.dart';
 import 'package:pilll/util/datetime/day.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:pilll/service/auth.dart';
 
 final _channel = MethodChannel("method.channel.MizukiOhashi.Pilll");
 definedChannel() {

--- a/lib/global_method_channel.dart
+++ b/lib/global_method_channel.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_app_badger/flutter_app_badger.dart';
 import 'package:pilll/analytics.dart';
 import 'package:pilll/database/batch.dart';
@@ -27,7 +28,11 @@ definedChannel() {
 }
 
 Future<void> recordPill() async {
-  final firebaseUser = await cachedUserOrSignInAnonymously();
+  final firebaseUser = FirebaseAuth.instance.currentUser;
+  if (firebaseUser == null) {
+    return;
+  }
+
   final database = DatabaseConnection(firebaseUser.uid);
   final pillSheetService = PillSheetService(database);
   final pillSheetModifiedHistoryService =

--- a/lib/global_method_channel.dart
+++ b/lib/global_method_channel.dart
@@ -27,7 +27,7 @@ definedChannel() {
 }
 
 Future<void> recordPill() async {
-  final firebaseUser = await signIn();
+  final firebaseUser = await cachedUserOrSignInAnonymously();
   final database = DatabaseConnection(firebaseUser.uid);
   final pillSheetService = PillSheetService(database);
   final pillSheetModifiedHistoryService =

--- a/lib/inquiry/inquiry.dart
+++ b/lib/inquiry/inquiry.dart
@@ -1,6 +1,5 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:pilll/entity/pill_sheet_group.dart';
-import 'package:pilll/service/auth.dart';
 import 'package:pilll/database/database.dart';
 import 'package:pilll/entity/menstruation.dart';
 import 'package:pilll/entity/setting.dart';

--- a/lib/inquiry/inquiry.dart
+++ b/lib/inquiry/inquiry.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:pilll/entity/pill_sheet_group.dart';
 import 'package:pilll/service/auth.dart';
 import 'package:pilll/database/database.dart';
@@ -20,12 +21,11 @@ inquiry() {
 }
 
 Future<String> debugInfo(String separator) async {
-  String userID;
-  try {
-    userID = (await cachedUserOrSignInAnonymously()).uid;
-  } catch (error) {
+  final userID = FirebaseAuth.instance.currentUser?.uid;
+  if (userID == null) {
     return Future.value("DEBUG INFO user is not found");
   }
+
   DatabaseConnection databaseConnection = DatabaseConnection(userID);
 
   PillSheetGroup? pillSheetGroup;

--- a/lib/inquiry/inquiry.dart
+++ b/lib/inquiry/inquiry.dart
@@ -22,7 +22,7 @@ inquiry() {
 Future<String> debugInfo(String separator) async {
   String userID;
   try {
-    userID = (await signIn()).uid;
+    userID = (await cachedUserOrSignInAnonymously()).uid;
   } catch (error) {
     return Future.value("DEBUG INFO user is not found");
   }

--- a/lib/service/auth.dart
+++ b/lib/service/auth.dart
@@ -43,7 +43,7 @@ Stream<User?> _userAuthStateChanges() {
 
 // Obtain the latest users form FirebaseAuth.
 // If it is not exists, return result of signin anonymous;
-Future<User> signIn() async {
+Future<User> cachedUserOrSignInAnonymously() async {
   analytics.logEvent(name: "call_sign_in");
   final currentUser = FirebaseAuth.instance.currentUser;
 

--- a/lib/service/push_notification.dart
+++ b/lib/service/push_notification.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:pilll/analytics.dart';
-import 'package:pilll/service/auth.dart';
 import 'package:pilll/database/database.dart';
 import 'package:pilll/service/user.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';

--- a/lib/service/push_notification.dart
+++ b/lib/service/push_notification.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:pilll/analytics.dart';
 import 'package:pilll/service/auth.dart';
 import 'package:pilll/database/database.dart';
@@ -8,6 +9,12 @@ import 'package:pilll/service/user.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 
 Future<void> requestNotificationPermissions() async {
+  final firebaseUser = FirebaseAuth.instance.currentUser;
+  if (firebaseUser == null) {
+    assert(false);
+    return;
+  }
+
   await FirebaseMessaging.instance.requestPermission();
   if (Platform.isIOS) {
     await FirebaseMessaging.instance
@@ -15,13 +22,11 @@ Future<void> requestNotificationPermissions() async {
             alert: true, badge: true, sound: true);
   }
   callRegisterRemoteNotification();
-  // ignore: unawaited_futures
-  signIn().then((firebaseUser) {
-    final userService = UserService(DatabaseConnection(firebaseUser.uid));
-    userService.fetch().then((_) async {
-      final token = await FirebaseMessaging.instance.getToken();
-      await userService.registerRemoteNotificationToken(token);
-    });
+
+  final userService = UserService(DatabaseConnection(firebaseUser.uid));
+  userService.fetch().then((_) async {
+    final token = await FirebaseMessaging.instance.getToken();
+    await userService.registerRemoteNotificationToken(token);
   });
   return Future.value();
 }


### PR DESCRIPTION
## Abstract
- 2重でSignInを叩く可能性を減らす
- 本来であればUserがいて欲しい場面であれば、確実にキャッシュのデータを引くようにする

## Why
- 2重でSignInを叩かれる可能性を減らす
- あと初期のコードでCachedUserを手に入れる場合とSignInをするコードをまとめて一緒くたに実行していたが、わかりづらいのでやめる

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した