### PR TITLE
Remove version 1.3.2 code from launch app

### DIFF
--- a/lib/domain/record/record_page_store.dart
+++ b/lib/domain/record/record_page_store.dart
@@ -1,4 +1,3 @@
-import 'dart:io' show Platform;
 import 'dart:async';
 import 'dart:math';
 
@@ -9,6 +8,7 @@ import 'package:pilll/entity/pill_sheet.dart';
 import 'package:pilll/entity/pill_sheet_group.dart';
 import 'package:pilll/entity/pill_sheet_type.dart';
 import 'package:pilll/entity/setting.dart';
+import 'package:pilll/native/legacy.dart';
 import 'package:pilll/service/auth.dart';
 import 'package:pilll/service/pill_sheet.dart';
 import 'package:pilll/domain/record/record_page_state.dart';
@@ -81,24 +81,7 @@ class RecordPageStore extends StateNotifier<RecordPageState> {
           final totalCountOfActionForTakenPill =
               sharedPreferences.getInt(IntKey.totalCountOfActionForTakenPill) ??
                   0;
-          final shouldShowMigrateInfo = () {
-            if (!Platform.isIOS) {
-              return false;
-            }
-            if (sharedPreferences.getBool(BoolKey.migrateFrom132IsShown) ??
-                false) {
-              return false;
-            }
-            if (!sharedPreferences
-                .containsKey(StringKey.salvagedOldStartTakenDate)) {
-              return false;
-            }
-            if (!sharedPreferences
-                .containsKey(StringKey.salvagedOldLastTakenDate)) {
-              return false;
-            }
-            return true;
-          }();
+          final _shouldShowMigrateInfo = await shouldShowMigrateInfo();
           final recommendedSignupNotificationIsAlreadyShow =
               sharedPreferences.getBool(
                       BoolKey.recommendedSignupNotificationIsAlreadyShow) ??
@@ -108,7 +91,7 @@ class RecordPageStore extends StateNotifier<RecordPageState> {
               false;
           state = state.copyWith(
             totalCountOfActionForTakenPill: totalCountOfActionForTakenPill,
-            shouldShowMigrateInfo: shouldShowMigrateInfo,
+            shouldShowMigrateInfo: _shouldShowMigrateInfo,
             isAlreadyShowTiral: sharedPreferences
                     .getBool(BoolKey.isAlreadyShowPremiumTrialModal) ??
                 false,

--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -182,25 +182,24 @@ class RootState extends State<Root> {
           setState(() {
             this.screenType = ScreenType.forceUpdate;
           });
-          return;
-        }
+        } else {
+          final firebaseUser = await _signIn();
 
-        final firebaseUser = await _signIn();
-
-        final screenType = await _screenType();
-        setState(() {
-          this.screenType = screenType;
-        });
-
-        // NOTE: Below code contains backward-compatible logic from version 1.3.2
-        // screenType is determined if necessary, but since it is a special pattern. So, it is determined last
-        final user = await _mutateUserWithLaunchInfoAnd(firebaseUser);
-        final screenTypeForLegacyUser =
-            await _screenTypeForLegacyUser(firebaseUser, user);
-        if (screenTypeForLegacyUser != null) {
+          final screenType = await _screenType();
           setState(() {
-            this.screenType = screenTypeForLegacyUser;
+            this.screenType = screenType;
           });
+
+          // NOTE: Below code contains backward-compatible logic from version 1.3.2
+          // screenType is determined if necessary, but since it is a special pattern. So, it is determined last
+          final user = await _mutateUserWithLaunchInfoAnd(firebaseUser);
+          final screenTypeForLegacyUser =
+              await _screenTypeForLegacyUser(firebaseUser, user);
+          if (screenTypeForLegacyUser != null) {
+            setState(() {
+              this.screenType = screenTypeForLegacyUser;
+            });
+          }
         }
       } catch (error, stackTrace) {
         errorLogger.recordError(error, stackTrace);

--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -192,6 +192,8 @@ class RootState extends State<Root> {
           this.screenType = screenType;
         });
 
+        // NOTE: Below code contains backward-compatible logic from version 1.3.2
+        // screenType is determined if necessary, but since it is a special pattern. So, it is determined last
         final user = await _mutateUserWithLaunchInfoAnd(firebaseUser);
         final screenTypeForLegacyUser =
             await _screenTypeForLegacyUser(firebaseUser, user);

--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -7,6 +7,7 @@ import 'package:pilll/analytics.dart';
 import 'package:pilll/components/page/ok_dialog.dart';
 import 'package:pilll/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_pill_sheet_type_select_row.dart';
 import 'package:pilll/entity/config.dart';
+import 'package:pilll/native/legacy.dart';
 import 'package:pilll/performance.dart';
 import 'package:pilll/service/auth.dart';
 import 'package:pilll/database/database.dart';
@@ -152,6 +153,11 @@ class RootState extends State<Root> {
 
           userService.saveUserLaunchInfo();
           unawaited(userService.temporarySyncronizeDiscountEntitlement(user));
+          final sharedPreferences = await SharedPreferences.getInstance();
+
+          if (await shouldShowMigrateInfo()) {
+            return ScreenType.initialSetting;
+          }
 
           if (!user.migratedFlutter) {
             await userService.deleteSettings();
@@ -162,9 +168,8 @@ class RootState extends State<Root> {
             return ScreenType.initialSetting;
           }
 
-          final storage = await SharedPreferences.getInstance();
           bool? didEndInitialSetting =
-              storage.getBool(BoolKey.didEndInitialSetting);
+              sharedPreferences.getBool(BoolKey.didEndInitialSetting);
           if (didEndInitialSetting == null) {
             return ScreenType.initialSetting;
           }

--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -171,6 +171,8 @@ class RootState extends State<Root> {
     return null;
   }
 
+  // forceUpdate -> signIn -> decide initial setting or home screen -> after effect: mutate user launch info to db and salvage old version user
+  // save launch app time, Keep last of `after effect: mutate user launch info to db and salvage old version user`
   void _decideScreenType() {
     Future(() async {
       final launchTrace = _trace(name: "appLaunch", uuid: _traceUUID);

--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -73,7 +73,8 @@ class RootState extends State<Root> {
       Future.microtask(() async {
         await showOKDialog(context,
             title: "アプリをアップデートしてください",
-            message: "お使いのアプリのバージョンが古いため$storeNameから最新バージョンにアップデートしてください",
+            message:
+                "お使いのアプリのバージョンのアップデートをお願いしております。$storeNameから最新バージョンにアップデートしてください",
             ok: () async {
           await launch(storeURL, forceSafariVC: false, forceWebView: false);
         });

--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -171,7 +171,7 @@ class RootState extends State<Root> {
     return null;
   }
 
-  Future<void> _decideScreenType() async {
+  void _decideScreenType() {
     Future(() async {
       final launchTrace = _trace(name: "appLaunch", uuid: _traceUUID);
       await launchTrace.start();

--- a/lib/native/legacy.dart
+++ b/lib/native/legacy.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+import 'package:pilll/util/shared_preference/keys.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 Future<void> salvagedOldStartTakenDate(dynamic arguments) async {
@@ -40,4 +42,24 @@ Future<void> salvagedOldStartTakenDate(dynamic arguments) async {
     storage.setString(
         "salvagedOldLastTakenDate", formattedSalvagedOldLastTakenDate);
   });
+}
+
+Future<bool> shouldShowMigrateInfo() async {
+  if (!Platform.isIOS) {
+    return false;
+  }
+
+  final sharedPreferences = await SharedPreferences.getInstance();
+
+  if (sharedPreferences.getBool(BoolKey.migrateFrom132IsShown) ?? false) {
+    return false;
+  }
+  if (!sharedPreferences.containsKey(StringKey.salvagedOldStartTakenDate)) {
+    return false;
+  }
+  if (!sharedPreferences.containsKey(StringKey.salvagedOldLastTakenDate)) {
+    return false;
+  }
+
+  return true;
 }


### PR DESCRIPTION
## Abstract
起動処理から1.3.2のコードの優先度を一番下に下げる。通常の起動画面の決定処理が終わった後に、移行が必要かどうかを確認する。必要な場合は初期設定に後から遷移することになるが、超特殊なケースとなったのでこれで良いだろう
今までの処理が 1.3.2からアップデートしたユーザーに必要な処理 → リプレイス後のPilllの起動時に必要な処理。の順番になっていたのでこれを逆にする

## Why
起動時間が長くなるから

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した