### PR TITLE
Fix title to 1/3

### DIFF
--- a/lib/domain/initial_setting/pill_type/initial_setting_pill_category_type_page.dart
+++ b/lib/domain/initial_setting/pill_type/initial_setting_pill_category_type_page.dart
@@ -61,7 +61,7 @@ class InitialSettingPillCategoryTypePage extends HookConsumerWidget {
         backgroundColor: PilllColors.background,
         appBar: AppBar(
           title: const Text(
-            "1/4",
+            "1/3",
             style: TextStyle(color: TextColor.black),
           ),
           backgroundColor: PilllColors.white,


### PR DESCRIPTION
## Abstract
初期設定1枚目のタイトルを 1/3 にする

## Why
タイトルの表示が `1/4` と `1/3` にすることで初期設定1枚目の達成率に変化があるかをウォッチする。明らかな間違いではある。

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した