### PR TITLE
Refactor setting page and TabView

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -58,6 +58,6 @@ jobs:
         java-version: '12.x'
     - uses: subosito/flutter-action@v1
       with:
-        flutter-version: '2.8.1'
+        flutter-version: '2.10.0'
     - run: flutter pub get
     - run: flutter test 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -26,7 +26,7 @@ jobs:
         FILE_FIREBASE_IOS_PRODUCTION: ${{ secrets.FILE_FIREBASE_IOS_PRODUCTION }}
     - uses: subosito/flutter-action@v1
       with:
-        flutter-version: '2.8.1'
+        flutter-version: '2.10.0'
     - run: flutter pub get
     - name: Run iOS
       run: flutter build ios --debug --no-codesign --flavor development --target lib/main.dev.dart --no-sound-null-safety
@@ -45,7 +45,7 @@ jobs:
         FILE_FIREBASE_ANDROID_PRODUCTION: ${{ secrets.FILE_FIREBASE_ANDROID_PRODUCTION }}
     - uses: subosito/flutter-action@v1
       with:
-        flutter-version: '2.8.1'
+        flutter-version: '2.10.0'
     - run: flutter pub get
     - run: flutter build apk --debug --flavor development --target lib/main.dev.dart --no-sound-null-safety
   test:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -33,7 +33,7 @@ if (keystorePropertiesFile.exists()) {
   keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 }
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -47,7 +47,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.mizuki.Ohashi.Pilll"
         minSdkVersion 23
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
         android:networkSecurityConfig="@xml/network_security_config">

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
+            android:exported="false"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
-            android:exported="false"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -49,7 +49,7 @@ PODS:
     - Firebase/Messaging (= 8.9.0)
     - firebase_core
     - Flutter
-  - firebase_remote_config (1.0.3):
+  - firebase_remote_config (2.0.0):
     - Firebase/RemoteConfig (= 8.9.0)
     - firebase_core
     - Flutter
@@ -311,7 +311,7 @@ SPEC CHECKSUMS:
   firebase_core: c263d7daf1dc92fcd9895e6abdc04872b0ee07ff
   firebase_crashlytics: 9cbd5d9e8560b218f02fce3c7359567ac822d05f
   firebase_messaging: dff5cd08781ee1de988565a83c977e435405cd7e
-  firebase_remote_config: fad608e4093070bc3759f2d2beb566d4259451b2
+  firebase_remote_config: 467ffe569bc5625f8264f9aeefec2b8786fd1399
   FirebaseABTesting: fc7255f7e96d3cf7a1131fd68636c47e312cef76
   FirebaseAnalytics: 4ab446ce08a3fe52e8a4303dd997cf26276bf968
   FirebaseAuth: 2b78b2a32c07b3ecfa4970bdf1d3632b8304099b

--- a/lib/domain/calendar/calendar_page.dart
+++ b/lib/domain/calendar/calendar_page.dart
@@ -15,6 +15,8 @@ import 'package:flutter/material.dart';
 import 'package:pilll/error/universal_error_page.dart';
 
 class CalendarPage extends HookConsumerWidget {
+  const CalendarPage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(calendarPageStateStoreProvider.notifier);

--- a/lib/domain/calendar/calendar_page.dart
+++ b/lib/domain/calendar/calendar_page.dart
@@ -13,6 +13,7 @@ import 'package:pilll/domain/home/home_page.dart';
 import 'package:pilll/domain/calendar/calendar_page_store.dart';
 import 'package:flutter/material.dart';
 import 'package:pilll/error/universal_error_page.dart';
+import 'package:pilll/hooks/automatic_keep_alive_client_mixin.dart';
 
 class CalendarPage extends HookConsumerWidget {
   @override
@@ -20,6 +21,8 @@ class CalendarPage extends HookConsumerWidget {
     final store = ref.watch(calendarPageStateStoreProvider.notifier);
     final state = ref.watch(calendarPageStateStoreProvider);
     homeKey.currentState?.diaries = state.diariesForMonth;
+
+    useAutomaticKeepAlive(wantKeepAlive: true);
 
     final exception = state.exception;
     if (exception != null) {

--- a/lib/domain/calendar/calendar_page.dart
+++ b/lib/domain/calendar/calendar_page.dart
@@ -15,8 +15,6 @@ import 'package:flutter/material.dart';
 import 'package:pilll/error/universal_error_page.dart';
 
 class CalendarPage extends HookConsumerWidget {
-  const CalendarPage({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(calendarPageStateStoreProvider.notifier);

--- a/lib/domain/home/home_page.dart
+++ b/lib/domain/home/home_page.dart
@@ -14,6 +14,11 @@ import 'package:flutter_svg/svg.dart';
 import '../../components/organisms/calendar/weekly/weekly_calendar.dart';
 
 GlobalKey<_HomePageState> homeKey = GlobalKey();
+PageStorageKey recordPageKey = PageStorageKey(HomePageTabType.record);
+PageStorageKey menstruationPageKey =
+    PageStorageKey(HomePageTabType.menstruation);
+PageStorageKey calendarPageKey = PageStorageKey(HomePageTabType.calendar);
+PageStorageKey settingPageKey = PageStorageKey(HomePageTabType.setting);
 
 class HomePage extends StatefulWidget {
   HomePage({required Key key}) : super(key: key);
@@ -105,10 +110,10 @@ class _HomePageState extends State<HomePage>
           physics: NeverScrollableScrollPhysics(),
           controller: _tabController,
           children: <Widget>[
-            RecordPage(),
-            MenstruationPage(),
-            CalendarPage(),
-            SettingPage(),
+            RecordPage(key: recordPageKey),
+            MenstruationPage(key: menstruationPageKey),
+            CalendarPage(key: calendarPageKey),
+            SettingPage(key: settingPageKey),
             // SettingsPage(),
           ],
         ),

--- a/lib/domain/home/home_page.dart
+++ b/lib/domain/home/home_page.dart
@@ -14,11 +14,6 @@ import 'package:flutter_svg/svg.dart';
 import '../../components/organisms/calendar/weekly/weekly_calendar.dart';
 
 GlobalKey<_HomePageState> homeKey = GlobalKey();
-PageStorageKey recordPageKey = PageStorageKey(HomePageTabType.record);
-PageStorageKey menstruationPageKey =
-    PageStorageKey(HomePageTabType.menstruation);
-PageStorageKey calendarPageKey = PageStorageKey(HomePageTabType.calendar);
-PageStorageKey settingPageKey = PageStorageKey(HomePageTabType.setting);
 
 class HomePage extends StatefulWidget {
   HomePage({required Key key}) : super(key: key);
@@ -110,10 +105,10 @@ class _HomePageState extends State<HomePage>
           physics: NeverScrollableScrollPhysics(),
           controller: _tabController,
           children: <Widget>[
-            RecordPage(key: recordPageKey),
-            MenstruationPage(key: menstruationPageKey),
-            CalendarPage(key: calendarPageKey),
-            SettingPage(key: settingPageKey),
+            RecordPage(),
+            MenstruationPage(),
+            CalendarPage(),
+            SettingPage(),
             // SettingsPage(),
           ],
         ),

--- a/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
+++ b/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
@@ -29,6 +29,7 @@ class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
 
     useEffect(() {
       store.fetch();
+      return null;
     }, [authStream]);
 
     useEffect(() {
@@ -49,6 +50,8 @@ class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
           AppRouter.signinAccount(context);
         }
       }
+
+      return null;
     }, [state.userIsNotAnonymous, state.accountType, state.settingIsExist]);
 
     return HUD(

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -28,8 +28,6 @@ abstract class MenstruationPageConst {
 }
 
 class MenstruationPage extends HookConsumerWidget {
-  const MenstruationPage({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(menstruationsStoreProvider.notifier);

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -16,6 +16,7 @@ import 'package:pilll/domain/menstruation/menstruation_select_modify_type_sheet.
 import 'package:pilll/domain/record/weekday_badge.dart';
 import 'package:pilll/domain/menstruation/menstruation_store.dart';
 import 'package:pilll/error/universal_error_page.dart';
+import 'package:pilll/hooks/automatic_keep_alive_client_mixin.dart';
 import 'package:pilll/util/datetime/day.dart';
 import 'package:pilll/util/formatter/date_time_formatter.dart';
 
@@ -32,6 +33,8 @@ class MenstruationPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(menstruationsStoreProvider.notifier);
     final state = ref.watch(menstruationsStoreProvider);
+
+    useAutomaticKeepAlive(wantKeepAlive: true);
 
     if (state.exception != null) {
       return UniversalErrorPage(

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -28,6 +28,8 @@ abstract class MenstruationPageConst {
 }
 
 class MenstruationPage extends HookConsumerWidget {
+  const MenstruationPage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(menstruationsStoreProvider.notifier);

--- a/lib/domain/record/components/notification_bar/notification_bar.dart
+++ b/lib/domain/record/components/notification_bar/notification_bar.dart
@@ -190,5 +190,6 @@ class NotificationBar extends HookConsumerWidget {
         },
       );
     }
+    return null;
   }
 }

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -18,8 +18,6 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class RecordPage extends HookConsumerWidget {
-  const RecordPage({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(recordPageStoreProvider);

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -16,12 +16,14 @@ import 'package:pilll/error/universal_error_page.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/hooks/automatic_keep_alive_client_mixin.dart';
 
 class RecordPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(recordPageStoreProvider);
     final store = ref.watch(recordPageStoreProvider.notifier);
+    useAutomaticKeepAlive(wantKeepAlive: true);
 
     final exception = state.exception;
     if (exception != null) {

--- a/lib/domain/record/record_page.dart
+++ b/lib/domain/record/record_page.dart
@@ -18,6 +18,8 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class RecordPage extends HookConsumerWidget {
+  const RecordPage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(recordPageStoreProvider);

--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -112,7 +112,7 @@ class RootState extends State<Root> {
 
   _decideScreenType() async {
     const minimumSupportedAppVersionKey = "minimum_supported_app_version";
-    final remoteConfig = RemoteConfig.instance;
+    final remoteConfig = FirebaseRemoteConfig.instance;
     await remoteConfig.setConfigSettings(
       RemoteConfigSettings(
         minimumFetchInterval: Duration(seconds: 0),

--- a/lib/domain/settings/reminder_times_page.dart
+++ b/lib/domain/settings/reminder_times_page.dart
@@ -15,7 +15,7 @@ class ReminderTimesPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(settingStoreProvider.notifier);
-    final state = ref.watch(settingStoreProvider);
+    final state = ref.watch(settingStateProvider);
     final setting = state.setting;
 
     if (setting == null) {

--- a/lib/domain/settings/setting_page.dart
+++ b/lib/domain/settings/setting_page.dart
@@ -19,6 +19,7 @@ import 'package:pilll/domain/settings/components/rows/update_from_132.dart';
 import 'package:pilll/domain/settings/components/setting_section_title.dart';
 import 'package:pilll/domain/settings/setting_page_state.dart';
 import 'package:pilll/error/universal_error_page.dart';
+import 'package:pilll/hooks/automatic_keep_alive_client_mixin.dart';
 import 'package:pilll/inquiry/inquiry.dart';
 import 'package:pilll/domain/settings/setting_page_store.dart';
 import 'package:pilll/components/atoms/color.dart';
@@ -44,6 +45,7 @@ class SettingPage extends HookConsumerWidget {
     final store = ref.watch(settingStoreProvider.notifier);
     final state = ref.watch(settingStoreProvider);
 
+    useAutomaticKeepAlive(wantKeepAlive: true);
     useEffect(() {
       store.setup();
       return store.cancel;

--- a/lib/domain/settings/setting_page.dart
+++ b/lib/domain/settings/setting_page.dart
@@ -39,8 +39,6 @@ enum SettingSection {
 }
 
 class SettingPage extends HookConsumerWidget {
-  const SettingPage({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(settingStoreProvider.notifier);

--- a/lib/domain/settings/setting_page.dart
+++ b/lib/domain/settings/setting_page.dart
@@ -44,6 +44,11 @@ class SettingPage extends HookConsumerWidget {
     final store = ref.watch(settingStoreProvider.notifier);
     final state = ref.watch(settingStoreProvider);
 
+    useEffect(() {
+      store.setup();
+      return store.cancel;
+    }, const []);
+
     return Scaffold(
       backgroundColor: PilllColors.background,
       appBar: AppBar(

--- a/lib/domain/settings/setting_page.dart
+++ b/lib/domain/settings/setting_page.dart
@@ -39,6 +39,8 @@ enum SettingSection {
 }
 
 class SettingPage extends HookConsumerWidget {
+  const SettingPage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(settingStoreProvider.notifier);
@@ -47,7 +49,7 @@ class SettingPage extends HookConsumerWidget {
     useEffect(() {
       store.setup();
       return store.cancel;
-    }, const []);
+    }, const [true]);
 
     return Scaffold(
       backgroundColor: PilllColors.background,

--- a/lib/domain/settings/setting_page.dart
+++ b/lib/domain/settings/setting_page.dart
@@ -49,7 +49,7 @@ class SettingPage extends HookConsumerWidget {
     useEffect(() {
       store.setup();
       return store.cancel;
-    }, const [true]);
+    }, const []);
 
     return Scaffold(
       backgroundColor: PilllColors.background,

--- a/lib/domain/settings/setting_page_state.dart
+++ b/lib/domain/settings/setting_page_state.dart
@@ -8,7 +8,7 @@ part 'setting_page_state.freezed.dart';
 class SettingState with _$SettingState {
   const SettingState._();
   const factory SettingState({
-    required Setting? setting,
+    Setting? setting,
     PillSheetGroup? latestPillSheetGroup,
     @Default(false) bool userIsUpdatedFrom132,
     @Default(false) bool isPremium,

--- a/lib/domain/settings/setting_page_state.freezed.dart
+++ b/lib/domain/settings/setting_page_state.freezed.dart
@@ -19,7 +19,7 @@ class _$SettingStateTearOff {
   const _$SettingStateTearOff();
 
   _SettingState call(
-      {required Setting? setting,
+      {Setting? setting,
       PillSheetGroup? latestPillSheetGroup,
       bool userIsUpdatedFrom132 = false,
       bool isPremium = false,
@@ -221,7 +221,7 @@ class __$SettingStateCopyWithImpl<$Res> extends _$SettingStateCopyWithImpl<$Res>
 
 class _$_SettingState extends _SettingState {
   const _$_SettingState(
-      {required this.setting,
+      {this.setting,
       this.latestPillSheetGroup,
       this.userIsUpdatedFrom132 = false,
       this.isPremium = false,
@@ -289,7 +289,7 @@ class _$_SettingState extends _SettingState {
 
 abstract class _SettingState extends SettingState {
   const factory _SettingState(
-      {required Setting? setting,
+      {Setting? setting,
       PillSheetGroup? latestPillSheetGroup,
       bool userIsUpdatedFrom132,
       bool isPremium,

--- a/lib/hooks/automatic_keep_alive_client_mixin.dart
+++ b/lib/hooks/automatic_keep_alive_client_mixin.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+// Ref: https://github.com/rrousselGit/flutter_hooks/issues/101#issuecomment-762121053
+// Re implement useAutomaticKeepAlive with NNDB
+void useAutomaticKeepAlive({
+  bool? wantKeepAlive,
+}) =>
+    use(_AutomaticKeepAliveHook(
+      wantKeepAlive: wantKeepAlive ?? true,
+    ));
+
+class _AutomaticKeepAliveHook extends Hook<void> {
+  final bool wantKeepAlive;
+
+  _AutomaticKeepAliveHook({required this.wantKeepAlive});
+
+  @override
+  HookState<void, _AutomaticKeepAliveHook> createState() =>
+      _AutomaticKeepAliveHookState();
+}
+
+class _AutomaticKeepAliveHookState
+    extends HookState<void, _AutomaticKeepAliveHook> {
+  KeepAliveHandle? _keepAliveHandle;
+
+  void _ensureKeepAlive() {
+    assert(_keepAliveHandle == null);
+    final keepAliveHandle = KeepAliveHandle();
+    _keepAliveHandle = keepAliveHandle;
+    KeepAliveNotification(keepAliveHandle).dispatch(context);
+  }
+
+  void _releaseKeepAlive() {
+    _keepAliveHandle?.release();
+    _keepAliveHandle = null;
+  }
+
+  void updateKeepAlive() {
+    if (hook.wantKeepAlive) {
+      if (_keepAliveHandle == null) _ensureKeepAlive();
+    } else {
+      if (_keepAliveHandle != null) _releaseKeepAlive();
+    }
+  }
+
+  @override
+  void initHook() {
+    super.initHook();
+    if (hook.wantKeepAlive) _ensureKeepAlive();
+  }
+
+  @override
+  void build(BuildContext context) {
+    if (hook.wantKeepAlive && _keepAliveHandle == null) _ensureKeepAlive();
+    return null;
+  }
+
+  @override
+  void deactivate() {
+    if (_keepAliveHandle != null) _releaseKeepAlive();
+    super.deactivate();
+  }
+
+  @override
+  Object get debugValue => _keepAliveHandle ?? "NULL";
+
+  @override
+  String get debugLabel => 'useAutomaticKeepAlive';
+}

--- a/lib/util/version/version.dart
+++ b/lib/util/version/version.dart
@@ -1,4 +1,5 @@
 import 'package:package_info/package_info.dart';
+import 'package:pilll/util/environment.dart';
 
 class Version {
   final int major;
@@ -13,7 +14,12 @@ class Version {
 
   factory Version.parse(String str) {
     final splited = str.split(".");
-    assert(splited.length <= 3, "unexpected version format $str");
+    if (Environment.isDevelopment) {
+      assert(
+          splited.length <= 3 ||
+              (splited.last == "last" && splited.length == 4),
+          "unexpected version format $str");
+    }
 
     final versions = List.filled(3, 0);
     for (int i = 0; i < splited.length; i++) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -512,7 +512,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: "direct main"
     description:
@@ -547,7 +547,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -589,7 +589,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_drawing:
     dependency: transitive
     description:
@@ -811,7 +811,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -860,7 +860,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   timing:
     dependency: transitive
     description:
@@ -937,7 +937,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   version:
     dependency: "direct main"
     description:
@@ -988,5 +988,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"
   flutter: ">=2.5.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "34.0.0"
+    version: "32.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.0.0"
   args:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.4"
+    version: "8.1.3"
   characters:
     dependency: transitive
     description:
@@ -133,21 +133,21 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.7"
+    version: "3.1.5"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.12"
+    version: "5.4.10"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.7"
+    version: "2.6.5"
   code_builder:
     dependency: transitive
     description:
@@ -231,49 +231,49 @@ packages:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.1.0"
+    version: "9.0.4"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0+6"
+    version: "0.4.0+4"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.6"
+    version: "3.3.4"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.11"
+    version: "6.1.9"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.7"
+    version: "3.3.5"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.12.0"
+    version: "1.10.6"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -294,35 +294,35 @@ packages:
       name: firebase_crashlytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.4.4"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.13"
+    version: "3.1.11"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "11.2.6"
+    version: "11.2.4"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.6"
+    version: "3.1.4"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.7"
+    version: "2.2.5"
   firebase_remote_config:
     dependency: "direct main"
     description:
@@ -390,7 +390,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -435,21 +435,21 @@ packages:
       name: google_sign_in
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.3"
+    version: "5.2.1"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
       name: google_sign_in_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   google_sign_in_web:
     dependency: transitive
     description:
       name: google_sign_in_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.0+4"
+    version: "0.10.0+3"
   graphs:
     dependency: transitive
     description:
@@ -484,14 +484,14 @@ packages:
       name: in_app_review
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.3"
   in_app_review_platform_interface:
     dependency: transitive
     description:
       name: in_app_review_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.2"
   intl:
     dependency: "direct main"
     description:
@@ -526,7 +526,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.4"
+    version: "6.1.3"
   logging:
     dependency: transitive
     description:
@@ -610,28 +610,21 @@ packages:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.4"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.1"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.1"
+    version: "2.0.4"
   petitparser:
     dependency: transitive
     description:
@@ -652,7 +645,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.0.2"
   pool:
     dependency: transitive
     description:
@@ -687,7 +680,7 @@ packages:
       name: purchases_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.9.3"
+    version: "3.8.0"
   quiver:
     dependency: transitive
     description:
@@ -708,28 +701,28 @@ packages:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
+    version: "2.0.11"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.0.9"
   shared_preferences_ios:
     dependency: transitive
     description:
       name: shared_preferences_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.8"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.3"
   shared_preferences_macos:
     dependency: transitive
     description:
@@ -750,14 +743,14 @@ packages:
       name: shared_preferences_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.2"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.3"
   shelf:
     dependency: transitive
     description:
@@ -832,7 +825,7 @@ packages:
       name: state_notifier
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.2+1"
+    version: "0.7.1"
   stream_channel:
     dependency: transitive
     description:
@@ -888,49 +881,49 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.18"
+    version: "6.0.17"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.14"
+    version: "6.0.13"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.14"
+    version: "6.0.13"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.2"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.2"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.4"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.5"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -972,14 +965,14 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.10"
+    version: "2.3.3"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+1"
+    version: "0.2.0"
   xml:
     dependency: transitive
     description:
@@ -996,4 +989,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.16.0-100.0.dev <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=2.5.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -541,6 +541,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -853,7 +860,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   timing:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "32.0.0"
+    version: "34.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.0"
   args:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.3"
+    version: "8.1.4"
   characters:
     dependency: transitive
     description:
@@ -133,21 +133,21 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.7"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.10"
+    version: "5.4.12"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.5"
+    version: "2.6.7"
   code_builder:
     dependency: transitive
     description:
@@ -231,49 +231,49 @@ packages:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.4"
+    version: "9.1.0"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0+4"
+    version: "0.4.0+6"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.4"
+    version: "3.3.6"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.9"
+    version: "6.1.11"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.5"
+    version: "3.3.7"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.6"
+    version: "1.12.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -294,35 +294,35 @@ packages:
       name: firebase_crashlytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.4"
+    version: "2.5.0"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.11"
+    version: "3.1.13"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "11.2.4"
+    version: "11.2.6"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.6"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.5"
+    version: "2.2.7"
   firebase_remote_config:
     dependency: "direct main"
     description:
@@ -390,7 +390,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -435,21 +435,21 @@ packages:
       name: google_sign_in
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.1"
+    version: "5.2.3"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
       name: google_sign_in_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   google_sign_in_web:
     dependency: transitive
     description:
       name: google_sign_in_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.0+3"
+    version: "0.10.0+4"
   graphs:
     dependency: transitive
     description:
@@ -484,14 +484,14 @@ packages:
       name: in_app_review
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   in_app_review_platform_interface:
     dependency: transitive
     description:
       name: in_app_review_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   intl:
     dependency: "direct main"
     description:
@@ -526,7 +526,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.3"
+    version: "6.1.4"
   logging:
     dependency: transitive
     description:
@@ -610,21 +610,28 @@ packages:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:
@@ -645,7 +652,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.2"
   pool:
     dependency: transitive
     description:
@@ -680,7 +687,7 @@ packages:
       name: purchases_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.8.0"
+    version: "3.9.3"
   quiver:
     dependency: transitive
     description:
@@ -701,28 +708,28 @@ packages:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.13"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.10"
   shared_preferences_ios:
     dependency: transitive
     description:
       name: shared_preferences_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.9"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   shared_preferences_macos:
     dependency: transitive
     description:
@@ -743,14 +750,14 @@ packages:
       name: shared_preferences_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   shelf:
     dependency: transitive
     description:
@@ -825,7 +832,7 @@ packages:
       name: state_notifier
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2+1"
   stream_channel:
     dependency: transitive
     description:
@@ -881,49 +888,49 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.17"
+    version: "6.0.18"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.13"
+    version: "6.0.14"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.13"
+    version: "6.0.14"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.8"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -965,14 +972,14 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.10"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.0+1"
   xml:
     dependency: transitive
     description:
@@ -989,4 +996,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.16.0-100.0.dev <3.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=2.10.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -280,14 +280,14 @@ packages:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.3"
+    version: "4.2.4"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.3"
+    version: "1.5.4"
   firebase_crashlytics:
     dependency: "direct main"
     description:
@@ -329,21 +329,21 @@ packages:
       name: firebase_remote_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.0"
   firebase_remote_config_platform_interface:
     dependency: transitive
     description:
       name: firebase_remote_config_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.5"
   firebase_remote_config_web:
     dependency: transitive
     description:
       name: firebase_remote_config_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.5"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -512,7 +512,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.3"
   json_annotation:
     dependency: "direct main"
     description:
@@ -547,7 +547,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -589,7 +589,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   path_drawing:
     dependency: transitive
     description:
@@ -811,7 +811,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -860,7 +860,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.8"
   timing:
     dependency: transitive
     description:
@@ -937,7 +937,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   version:
     dependency: "direct main"
     description:
@@ -988,5 +988,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.16.0-100.0.dev <3.0.0"
+  dart: ">=2.15.0 <3.0.0"
   flutter: ">=2.5.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   sign_in_with_apple: ^3.0.0
   google_sign_in: ^5.0.4
   purchases_flutter: ^3.2.2
-  firebase_remote_config: ^1.0.3
+  firebase_remote_config: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/test/domain/calendar/widget/calendar_test.dart
+++ b/test/domain/calendar/widget/calendar_test.dart
@@ -15,7 +15,7 @@ void main() {
   setUp(() {
     TestWidgetsFlutterBinding.ensureInitialized();
     SharedPreferences.setMockInitialValues({});
-    WidgetsBinding.instance!.renderView.configuration =
+    WidgetsBinding.instance.renderView.configuration =
         new TestViewConfiguration(size: const Size(375.0, 667.0));
   });
   group("Appearance Next Sheet Label", () {

--- a/test/domain/calendar/widget/calendar_test.dart
+++ b/test/domain/calendar/widget/calendar_test.dart
@@ -15,7 +15,7 @@ void main() {
   setUp(() {
     TestWidgetsFlutterBinding.ensureInitialized();
     SharedPreferences.setMockInitialValues({});
-    WidgetsBinding.instance.renderView.configuration =
+    WidgetsBinding.instance?.renderView.configuration =
         new TestViewConfiguration(size: const Size(375.0, 667.0));
   });
   group("Appearance Next Sheet Label", () {

--- a/test/domain/menstruation/menstruation_store_test.dart
+++ b/test/domain/menstruation/menstruation_store_test.dart
@@ -17,10 +17,15 @@ import '../../helper/mock.mocks.dart';
 
 class _FakeUser extends Fake implements User {
   _FakeUser({
+// ignore: unused_element
     this.fakeIsPremium = false,
+// ignore: unused_element
     this.fakeIsTrial = false,
+// ignore: unused_element
     this.fakeTrialDeadlineDate,
+// ignore: unused_element
     this.fakeDiscountEntitlementDeadlineDate,
+// ignore: unused_element
     this.fakeIsExpiredDiscountEntitlements = false,
   });
   final DateTime? fakeTrialDeadlineDate;

--- a/test/domain/premium_introduction/premium_introduction_sheet_test.dart
+++ b/test/domain/premium_introduction/premium_introduction_sheet_test.dart
@@ -62,7 +62,7 @@ void main() {
     initializeDateFormatting('ja_JP');
     Environment.isTest = true;
     analytics = MockAnalytics();
-    WidgetsBinding.instance!.renderView.configuration =
+    WidgetsBinding.instance.renderView.configuration =
         new TestViewConfiguration(size: const Size(375.0, 667.0));
   });
   group('#PremiumIntroductionSheet', () {

--- a/test/domain/premium_introduction/premium_introduction_sheet_test.dart
+++ b/test/domain/premium_introduction/premium_introduction_sheet_test.dart
@@ -62,7 +62,7 @@ void main() {
     initializeDateFormatting('ja_JP');
     Environment.isTest = true;
     analytics = MockAnalytics();
-    WidgetsBinding.instance.renderView.configuration =
+    WidgetsBinding.instance?.renderView.configuration =
         new TestViewConfiguration(size: const Size(375.0, 667.0));
   });
   group('#PremiumIntroductionSheet', () {

--- a/test/domain/record/notification_bar/notification_bar_test.dart
+++ b/test/domain/record/notification_bar/notification_bar_test.dart
@@ -40,7 +40,7 @@ void main() {
     initializeDateFormatting('ja_JP');
     Environment.isTest = true;
     analytics = MockAnalytics();
-    WidgetsBinding.instance!.renderView.configuration =
+    WidgetsBinding.instance.renderView.configuration =
         new TestViewConfiguration(size: const Size(375.0, 667.0));
   });
   group('notification bar appearance content type', () {

--- a/test/domain/record/notification_bar/notification_bar_test.dart
+++ b/test/domain/record/notification_bar/notification_bar_test.dart
@@ -40,7 +40,7 @@ void main() {
     initializeDateFormatting('ja_JP');
     Environment.isTest = true;
     analytics = MockAnalytics();
-    WidgetsBinding.instance.renderView.configuration =
+    WidgetsBinding.instance?.renderView.configuration =
         new TestViewConfiguration(size: const Size(375.0, 667.0));
   });
   group('notification bar appearance content type', () {

--- a/test/domain/record/record_page_button_state_test.dart
+++ b/test/domain/record/record_page_button_state_test.dart
@@ -24,7 +24,7 @@ void main() {
     initializeDateFormatting('ja_JP');
     Environment.isTest = true;
     analytics = MockAnalytics();
-    WidgetsBinding.instance.renderView.configuration =
+    WidgetsBinding.instance?.renderView.configuration =
         new TestViewConfiguration(size: const Size(375.0, 667.0));
   });
   group('appearance taken button type', () {

--- a/test/domain/record/record_page_button_state_test.dart
+++ b/test/domain/record/record_page_button_state_test.dart
@@ -24,7 +24,7 @@ void main() {
     initializeDateFormatting('ja_JP');
     Environment.isTest = true;
     analytics = MockAnalytics();
-    WidgetsBinding.instance!.renderView.configuration =
+    WidgetsBinding.instance.renderView.configuration =
         new TestViewConfiguration(size: const Size(375.0, 667.0));
   });
   group('appearance taken button type', () {

--- a/test/domain/record/record_page_state_test.dart
+++ b/test/domain/record/record_page_state_test.dart
@@ -18,10 +18,15 @@ import '../../helper/mock.mocks.dart';
 
 class _FakeUser extends Fake implements User {
   _FakeUser({
+// ignore: unused_element
     this.fakeIsPremium = false,
+// ignore: unused_element
     this.fakeIsTrial = false,
+// ignore: unused_element
     this.fakeTrialDeadlineDate,
+// ignore: unused_element
     this.fakeDiscountEntitlementDeadlineDate,
+// ignore: unused_element
     this.fakeIsExpiredDiscountEntitlements = false,
   });
   final DateTime? fakeTrialDeadlineDate;
@@ -107,7 +112,8 @@ void main() {
       );
 
       await waitForResetStoreState();
-      expect(state.pillSheetGroup?.pillSheets.first.todayPillIsAlreadyTaken, isTrue);
+      expect(state.pillSheetGroup?.pillSheets.first.todayPillIsAlreadyTaken,
+          isTrue);
       expect(
           store.markFor(pillNumberIntoPillSheet: 1, pillSheet: pillSheetEntity),
           PillMarkType.done);
@@ -180,7 +186,8 @@ void main() {
       );
 
       await waitForResetStoreState();
-      expect(state.pillSheetGroup?.pillSheets.first.todayPillIsAlreadyTaken, isFalse);
+      expect(state.pillSheetGroup?.pillSheets.first.todayPillIsAlreadyTaken,
+          isFalse);
       expect(
           store.markFor(pillNumberIntoPillSheet: 1, pillSheet: pillSheetEntity),
           PillMarkType.done);
@@ -255,7 +262,8 @@ void main() {
       );
 
       await waitForResetStoreState();
-      expect(state.pillSheetGroup?.pillSheets.first.todayPillIsAlreadyTaken, isTrue);
+      expect(state.pillSheetGroup?.pillSheets.first.todayPillIsAlreadyTaken,
+          isTrue);
       for (int i = 1; i <= pillSheetEntity.pillSheetType.totalCount; i++) {
         expect(
             store.shouldPillMarkAnimation(
@@ -325,7 +333,8 @@ void main() {
       );
 
       await waitForResetStoreState();
-      expect(state.pillSheetGroup?.pillSheets.first.todayPillIsAlreadyTaken, isFalse);
+      expect(state.pillSheetGroup?.pillSheets.first.todayPillIsAlreadyTaken,
+          isFalse);
       expect(
           store.shouldPillMarkAnimation(
             pillNumberIntoPillSheet: 3,

--- a/test/domain/settings/reminder_times_widget_test.dart
+++ b/test/domain/settings/reminder_times_widget_test.dart
@@ -20,9 +20,13 @@ import '../../helper/supported_device.dart';
 
 class _FakeUser extends Fake implements User {
   _FakeUser({
+// ignore: unused_element
     this.fakeIsPremium = false,
+// ignore: unused_element
     this.fakeIsTrial = false,
+// ignore: unused_element
     this.fakeIsExpiredDiscountEntitlements = false,
+// ignore: unused_element
     this.fakeIsTrialDeadlineDate,
   });
   final bool fakeIsPremium;

--- a/test/domain/settings/reminder_times_widget_test.dart
+++ b/test/domain/settings/reminder_times_widget_test.dart
@@ -112,6 +112,7 @@ void main() {
           child: MaterialApp(home: ReminderTimesPage()),
         ),
       );
+      await tester.pumpAndSettle(Duration(milliseconds: 500));
 
       expect(find.text("通知時間の追加"), findsOneWidget);
       expect(find.byWidgetPredicate((widget) => widget is Dismissible),
@@ -133,27 +134,23 @@ void main() {
           ReminderTime(hour: 12, minute: 0)
         ],
       );
-      when(settingService.fetch())
-          .thenAnswer((realInvocation) => Future.value(entity));
       when(settingService.stream())
           .thenAnswer((realInvocation) => Stream.value(entity));
 
-      final batchFactory = MockBatchFactory();
+      final userService = MockUserService();
+      when(userService.stream())
+          .thenAnswer((realInvocation) => Stream.value(_FakeUser()));
+
       final pillSheet = PillSheet.create(PillSheetType.pillsheet_21);
       final pillSheetGroup = PillSheetGroup(
           pillSheetIDs: ["1"], pillSheets: [pillSheet], createdAt: now());
-
-      final pillSheetService = MockPillSheetService();
-      final userService = MockUserService();
-      when(userService.fetch())
-          .thenAnswer((realInvocation) => Future.value(_FakeUser()));
-      when(userService.stream()).thenAnswer((realInvocation) => Stream.empty());
-      final pillSheetModifiedService = MockPillSheetModifiedHistoryService();
       final pillSheetGroupService = MockPillSheetGroupService();
-      when(pillSheetGroupService.fetchLatest())
-          .thenAnswer((realInvocation) => Future.value(pillSheetGroup));
       when(pillSheetGroupService.streamForLatest())
-          .thenAnswer((realInvocation) => Stream.empty());
+          .thenAnswer((realInvocation) => Stream.value(pillSheetGroup));
+
+      final batchFactory = MockBatchFactory();
+      final pillSheetService = MockPillSheetService();
+      final pillSheetModifiedService = MockPillSheetModifiedHistoryService();
 
       final store = SettingStateStore(
         batchFactory,
@@ -163,12 +160,21 @@ void main() {
         pillSheetModifiedService,
         pillSheetGroupService,
       );
-
       store.setup();
+
+      final fakeUser = _FakeUser();
+      final state = SettingState(
+        setting: entity,
+        isPremium: fakeUser.isPremium,
+        isTrial: fakeUser.isTrial,
+        latestPillSheetGroup: pillSheetGroup,
+        trialDeadlineDate: fakeUser.trialDeadlineDate,
+      );
 
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            settingStateProvider.overrideWithValue(state),
             settingStoreProvider.overrideWithProvider(
               StateNotifierProvider(
                 (ref) => store,

--- a/test/domain/settings/store_test.dart
+++ b/test/domain/settings/store_test.dart
@@ -14,9 +14,13 @@ import '../../helper/mock.mocks.dart';
 
 class _FakeUser extends Fake implements User {
   _FakeUser({
+// ignore: unused_element
     this.fakeIsPremium = false,
+// ignore: unused_element
     this.fakeIsTrial = false,
+// ignore: unused_element
     this.fakeIsExpiredDiscountEntitlements = false,
+// ignore: unused_element
     this.fakeIsTrialDeadlineDate,
   });
   final bool fakeIsPremium;


### PR DESCRIPTION
## Abstract
- SettingPageの最初のデータ取得を並列化した
- ついでにuseEffect使うようにした
- useEffect使う過程でkeysを変えてないのにTabPageの切り替えでuseEffectが再度呼ばれていることが気づいた。原因調査するとTabViewの子供はタブの切り替えごとにWidgetが生成され直すらしい。なので AutomaticKeepAlive を hooks 経由で指定できるようにした


## Why

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した