### PR TITLE
Add permission for internet"h

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -80,4 +80,6 @@
             </intent-filter>
         </service>
     </application>
+
+    <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>


### PR DESCRIPTION
## Abstract
Android の dev の環境で firestore service unavailable がよく出るなあ。と思って調べたところ、release buildでは android.permission.INTERNET の指定が必要だったので追加。逆に今までどうして動いていたのかが謎

これでも治らなかったらこれをつける
https://github.com/FirebaseExtended/flutterfire/discussions/5708#discussioncomment-925997

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [ ] リリースノートを追加した