### PR TITLE
Replace setup from useEffect to constructor

### DIFF
--- a/lib/domain/home/home_page.dart
+++ b/lib/domain/home/home_page.dart
@@ -109,7 +109,6 @@ class _HomePageState extends State<HomePage>
             MenstruationPage(),
             CalendarPage(),
             SettingPage(),
-            // SettingsPage(),
           ],
         ),
         floatingActionButton: Visibility(

--- a/lib/domain/settings/setting_page.dart
+++ b/lib/domain/settings/setting_page.dart
@@ -46,10 +46,6 @@ class SettingPage extends HookConsumerWidget {
     final state = ref.watch(settingStoreProvider);
 
     useAutomaticKeepAlive(wantKeepAlive: true);
-    useEffect(() {
-      store.setup();
-      return store.cancel;
-    }, const []);
 
     return Scaffold(
       backgroundColor: PilllColors.background,

--- a/lib/domain/settings/setting_page_store.dart
+++ b/lib/domain/settings/setting_page_store.dart
@@ -40,7 +40,9 @@ class SettingStateStore extends StateNotifier<SettingState> {
     this._userService,
     this._pillSheetModifiedHistoryService,
     this._pillSheetGroupService,
-  ) : super(SettingState());
+  ) : super(SettingState()) {
+    setup();
+  }
 
   void reset() {
     state = SettingState();

--- a/lib/domain/settings/setting_page_store.dart
+++ b/lib/domain/settings/setting_page_store.dart
@@ -44,6 +44,7 @@ class SettingStateStore extends StateNotifier<SettingState> {
 
   void reset() {
     state = SettingState();
+    cancel();
     setup();
   }
 


### PR DESCRIPTION
## Abstract
SettingPageのsetupメソッドをuseEffect越しではなく、storeが作られるタイミングで実行する

## Why
なぜかstoreが作り直されてWidgetが残り続ける問題が発生してそう。その結果、Storeだけが作り直されてStateがクリアされて、Widgetのbuild時に何も存在してない画面が出てきてしまう

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した