### PR TITLE
Record with taken value history isQuickRecord

### DIFF
--- a/lib/domain/record/record_page_store.dart
+++ b/lib/domain/record/record_page_store.dart
@@ -252,6 +252,7 @@ class RecordPageStore extends StateNotifier<RecordPageState> {
       pillSheetService: _pillSheetService,
       pillSheetModifiedHistoryService: _pillSheetModifiedHistoryService,
       pillSheetGroupService: _pillSheetGroupService,
+      isQuickRecord: false,
     );
     if (updatedPillSheetGroup == null) {
       return false;

--- a/lib/domain/record/util/take.dart
+++ b/lib/domain/record/util/take.dart
@@ -55,6 +55,7 @@ Future<PillSheetGroup?> take({
   required PillSheetService pillSheetService,
   required PillSheetModifiedHistoryService pillSheetModifiedHistoryService,
   required PillSheetGroupService pillSheetGroupService,
+  required bool isQuickRecord,
 }) async {
   if (activedPillSheet.todayPillIsAlreadyTaken) {
     return null;

--- a/lib/domain/record/util/take.dart
+++ b/lib/domain/record/util/take.dart
@@ -106,6 +106,7 @@ Future<PillSheetGroup?> take({
     pillSheetGroupID: pillSheetGroup.id,
     before: before,
     after: after,
+    isQuickRecord: isQuickRecord,
   );
   pillSheetModifiedHistoryService.add(batch, history);
 

--- a/lib/entity/pill_sheet_modified_history_value.dart
+++ b/lib/entity/pill_sheet_modified_history_value.dart
@@ -107,6 +107,7 @@ class TakenPillValue with _$TakenPillValue {
         required DateTime afterLastTakenDate,
     required int beforeLastTakenPillNumber,
     required int afterLastTakenPillNumber,
+    required bool isQuickRecord,
     TakenPillEditedValue? edited,
   }) = _TakenPillValue;
 

--- a/lib/entity/pill_sheet_modified_history_value.dart
+++ b/lib/entity/pill_sheet_modified_history_value.dart
@@ -107,7 +107,7 @@ class TakenPillValue with _$TakenPillValue {
         required DateTime afterLastTakenDate,
     required int beforeLastTakenPillNumber,
     required int afterLastTakenPillNumber,
-    required bool isQuickRecord,
+    bool? isQuickRecord,
     TakenPillEditedValue? edited,
   }) = _TakenPillValue;
 

--- a/lib/entity/pill_sheet_modified_history_value.dart
+++ b/lib/entity/pill_sheet_modified_history_value.dart
@@ -107,6 +107,7 @@ class TakenPillValue with _$TakenPillValue {
         required DateTime afterLastTakenDate,
     required int beforeLastTakenPillNumber,
     required int afterLastTakenPillNumber,
+    // null => 途中から追加したプロパティなので、どちらか不明
     bool? isQuickRecord,
     TakenPillEditedValue? edited,
   }) = _TakenPillValue;

--- a/lib/entity/pill_sheet_modified_history_value.freezed.dart
+++ b/lib/entity/pill_sheet_modified_history_value.freezed.dart
@@ -1252,7 +1252,7 @@ class _$TakenPillValueTearOff {
           required DateTime afterLastTakenDate,
       required int beforeLastTakenPillNumber,
       required int afterLastTakenPillNumber,
-      required bool isQuickRecord,
+      bool? isQuickRecord,
       TakenPillEditedValue? edited}) {
     return _TakenPillValue(
       beforeLastTakenDate: beforeLastTakenDate,
@@ -1284,7 +1284,7 @@ mixin _$TakenPillValue {
   DateTime get afterLastTakenDate => throw _privateConstructorUsedError;
   int get beforeLastTakenPillNumber => throw _privateConstructorUsedError;
   int get afterLastTakenPillNumber => throw _privateConstructorUsedError;
-  bool get isQuickRecord => throw _privateConstructorUsedError;
+  bool? get isQuickRecord => throw _privateConstructorUsedError;
   TakenPillEditedValue? get edited => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -1305,7 +1305,7 @@ abstract class $TakenPillValueCopyWith<$Res> {
           DateTime afterLastTakenDate,
       int beforeLastTakenPillNumber,
       int afterLastTakenPillNumber,
-      bool isQuickRecord,
+      bool? isQuickRecord,
       TakenPillEditedValue? edited});
 
   $TakenPillEditedValueCopyWith<$Res>? get edited;
@@ -1349,7 +1349,7 @@ class _$TakenPillValueCopyWithImpl<$Res>
       isQuickRecord: isQuickRecord == freezed
           ? _value.isQuickRecord
           : isQuickRecord // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       edited: edited == freezed
           ? _value.edited
           : edited // ignore: cast_nullable_to_non_nullable
@@ -1383,7 +1383,7 @@ abstract class _$TakenPillValueCopyWith<$Res>
           DateTime afterLastTakenDate,
       int beforeLastTakenPillNumber,
       int afterLastTakenPillNumber,
-      bool isQuickRecord,
+      bool? isQuickRecord,
       TakenPillEditedValue? edited});
 
   @override
@@ -1430,7 +1430,7 @@ class __$TakenPillValueCopyWithImpl<$Res>
       isQuickRecord: isQuickRecord == freezed
           ? _value.isQuickRecord
           : isQuickRecord // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       edited: edited == freezed
           ? _value.edited
           : edited // ignore: cast_nullable_to_non_nullable
@@ -1450,7 +1450,7 @@ class _$_TakenPillValue extends _TakenPillValue {
           required this.afterLastTakenDate,
       required this.beforeLastTakenPillNumber,
       required this.afterLastTakenPillNumber,
-      required this.isQuickRecord,
+      this.isQuickRecord,
       this.edited})
       : super._();
 
@@ -1472,7 +1472,7 @@ class _$_TakenPillValue extends _TakenPillValue {
   @override
   final int afterLastTakenPillNumber;
   @override
-  final bool isQuickRecord;
+  final bool? isQuickRecord;
   @override
   final TakenPillEditedValue? edited;
 
@@ -1528,7 +1528,7 @@ abstract class _TakenPillValue extends TakenPillValue {
           required DateTime afterLastTakenDate,
       required int beforeLastTakenPillNumber,
       required int afterLastTakenPillNumber,
-      required bool isQuickRecord,
+      bool? isQuickRecord,
       TakenPillEditedValue? edited}) = _$_TakenPillValue;
   const _TakenPillValue._() : super._();
 
@@ -1550,7 +1550,7 @@ abstract class _TakenPillValue extends TakenPillValue {
   @override
   int get afterLastTakenPillNumber;
   @override
-  bool get isQuickRecord;
+  bool? get isQuickRecord;
   @override
   TakenPillEditedValue? get edited;
   @override

--- a/lib/entity/pill_sheet_modified_history_value.freezed.dart
+++ b/lib/entity/pill_sheet_modified_history_value.freezed.dart
@@ -1252,12 +1252,14 @@ class _$TakenPillValueTearOff {
           required DateTime afterLastTakenDate,
       required int beforeLastTakenPillNumber,
       required int afterLastTakenPillNumber,
+      required bool isQuickRecord,
       TakenPillEditedValue? edited}) {
     return _TakenPillValue(
       beforeLastTakenDate: beforeLastTakenDate,
       afterLastTakenDate: afterLastTakenDate,
       beforeLastTakenPillNumber: beforeLastTakenPillNumber,
       afterLastTakenPillNumber: afterLastTakenPillNumber,
+      isQuickRecord: isQuickRecord,
       edited: edited,
     );
   }
@@ -1282,6 +1284,7 @@ mixin _$TakenPillValue {
   DateTime get afterLastTakenDate => throw _privateConstructorUsedError;
   int get beforeLastTakenPillNumber => throw _privateConstructorUsedError;
   int get afterLastTakenPillNumber => throw _privateConstructorUsedError;
+  bool get isQuickRecord => throw _privateConstructorUsedError;
   TakenPillEditedValue? get edited => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -1302,6 +1305,7 @@ abstract class $TakenPillValueCopyWith<$Res> {
           DateTime afterLastTakenDate,
       int beforeLastTakenPillNumber,
       int afterLastTakenPillNumber,
+      bool isQuickRecord,
       TakenPillEditedValue? edited});
 
   $TakenPillEditedValueCopyWith<$Res>? get edited;
@@ -1322,6 +1326,7 @@ class _$TakenPillValueCopyWithImpl<$Res>
     Object? afterLastTakenDate = freezed,
     Object? beforeLastTakenPillNumber = freezed,
     Object? afterLastTakenPillNumber = freezed,
+    Object? isQuickRecord = freezed,
     Object? edited = freezed,
   }) {
     return _then(_value.copyWith(
@@ -1341,6 +1346,10 @@ class _$TakenPillValueCopyWithImpl<$Res>
           ? _value.afterLastTakenPillNumber
           : afterLastTakenPillNumber // ignore: cast_nullable_to_non_nullable
               as int,
+      isQuickRecord: isQuickRecord == freezed
+          ? _value.isQuickRecord
+          : isQuickRecord // ignore: cast_nullable_to_non_nullable
+              as bool,
       edited: edited == freezed
           ? _value.edited
           : edited // ignore: cast_nullable_to_non_nullable
@@ -1374,6 +1383,7 @@ abstract class _$TakenPillValueCopyWith<$Res>
           DateTime afterLastTakenDate,
       int beforeLastTakenPillNumber,
       int afterLastTakenPillNumber,
+      bool isQuickRecord,
       TakenPillEditedValue? edited});
 
   @override
@@ -1397,6 +1407,7 @@ class __$TakenPillValueCopyWithImpl<$Res>
     Object? afterLastTakenDate = freezed,
     Object? beforeLastTakenPillNumber = freezed,
     Object? afterLastTakenPillNumber = freezed,
+    Object? isQuickRecord = freezed,
     Object? edited = freezed,
   }) {
     return _then(_TakenPillValue(
@@ -1416,6 +1427,10 @@ class __$TakenPillValueCopyWithImpl<$Res>
           ? _value.afterLastTakenPillNumber
           : afterLastTakenPillNumber // ignore: cast_nullable_to_non_nullable
               as int,
+      isQuickRecord: isQuickRecord == freezed
+          ? _value.isQuickRecord
+          : isQuickRecord // ignore: cast_nullable_to_non_nullable
+              as bool,
       edited: edited == freezed
           ? _value.edited
           : edited // ignore: cast_nullable_to_non_nullable
@@ -1435,6 +1450,7 @@ class _$_TakenPillValue extends _TakenPillValue {
           required this.afterLastTakenDate,
       required this.beforeLastTakenPillNumber,
       required this.afterLastTakenPillNumber,
+      required this.isQuickRecord,
       this.edited})
       : super._();
 
@@ -1456,11 +1472,13 @@ class _$_TakenPillValue extends _TakenPillValue {
   @override
   final int afterLastTakenPillNumber;
   @override
+  final bool isQuickRecord;
+  @override
   final TakenPillEditedValue? edited;
 
   @override
   String toString() {
-    return 'TakenPillValue(beforeLastTakenDate: $beforeLastTakenDate, afterLastTakenDate: $afterLastTakenDate, beforeLastTakenPillNumber: $beforeLastTakenPillNumber, afterLastTakenPillNumber: $afterLastTakenPillNumber, edited: $edited)';
+    return 'TakenPillValue(beforeLastTakenDate: $beforeLastTakenDate, afterLastTakenDate: $afterLastTakenDate, beforeLastTakenPillNumber: $beforeLastTakenPillNumber, afterLastTakenPillNumber: $afterLastTakenPillNumber, isQuickRecord: $isQuickRecord, edited: $edited)';
   }
 
   @override
@@ -1476,6 +1494,8 @@ class _$_TakenPillValue extends _TakenPillValue {
                 other.beforeLastTakenPillNumber, beforeLastTakenPillNumber) &&
             const DeepCollectionEquality().equals(
                 other.afterLastTakenPillNumber, afterLastTakenPillNumber) &&
+            const DeepCollectionEquality()
+                .equals(other.isQuickRecord, isQuickRecord) &&
             const DeepCollectionEquality().equals(other.edited, edited));
   }
 
@@ -1486,6 +1506,7 @@ class _$_TakenPillValue extends _TakenPillValue {
       const DeepCollectionEquality().hash(afterLastTakenDate),
       const DeepCollectionEquality().hash(beforeLastTakenPillNumber),
       const DeepCollectionEquality().hash(afterLastTakenPillNumber),
+      const DeepCollectionEquality().hash(isQuickRecord),
       const DeepCollectionEquality().hash(edited));
 
   @JsonKey(ignore: true)
@@ -1507,6 +1528,7 @@ abstract class _TakenPillValue extends TakenPillValue {
           required DateTime afterLastTakenDate,
       required int beforeLastTakenPillNumber,
       required int afterLastTakenPillNumber,
+      required bool isQuickRecord,
       TakenPillEditedValue? edited}) = _$_TakenPillValue;
   const _TakenPillValue._() : super._();
 
@@ -1527,6 +1549,8 @@ abstract class _TakenPillValue extends TakenPillValue {
   int get beforeLastTakenPillNumber;
   @override
   int get afterLastTakenPillNumber;
+  @override
+  bool get isQuickRecord;
   @override
   TakenPillEditedValue? get edited;
   @override

--- a/lib/entity/pill_sheet_modified_history_value.g.dart
+++ b/lib/entity/pill_sheet_modified_history_value.g.dart
@@ -136,7 +136,7 @@ _$_TakenPillValue _$$_TakenPillValueFromJson(Map<String, dynamic> json) =>
           json['afterLastTakenDate'] as Timestamp),
       beforeLastTakenPillNumber: json['beforeLastTakenPillNumber'] as int,
       afterLastTakenPillNumber: json['afterLastTakenPillNumber'] as int,
-      isQuickRecord: json['isQuickRecord'] as bool,
+      isQuickRecord: json['isQuickRecord'] as bool?,
       edited: json['edited'] == null
           ? null
           : TakenPillEditedValue.fromJson(

--- a/lib/entity/pill_sheet_modified_history_value.g.dart
+++ b/lib/entity/pill_sheet_modified_history_value.g.dart
@@ -136,6 +136,7 @@ _$_TakenPillValue _$$_TakenPillValueFromJson(Map<String, dynamic> json) =>
           json['afterLastTakenDate'] as Timestamp),
       beforeLastTakenPillNumber: json['beforeLastTakenPillNumber'] as int,
       afterLastTakenPillNumber: json['afterLastTakenPillNumber'] as int,
+      isQuickRecord: json['isQuickRecord'] as bool,
       edited: json['edited'] == null
           ? null
           : TakenPillEditedValue.fromJson(
@@ -150,6 +151,7 @@ Map<String, dynamic> _$$_TakenPillValueToJson(_$_TakenPillValue instance) =>
           instance.afterLastTakenDate),
       'beforeLastTakenPillNumber': instance.beforeLastTakenPillNumber,
       'afterLastTakenPillNumber': instance.afterLastTakenPillNumber,
+      'isQuickRecord': instance.isQuickRecord,
       'edited': instance.edited?.toJson(),
     };
 

--- a/lib/native/pill.dart
+++ b/lib/native/pill.dart
@@ -39,6 +39,7 @@ Future<void> recordPill() async {
     pillSheetService: pillSheetService,
     pillSheetModifiedHistoryService: pillSheetModifiedHistoryService,
     pillSheetGroupService: pillSheetGroupService,
+    isQuickRecord: true,
   );
 
   FlutterAppBadger.removeBadge();

--- a/lib/service/pill_sheet_modified_history.dart
+++ b/lib/service/pill_sheet_modified_history.dart
@@ -122,6 +122,7 @@ extension PillSheetModifiedHistoryServiceActionFactory
           afterLastTakenPillNumber: after.lastTakenPillNumber,
           beforeLastTakenDate: before.lastTakenDate,
           beforeLastTakenPillNumber: before.lastTakenPillNumber,
+          isQuickRecord: isQuickRecord,
         ),
       ),
       after: after,

--- a/lib/service/pill_sheet_modified_history.dart
+++ b/lib/service/pill_sheet_modified_history.dart
@@ -104,6 +104,7 @@ extension PillSheetModifiedHistoryServiceActionFactory
     required String? pillSheetGroupID,
     required PillSheet before,
     required PillSheet after,
+    required bool isQuickRecord,
   }) {
     assert(pillSheetGroupID != null);
 

--- a/test/domain/record/record_page_store_test.dart
+++ b/test/domain/record/record_page_store_test.dart
@@ -279,6 +279,7 @@ void main() {
         after: pillSheet.copyWith(
           lastTakenDate: _today,
         ),
+        isQuickRecord: false,
       );
       final pillSheetModifiedHistoryService =
           MockPillSheetModifiedHistoryService();
@@ -396,6 +397,7 @@ void main() {
         after: pillSheet.copyWith(
           lastTakenDate: _today,
         ),
+        isQuickRecord: false,
       );
       final pillSheetModifiedHistoryService =
           MockPillSheetModifiedHistoryService();
@@ -515,6 +517,7 @@ void main() {
         after: pillSheet2.copyWith(
           lastTakenDate: _today,
         ),
+        isQuickRecord: false,
       );
       final pillSheetModifiedHistoryService =
           MockPillSheetModifiedHistoryService();
@@ -637,6 +640,7 @@ void main() {
         after: pillSheet2.copyWith(
           lastTakenDate: _today,
         ),
+        isQuickRecord: false,
       );
       final pillSheetModifiedHistoryService =
           MockPillSheetModifiedHistoryService();


### PR DESCRIPTION
## Abstract
服用履歴にquick recordかどうかを判断するプロパティを追加

## Why
Quick Record機能(Push通知からActionable Button経由で記録する機能)だとsession_startやfirebase analytics イベントが取得できない場合が多く、集計用のプロパティとして追加する

理由は下記のリンクの通りである。自分でも確認したがsession_startやanalyticsのイベントは記録できてない

https://support.google.com/firebase/answer/9191807?hl=en
> Opens your app in the foreground

https://stackoverflow.com/questions/41030377/how-does-firebase-analytics-define-a-session
> And I'll answer my question by saying that Firebase Analytics defines a session as a user engaging with your app for a minimum amount of time (10 seconds by default) followed by your user not engaging with your app for a certain amount of time (30 minutes by default). But you can change those times if you'd like something different.

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した