### PR TITLE
to front of appearance word

### DIFF
--- a/lib/domain/record/components/supports/components/appearance_mode/switching_appearance_mode.dart
+++ b/lib/domain/record/components/supports/components/appearance_mode/switching_appearance_mode.dart
@@ -20,9 +20,9 @@ class SwitchingAppearanceMode extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       child: Row(children: [
-        const Text(
-          "表示モード",
-          style: TextStyle(
+        Text(
+          _text,
+          style: const TextStyle(
             color: TextColor.main,
             fontSize: 12,
             fontFamily: FontFamily.japanese,
@@ -37,5 +37,16 @@ class SwitchingAppearanceMode extends StatelessWidget {
         showSelectAppearanceModeModal(context);
       },
     );
+  }
+
+  String get _text {
+    switch (mode) {
+      case PillSheetAppearanceMode.number:
+        return "ピル番号表示";
+      case PillSheetAppearanceMode.date:
+        return "日付表示";
+      case PillSheetAppearanceMode.sequential:
+        return "服用日数表示";
+    }
   }
 }


### PR DESCRIPTION
## Abstract
記録画面のピルシートの番号表示のモード切り替えのワーディングを機能名ではなく、現在設定されている表示モードの値の名前にする

## Why
こっちの方がわかりやすいかも。と考えた。

最初はタップ数が増えれば良いと考えてたが、逆に今表示されている状態が分かりやすくなる可能性があるのでタップ数が減る可能性もあると考えれれる

なので、目的があると言うよりは好奇心的な原動力でどう数字が変化するか少し見てみる

## Links
Notion: https://www.notion.so/28654462899140b19cc50177056c0349?v=3bec3c7c5a0149998e8239ef3cdc5a2f&p=afa820157a1a468da88979afc8af589c


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した