### PR TITLE
Add test case for pill sheet group

### DIFF
--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -66,14 +66,8 @@ class PillSheetGroup with _$PillSheetGroup {
     if (activedPillSheet == null) {
       return 0;
     }
-    if (activedPillSheet.groupIndex == 0) {
-      return activedPillSheet.todayPillNumber;
-    }
-    final passedPillSheets = pillSheets.sublist(0, activedPillSheet.groupIndex);
-    if (passedPillSheets.isEmpty) {
-      return activedPillSheet.todayPillNumber;
-    }
 
+    final passedPillSheets = pillSheets.sublist(0, activedPillSheet.groupIndex);
     final passedPillCountForPillSheetTypes =
         summarizedPillSheetTypeTotalCountToPageIndex(
             pillSheetTypes:
@@ -90,14 +84,8 @@ class PillSheetGroup with _$PillSheetGroup {
     if (activedPillSheet == null) {
       return 0;
     }
-    if (activedPillSheet.groupIndex == 0) {
-      return activedPillSheet.lastTakenPillNumber;
-    }
-    final passedPillSheets = pillSheets.sublist(0, activedPillSheet.groupIndex);
-    if (passedPillSheets.isEmpty) {
-      return activedPillSheet.lastTakenPillNumber;
-    }
 
+    final passedPillSheets = pillSheets.sublist(0, activedPillSheet.groupIndex);
     final passedPillCountForPillSheetTypes =
         summarizedPillSheetTypeTotalCountToPageIndex(
             pillSheetTypes:

--- a/test/entity/pill_sheet_group_test.dart
+++ b/test/entity/pill_sheet_group_test.dart
@@ -516,6 +516,47 @@ void main() {
           });
         });
       });
+      group("has two pill sheets", () {
+        test("it is plane pattern", () {
+          final mockTodayRepository = MockTodayService();
+          todayRepository = mockTodayRepository;
+          when(mockTodayRepository.today())
+              .thenReturn(DateTime.parse("2022-03-30"));
+          when(mockTodayRepository.now())
+              .thenReturn(DateTime.parse("2022-03-30"));
+
+          final sheetType = PillSheetType.pillsheet_21;
+          final pillSheet1 = PillSheet(
+            beginingDate: DateTime.parse("2022-03-01"),
+            lastTakenDate: DateTime.parse("2020-03-28"),
+            groupIndex: 0,
+            typeInfo: PillSheetTypeInfo(
+              dosingPeriod: sheetType.dosingPeriod,
+              name: sheetType.fullName,
+              totalCount: sheetType.totalCount,
+              pillSheetTypeReferencePath: sheetType.rawPath,
+            ),
+          );
+          final pillSheet2 = PillSheet(
+            beginingDate: DateTime.parse("2022-03-29"),
+            lastTakenDate: DateTime.parse("2022-03-29"),
+            groupIndex: 1,
+            typeInfo: PillSheetTypeInfo(
+              dosingPeriod: sheetType.dosingPeriod,
+              name: sheetType.fullName,
+              totalCount: sheetType.totalCount,
+              pillSheetTypeReferencePath: sheetType.rawPath,
+            ),
+          );
+          // created at and id are anything value
+          final pillSheetGroup = PillSheetGroup(
+            pillSheetIDs: ["sheet_id", "sheet_id2"],
+            pillSheets: [pillSheet1, pillSheet2],
+            createdAt: DateTime.now(),
+          );
+          expect(pillSheetGroup.sequentialLastTakenPillNumber, 29);
+        });
+      });
     });
   });
 }

--- a/test/entity/pill_sheet_group_test.dart
+++ b/test/entity/pill_sheet_group_test.dart
@@ -220,6 +220,47 @@ void main() {
         });
       });
     });
+    group("has three pill sheets", () {
+      test("it is plane pattern", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.today())
+            .thenReturn(DateTime.parse("2022-03-29"));
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2022-03-29"));
+
+        final sheetType = PillSheetType.pillsheet_21;
+        final pillSheet1 = PillSheet(
+          beginingDate: DateTime.parse("2022-03-01"),
+          lastTakenDate: DateTime.parse("2020-03-28"),
+          groupIndex: 0,
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+        );
+        final pillSheet2 = PillSheet(
+          beginingDate: DateTime.parse("2022-03-29"),
+          lastTakenDate: null,
+          groupIndex: 1,
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+        );
+        // created at and id are anything value
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id", "sheet_id2"],
+          pillSheets: [pillSheet1, pillSheet2],
+          createdAt: DateTime.now(),
+        );
+        expect(pillSheetGroup.sequentialTodayPillNumber, 29);
+      });
+    });
   });
 
   group("#sequentialLastTakenPillNumber", () {

--- a/test/entity/pill_sheet_group_test.dart
+++ b/test/entity/pill_sheet_group_test.dart
@@ -220,7 +220,7 @@ void main() {
         });
       });
     });
-    group("has three pill sheets", () {
+    group("has two pill sheets", () {
       test("it is plane pattern", () {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;

--- a/test/entity/pill_sheet_group_test.dart
+++ b/test/entity/pill_sheet_group_test.dart
@@ -1,0 +1,220 @@
+import 'package:pilll/entity/pill_sheet.codegen.dart';
+import 'package:pilll/entity/pill_sheet_group.codegen.dart';
+import 'package:pilll/entity/pill_sheet_type.dart';
+import 'package:pilll/service/day.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helper/mock.mocks.dart';
+
+void main() {
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group("#sequentialTodayPillNumber", () {
+    test("has one pill sheet", () {
+      final mockTodayRepository = MockTodayService();
+      todayRepository = mockTodayRepository;
+      when(mockTodayRepository.today())
+          .thenReturn(DateTime.parse("2020-09-19"));
+      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-19"));
+
+      final sheetType = PillSheetType.pillsheet_21;
+      final pillSheet = PillSheet(
+        beginingDate: DateTime.parse("2020-09-14"),
+        lastTakenDate: DateTime.parse("2020-09-18"),
+        typeInfo: PillSheetTypeInfo(
+          dosingPeriod: sheetType.dosingPeriod,
+          name: sheetType.fullName,
+          totalCount: sheetType.totalCount,
+          pillSheetTypeReferencePath: sheetType.rawPath,
+        ),
+      );
+      // created at is anything value
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ["sheet_id"],
+        pillSheets: [pillSheet],
+        createdAt: DateTime.now(),
+      );
+      expect(pillSheetGroup.sequentialTodayPillNumber, 6);
+    });
+    test("today: 2020-09-28, begin: 2020-09-01, end: 2020-09-28", () {
+      final mockTodayRepository = MockTodayService();
+      todayRepository = mockTodayRepository;
+      when(mockTodayRepository.today())
+          .thenReturn(DateTime.parse("2020-09-28"));
+      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-19"));
+
+      final sheetType = PillSheetType.pillsheet_21;
+      final pillSheet = PillSheet(
+        beginingDate: DateTime.parse("2020-09-01"),
+        lastTakenDate: DateTime.parse("2020-09-28"),
+        typeInfo: PillSheetTypeInfo(
+          dosingPeriod: sheetType.dosingPeriod,
+          name: sheetType.fullName,
+          totalCount: sheetType.totalCount,
+          pillSheetTypeReferencePath: sheetType.rawPath,
+        ),
+      );
+      // created at is anything value
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ["sheet_id"],
+        pillSheets: [pillSheet],
+        createdAt: DateTime.now(),
+      );
+      expect(pillSheetGroup.sequentialTodayPillNumber, 28);
+    });
+    group("pillsheet has rest durations", () {
+      test("rest duration is not end", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.today())
+            .thenReturn(DateTime.parse("2020-09-28"));
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-19"));
+
+        final sheetType = PillSheetType.pillsheet_21;
+        final pillSheet = PillSheet(
+          beginingDate: DateTime.parse("2020-09-01"),
+          lastTakenDate: DateTime.parse("2020-09-28"),
+          restDurations: [
+            RestDuration(
+              beginDate: DateTime.parse("2020-09-22"),
+              createdDate: DateTime.parse("2020-09-22"),
+            )
+          ],
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+        );
+        // created at is anything value
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: DateTime.now(),
+        );
+        expect(pillSheetGroup.sequentialTodayPillNumber, 22);
+      });
+
+      test("rest duration is ended", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.today())
+            .thenReturn(DateTime.parse("2020-09-28"));
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-19"));
+
+        final sheetType = PillSheetType.pillsheet_21;
+        final pillSheet = PillSheet(
+          beginingDate: DateTime.parse("2020-09-01"),
+          lastTakenDate: DateTime.parse("2020-09-28"),
+          restDurations: [
+            RestDuration(
+              beginDate: DateTime.parse("2020-09-22"),
+              createdDate: DateTime.parse("2020-09-22"),
+              endDate: DateTime.parse("2020-09-25"),
+            )
+          ],
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+        );
+        // created at is anything value
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: DateTime.now(),
+        );
+        expect(pillSheetGroup.sequentialTodayPillNumber, 25);
+      });
+      group("rest duration has plural rest duration. ", () {
+        test("last rest duration is not ended", () {
+          final mockTodayRepository = MockTodayService();
+          todayRepository = mockTodayRepository;
+          when(mockTodayRepository.today())
+              .thenReturn(DateTime.parse("2020-09-28"));
+          when(mockTodayRepository.now())
+              .thenReturn(DateTime.parse("2020-09-19"));
+
+          final sheetType = PillSheetType.pillsheet_21;
+          final pillSheet = PillSheet(
+            beginingDate: DateTime.parse("2020-09-01"),
+            lastTakenDate: DateTime.parse("2020-09-28"),
+            restDurations: [
+              RestDuration(
+                beginDate: DateTime.parse("2020-09-12"),
+                createdDate: DateTime.parse("2020-09-12"),
+                endDate: DateTime.parse("2020-09-15"),
+              ),
+              RestDuration(
+                beginDate: DateTime.parse("2020-09-22"),
+                createdDate: DateTime.parse("2020-09-22"),
+              )
+            ],
+            typeInfo: PillSheetTypeInfo(
+              dosingPeriod: sheetType.dosingPeriod,
+              name: sheetType.fullName,
+              totalCount: sheetType.totalCount,
+              pillSheetTypeReferencePath: sheetType.rawPath,
+            ),
+          );
+          // created at is anything value
+          final pillSheetGroup = PillSheetGroup(
+            pillSheetIDs: ["sheet_id"],
+            pillSheets: [pillSheet],
+            createdAt: DateTime.now(),
+          );
+          expect(pillSheetGroup.sequentialTodayPillNumber, 19);
+        });
+        test("last rest duration is ended", () {
+          final mockTodayRepository = MockTodayService();
+          todayRepository = mockTodayRepository;
+          when(mockTodayRepository.today())
+              .thenReturn(DateTime.parse("2020-09-28"));
+          when(mockTodayRepository.now())
+              .thenReturn(DateTime.parse("2020-09-19"));
+
+          final sheetType = PillSheetType.pillsheet_21;
+          final pillSheet = PillSheet(
+            beginingDate: DateTime.parse("2020-09-01"),
+            lastTakenDate: DateTime.parse("2020-09-28"),
+            restDurations: [
+              RestDuration(
+                beginDate: DateTime.parse("2020-09-12"),
+                createdDate: DateTime.parse("2020-09-12"),
+                endDate: DateTime.parse("2020-09-15"),
+              ),
+              RestDuration(
+                beginDate: DateTime.parse("2020-09-22"),
+                createdDate: DateTime.parse("2020-09-22"),
+                endDate: DateTime.parse("2020-09-25"),
+              )
+            ],
+            typeInfo: PillSheetTypeInfo(
+              dosingPeriod: sheetType.dosingPeriod,
+              name: sheetType.fullName,
+              totalCount: sheetType.totalCount,
+              pillSheetTypeReferencePath: sheetType.rawPath,
+            ),
+          );
+          // created at is anything value
+          final pillSheetGroup = PillSheetGroup(
+            pillSheetIDs: ["sheet_id"],
+            pillSheets: [pillSheet],
+            createdAt: DateTime.now(),
+          );
+          expect(pillSheetGroup.sequentialTodayPillNumber, 22);
+        });
+      });
+    });
+  });
+}

--- a/test/entity/pill_sheet_group_test.dart
+++ b/test/entity/pill_sheet_group_test.dart
@@ -139,7 +139,7 @@ void main() {
           );
           expect(pillSheetGroup.sequentialTodayPillNumber, 25);
         });
-        group("rest duration has plural rest duration. ", () {
+        group("pill sheet has plural rest duration. ", () {
           test("last rest duration is not ended", () {
             final mockTodayRepository = MockTodayService();
             todayRepository = mockTodayRepository;

--- a/test/entity/pill_sheet_group_test.dart
+++ b/test/entity/pill_sheet_group_test.dart
@@ -15,60 +15,35 @@ void main() {
   });
 
   group("#sequentialTodayPillNumber", () {
-    test("has one pill sheet", () {
-      final mockTodayRepository = MockTodayService();
-      todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today())
-          .thenReturn(DateTime.parse("2020-09-19"));
-      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-19"));
+    group("has one pill sheet", () {
+      test("today: 2020-09-19, begin: 2020-09-14, end: 2020-09-18", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.today())
+            .thenReturn(DateTime.parse("2020-09-19"));
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-19"));
 
-      final sheetType = PillSheetType.pillsheet_21;
-      final pillSheet = PillSheet(
-        beginingDate: DateTime.parse("2020-09-14"),
-        lastTakenDate: DateTime.parse("2020-09-18"),
-        typeInfo: PillSheetTypeInfo(
-          dosingPeriod: sheetType.dosingPeriod,
-          name: sheetType.fullName,
-          totalCount: sheetType.totalCount,
-          pillSheetTypeReferencePath: sheetType.rawPath,
-        ),
-      );
-      // created at is anything value
-      final pillSheetGroup = PillSheetGroup(
-        pillSheetIDs: ["sheet_id"],
-        pillSheets: [pillSheet],
-        createdAt: DateTime.now(),
-      );
-      expect(pillSheetGroup.sequentialTodayPillNumber, 6);
-    });
-    test("today: 2020-09-28, begin: 2020-09-01, end: 2020-09-28", () {
-      final mockTodayRepository = MockTodayService();
-      todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today())
-          .thenReturn(DateTime.parse("2020-09-28"));
-      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-19"));
-
-      final sheetType = PillSheetType.pillsheet_21;
-      final pillSheet = PillSheet(
-        beginingDate: DateTime.parse("2020-09-01"),
-        lastTakenDate: DateTime.parse("2020-09-28"),
-        typeInfo: PillSheetTypeInfo(
-          dosingPeriod: sheetType.dosingPeriod,
-          name: sheetType.fullName,
-          totalCount: sheetType.totalCount,
-          pillSheetTypeReferencePath: sheetType.rawPath,
-        ),
-      );
-      // created at is anything value
-      final pillSheetGroup = PillSheetGroup(
-        pillSheetIDs: ["sheet_id"],
-        pillSheets: [pillSheet],
-        createdAt: DateTime.now(),
-      );
-      expect(pillSheetGroup.sequentialTodayPillNumber, 28);
-    });
-    group("pillsheet has rest durations", () {
-      test("rest duration is not end", () {
+        final sheetType = PillSheetType.pillsheet_21;
+        final pillSheet = PillSheet(
+          beginingDate: DateTime.parse("2020-09-14"),
+          lastTakenDate: DateTime.parse("2020-09-18"),
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+        );
+        // created at and id are anything value
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: DateTime.now(),
+        );
+        expect(pillSheetGroup.sequentialTodayPillNumber, 6);
+      });
+      test("today: 2020-09-28, begin: 2020-09-01, end: 2020-09-28", () {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.today())
@@ -80,12 +55,6 @@ void main() {
         final pillSheet = PillSheet(
           beginingDate: DateTime.parse("2020-09-01"),
           lastTakenDate: DateTime.parse("2020-09-28"),
-          restDurations: [
-            RestDuration(
-              beginDate: DateTime.parse("2020-09-22"),
-              createdDate: DateTime.parse("2020-09-22"),
-            )
-          ],
           typeInfo: PillSheetTypeInfo(
             dosingPeriod: sheetType.dosingPeriod,
             name: sheetType.fullName,
@@ -93,51 +62,16 @@ void main() {
             pillSheetTypeReferencePath: sheetType.rawPath,
           ),
         );
-        // created at is anything value
+        // created at and id are anything value
         final pillSheetGroup = PillSheetGroup(
           pillSheetIDs: ["sheet_id"],
           pillSheets: [pillSheet],
           createdAt: DateTime.now(),
         );
-        expect(pillSheetGroup.sequentialTodayPillNumber, 22);
+        expect(pillSheetGroup.sequentialTodayPillNumber, 28);
       });
-
-      test("rest duration is ended", () {
-        final mockTodayRepository = MockTodayService();
-        todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today())
-            .thenReturn(DateTime.parse("2020-09-28"));
-        when(mockTodayRepository.now())
-            .thenReturn(DateTime.parse("2020-09-19"));
-
-        final sheetType = PillSheetType.pillsheet_21;
-        final pillSheet = PillSheet(
-          beginingDate: DateTime.parse("2020-09-01"),
-          lastTakenDate: DateTime.parse("2020-09-28"),
-          restDurations: [
-            RestDuration(
-              beginDate: DateTime.parse("2020-09-22"),
-              createdDate: DateTime.parse("2020-09-22"),
-              endDate: DateTime.parse("2020-09-25"),
-            )
-          ],
-          typeInfo: PillSheetTypeInfo(
-            dosingPeriod: sheetType.dosingPeriod,
-            name: sheetType.fullName,
-            totalCount: sheetType.totalCount,
-            pillSheetTypeReferencePath: sheetType.rawPath,
-          ),
-        );
-        // created at is anything value
-        final pillSheetGroup = PillSheetGroup(
-          pillSheetIDs: ["sheet_id"],
-          pillSheets: [pillSheet],
-          createdAt: DateTime.now(),
-        );
-        expect(pillSheetGroup.sequentialTodayPillNumber, 25);
-      });
-      group("rest duration has plural rest duration. ", () {
-        test("last rest duration is not ended", () {
+      group("pillsheet has rest durations", () {
+        test("rest duration is not end", () {
           final mockTodayRepository = MockTodayService();
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.today())
@@ -150,11 +84,6 @@ void main() {
             beginingDate: DateTime.parse("2020-09-01"),
             lastTakenDate: DateTime.parse("2020-09-28"),
             restDurations: [
-              RestDuration(
-                beginDate: DateTime.parse("2020-09-12"),
-                createdDate: DateTime.parse("2020-09-12"),
-                endDate: DateTime.parse("2020-09-15"),
-              ),
               RestDuration(
                 beginDate: DateTime.parse("2020-09-22"),
                 createdDate: DateTime.parse("2020-09-22"),
@@ -167,15 +96,16 @@ void main() {
               pillSheetTypeReferencePath: sheetType.rawPath,
             ),
           );
-          // created at is anything value
+          // created at and id are anything value
           final pillSheetGroup = PillSheetGroup(
             pillSheetIDs: ["sheet_id"],
             pillSheets: [pillSheet],
             createdAt: DateTime.now(),
           );
-          expect(pillSheetGroup.sequentialTodayPillNumber, 19);
+          expect(pillSheetGroup.sequentialTodayPillNumber, 22);
         });
-        test("last rest duration is ended", () {
+
+        test("rest duration is ended", () {
           final mockTodayRepository = MockTodayService();
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.today())
@@ -188,11 +118,6 @@ void main() {
             beginingDate: DateTime.parse("2020-09-01"),
             lastTakenDate: DateTime.parse("2020-09-28"),
             restDurations: [
-              RestDuration(
-                beginDate: DateTime.parse("2020-09-12"),
-                createdDate: DateTime.parse("2020-09-12"),
-                endDate: DateTime.parse("2020-09-15"),
-              ),
               RestDuration(
                 beginDate: DateTime.parse("2020-09-22"),
                 createdDate: DateTime.parse("2020-09-22"),
@@ -206,13 +131,348 @@ void main() {
               pillSheetTypeReferencePath: sheetType.rawPath,
             ),
           );
-          // created at is anything value
+          // created at and id are anything value
           final pillSheetGroup = PillSheetGroup(
             pillSheetIDs: ["sheet_id"],
             pillSheets: [pillSheet],
             createdAt: DateTime.now(),
           );
-          expect(pillSheetGroup.sequentialTodayPillNumber, 22);
+          expect(pillSheetGroup.sequentialTodayPillNumber, 25);
+        });
+        group("rest duration has plural rest duration. ", () {
+          test("last rest duration is not ended", () {
+            final mockTodayRepository = MockTodayService();
+            todayRepository = mockTodayRepository;
+            when(mockTodayRepository.today())
+                .thenReturn(DateTime.parse("2020-09-28"));
+            when(mockTodayRepository.now())
+                .thenReturn(DateTime.parse("2020-09-19"));
+
+            final sheetType = PillSheetType.pillsheet_21;
+            final pillSheet = PillSheet(
+              beginingDate: DateTime.parse("2020-09-01"),
+              lastTakenDate: DateTime.parse("2020-09-28"),
+              restDurations: [
+                RestDuration(
+                  beginDate: DateTime.parse("2020-09-12"),
+                  createdDate: DateTime.parse("2020-09-12"),
+                  endDate: DateTime.parse("2020-09-15"),
+                ),
+                RestDuration(
+                  beginDate: DateTime.parse("2020-09-22"),
+                  createdDate: DateTime.parse("2020-09-22"),
+                )
+              ],
+              typeInfo: PillSheetTypeInfo(
+                dosingPeriod: sheetType.dosingPeriod,
+                name: sheetType.fullName,
+                totalCount: sheetType.totalCount,
+                pillSheetTypeReferencePath: sheetType.rawPath,
+              ),
+            );
+            // created at and id are anything value
+            final pillSheetGroup = PillSheetGroup(
+              pillSheetIDs: ["sheet_id"],
+              pillSheets: [pillSheet],
+              createdAt: DateTime.now(),
+            );
+            expect(pillSheetGroup.sequentialTodayPillNumber, 19);
+          });
+          test("last rest duration is ended", () {
+            final mockTodayRepository = MockTodayService();
+            todayRepository = mockTodayRepository;
+            when(mockTodayRepository.today())
+                .thenReturn(DateTime.parse("2020-09-28"));
+            when(mockTodayRepository.now())
+                .thenReturn(DateTime.parse("2020-09-19"));
+
+            final sheetType = PillSheetType.pillsheet_21;
+            final pillSheet = PillSheet(
+              beginingDate: DateTime.parse("2020-09-01"),
+              lastTakenDate: DateTime.parse("2020-09-28"),
+              restDurations: [
+                RestDuration(
+                  beginDate: DateTime.parse("2020-09-12"),
+                  createdDate: DateTime.parse("2020-09-12"),
+                  endDate: DateTime.parse("2020-09-15"),
+                ),
+                RestDuration(
+                  beginDate: DateTime.parse("2020-09-22"),
+                  createdDate: DateTime.parse("2020-09-22"),
+                  endDate: DateTime.parse("2020-09-25"),
+                )
+              ],
+              typeInfo: PillSheetTypeInfo(
+                dosingPeriod: sheetType.dosingPeriod,
+                name: sheetType.fullName,
+                totalCount: sheetType.totalCount,
+                pillSheetTypeReferencePath: sheetType.rawPath,
+              ),
+            );
+            // created at and id are anything value
+            final pillSheetGroup = PillSheetGroup(
+              pillSheetIDs: ["sheet_id"],
+              pillSheets: [pillSheet],
+              createdAt: DateTime.now(),
+            );
+            expect(pillSheetGroup.sequentialTodayPillNumber, 22);
+          });
+        });
+      });
+    });
+  });
+
+  group("#sequentialLastTakenPillNumber", () {
+    group("has one pill sheet", () {
+      test("it is not taken yet", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-19"));
+
+        final sheetType = PillSheetType.pillsheet_21;
+        final pillSheet = PillSheet(
+          beginingDate: DateTime.parse("2020-09-14"),
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+        );
+        // created at and id are anything value
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: DateTime.now(),
+        );
+        expect(pillSheetGroup.sequentialLastTakenPillNumber, 0);
+      });
+      test("it is taken", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-19"));
+
+        final sheetType = PillSheetType.pillsheet_21;
+        final pillSheet = PillSheet(
+          beginingDate: DateTime.parse("2020-09-14"),
+          lastTakenDate: DateTime.parse("2020-09-17"),
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+        );
+        // created at and id are anything value
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: DateTime.now(),
+        );
+        expect(pillSheetGroup.sequentialLastTakenPillNumber, 4);
+      });
+      test("it is boundary test", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-28"));
+
+        final sheetType = PillSheetType.pillsheet_21;
+        final pillSheet = PillSheet(
+          beginingDate: DateTime.parse("2020-09-01"),
+          lastTakenDate: DateTime.parse("2020-09-28"),
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+        );
+        // created at and id are anything value
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: DateTime.now(),
+        );
+        expect(pillSheetGroup.sequentialLastTakenPillNumber, 28);
+      });
+      group("pillsheet has rest durations", () {
+        test("rest duration is not ended", () {
+          final mockTodayRepository = MockTodayService();
+          todayRepository = mockTodayRepository;
+          when(mockTodayRepository.now())
+              .thenReturn(DateTime.parse("2020-09-28"));
+          when(mockTodayRepository.today())
+              .thenReturn(DateTime.parse("2020-09-28"));
+
+          final sheetType = PillSheetType.pillsheet_21;
+          final pillSheet = PillSheet(
+            beginingDate: DateTime.parse("2020-09-01"),
+            lastTakenDate: DateTime.parse("2020-09-22"),
+            restDurations: [
+              RestDuration(
+                beginDate: DateTime.parse("2020-09-23"),
+                createdDate: DateTime.parse("2020-09-23"),
+              ),
+            ],
+            typeInfo: PillSheetTypeInfo(
+              dosingPeriod: sheetType.dosingPeriod,
+              name: sheetType.fullName,
+              totalCount: sheetType.totalCount,
+              pillSheetTypeReferencePath: sheetType.rawPath,
+            ),
+          );
+          // created at and id are anything value
+          final pillSheetGroup = PillSheetGroup(
+            pillSheetIDs: ["sheet_id"],
+            pillSheets: [pillSheet],
+            createdAt: DateTime.now(),
+          );
+          expect(pillSheetGroup.sequentialLastTakenPillNumber, 22);
+        });
+        test("rest duration is ended", () {
+          final mockTodayRepository = MockTodayService();
+          todayRepository = mockTodayRepository;
+          when(mockTodayRepository.now())
+              .thenReturn(DateTime.parse("2020-09-28"));
+
+          final sheetType = PillSheetType.pillsheet_21;
+          final pillSheet = PillSheet(
+            beginingDate: DateTime.parse("2020-09-01"),
+            lastTakenDate: DateTime.parse("2020-09-27"),
+            restDurations: [
+              RestDuration(
+                beginDate: DateTime.parse("2020-09-23"),
+                createdDate: DateTime.parse("2020-09-23"),
+                endDate: DateTime.parse("2020-09-25"),
+              ),
+            ],
+            typeInfo: PillSheetTypeInfo(
+              dosingPeriod: sheetType.dosingPeriod,
+              name: sheetType.fullName,
+              totalCount: sheetType.totalCount,
+              pillSheetTypeReferencePath: sheetType.rawPath,
+            ),
+          );
+          // created at and id are anything value
+          final pillSheetGroup = PillSheetGroup(
+            pillSheetIDs: ["sheet_id"],
+            pillSheets: [pillSheet],
+            createdAt: DateTime.now(),
+          );
+          expect(pillSheetGroup.sequentialLastTakenPillNumber, 25);
+        });
+        test("rest duration is ended and not yet taken pill", () {
+          final mockTodayRepository = MockTodayService();
+          todayRepository = mockTodayRepository;
+          when(mockTodayRepository.now())
+              .thenReturn(DateTime.parse("2020-09-28"));
+
+          final sheetType = PillSheetType.pillsheet_21;
+          final pillSheet = PillSheet(
+            beginingDate: DateTime.parse("2020-09-01"),
+            lastTakenDate: null,
+            restDurations: [
+              RestDuration(
+                beginDate: DateTime.parse("2020-09-23"),
+                createdDate: DateTime.parse("2020-09-23"),
+                endDate: DateTime.parse("2020-09-25"),
+              ),
+            ],
+            typeInfo: PillSheetTypeInfo(
+              dosingPeriod: sheetType.dosingPeriod,
+              name: sheetType.fullName,
+              totalCount: sheetType.totalCount,
+              pillSheetTypeReferencePath: sheetType.rawPath,
+            ),
+          );
+          // created at and id are anything value
+          final pillSheetGroup = PillSheetGroup(
+            pillSheetIDs: ["sheet_id"],
+            pillSheets: [pillSheet],
+            createdAt: DateTime.now(),
+          );
+          expect(pillSheetGroup.sequentialLastTakenPillNumber, 0);
+        });
+
+        group("pillsheet has plural rest durations", () {
+          test("last rest duration is not ended", () {
+            final mockTodayRepository = MockTodayService();
+            todayRepository = mockTodayRepository;
+            when(mockTodayRepository.now())
+                .thenReturn(DateTime.parse("2020-09-28"));
+            when(mockTodayRepository.today())
+                .thenReturn(DateTime.parse("2020-09-28"));
+
+            final sheetType = PillSheetType.pillsheet_21;
+            final pillSheet = PillSheet(
+              beginingDate: DateTime.parse("2020-09-01"),
+              lastTakenDate: DateTime.parse("2020-09-22"),
+              restDurations: [
+                RestDuration(
+                  beginDate: DateTime.parse("2020-09-12"),
+                  createdDate: DateTime.parse("2020-09-12"),
+                  endDate: DateTime.parse("2020-09-15"),
+                ),
+                RestDuration(
+                  beginDate: DateTime.parse("2020-09-26"),
+                  createdDate: DateTime.parse("2020-09-26"),
+                ),
+              ],
+              typeInfo: PillSheetTypeInfo(
+                dosingPeriod: sheetType.dosingPeriod,
+                name: sheetType.fullName,
+                totalCount: sheetType.totalCount,
+                pillSheetTypeReferencePath: sheetType.rawPath,
+              ),
+            );
+            // created at and id are anything value
+            final pillSheetGroup = PillSheetGroup(
+              pillSheetIDs: ["sheet_id"],
+              pillSheets: [pillSheet],
+              createdAt: DateTime.now(),
+            );
+            expect(pillSheetGroup.sequentialLastTakenPillNumber, 19);
+          });
+          test("last rest duration is ended", () {
+            final mockTodayRepository = MockTodayService();
+            todayRepository = mockTodayRepository;
+            when(mockTodayRepository.now())
+                .thenReturn(DateTime.parse("2020-09-28"));
+
+            final sheetType = PillSheetType.pillsheet_21;
+            final pillSheet = PillSheet(
+              beginingDate: DateTime.parse("2020-09-01"),
+              lastTakenDate: DateTime.parse("2020-09-22"),
+              restDurations: [
+                RestDuration(
+                  beginDate: DateTime.parse("2020-09-12"),
+                  createdDate: DateTime.parse("2020-09-12"),
+                  endDate: DateTime.parse("2020-09-15"),
+                ),
+                RestDuration(
+                  beginDate: DateTime.parse("2020-09-26"),
+                  createdDate: DateTime.parse("2020-09-26"),
+                  endDate: DateTime.parse("2020-09-27"),
+                ),
+              ],
+              typeInfo: PillSheetTypeInfo(
+                dosingPeriod: sheetType.dosingPeriod,
+                name: sheetType.fullName,
+                totalCount: sheetType.totalCount,
+                pillSheetTypeReferencePath: sheetType.rawPath,
+              ),
+            );
+            // created at and id are anything value
+            final pillSheetGroup = PillSheetGroup(
+              pillSheetIDs: ["sheet_id"],
+              pillSheets: [pillSheet],
+              createdAt: DateTime.now(),
+            );
+            expect(pillSheetGroup.sequentialLastTakenPillNumber, 19);
+          });
         });
       });
     });

--- a/test/entity/pill_sheet_test.dart
+++ b/test/entity/pill_sheet_test.dart
@@ -104,7 +104,7 @@ void main() {
         );
         expect(model.todayPillNumber, 25);
       });
-      group("rest duration has plural rest duration. ", () {
+      group("pill sheet has plural rest duration. ", () {
         test("last rest duration is not ended", () {
           final mockTodayRepository = MockTodayService();
           todayRepository = mockTodayRepository;

--- a/test/entity/pill_sheet_test.dart
+++ b/test/entity/pill_sheet_test.dart
@@ -441,7 +441,7 @@ void main() {
       expect(model.isBegan, false);
     });
   });
-  group("#lastTakenDate", () {
+  group("#lastTakenPillNumber", () {
     test("it is not taken yet", () {
       final mockTodayRepository = MockTodayService();
       todayRepository = mockTodayRepository;
@@ -748,8 +748,10 @@ void main() {
               pillSheetTypeReferencePath: sheetType.rawPath,
             ),
           );
-          expect(pillSheet.estimatedLastTakenDate,
-              DateTime.parse("2022-06-03").subtract(const Duration(seconds: 1)));
+          expect(
+              pillSheet.estimatedLastTakenDate,
+              DateTime.parse("2022-06-03")
+                  .subtract(const Duration(seconds: 1)));
         });
         test("last rest duration is ended", () {
           final mockTodayRepository = MockTodayService();
@@ -781,8 +783,10 @@ void main() {
               pillSheetTypeReferencePath: sheetType.rawPath,
             ),
           );
-          expect(pillSheet.estimatedLastTakenDate,
-              DateTime.parse("2022-06-01").subtract(const Duration(seconds: 1)));
+          expect(
+              pillSheet.estimatedLastTakenDate,
+              DateTime.parse("2022-06-01")
+                  .subtract(const Duration(seconds: 1)));
         });
       });
     });


### PR DESCRIPTION
## Abstract
entity/PillSheetGroup の sequentialTodayPillNumber と sequentialLastTakenPillNumber のテストケースを追加

## Why
この部分に変更を加えるため先にテストケースを追加した

## Links
ref: https://github.com/bannzai/Pilll/pull/548


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した
; -x---------------------- >8 ------------------------
; Do not modify or remove the line above.
; Everything below it will be ignored.

Requesting a pull to bannzai:main from bannzai:add/test/pill_sheet_group

Write a message for this pull request. The first block
of text is the title and the rest is the description.

Changes:

168689a5 (bannzai, 81 seconds ago)
   Remove unnecessary code

f31de9f8 (bannzai, 2 minutes ago)
   Add test case

977ce4d2 (bannzai, 7 minutes ago)
   Rename test case

9799bb3c (bannzai, 8 minutes ago)
   to two pill sheet

e416cccd (bannzai, 8 minutes ago)
   Add multiple pill sheet test case

f1e2ebab (bannzai, 13 minutes ago)
   Add test case

a31ff5e0 (bannzai, 17 minutes ago)
   Rename to lastTakenPillNumber

9f6059e2 (bannzai, 19 minutes ago)
   Add test case