### PR TITLE
Add early return when today pill is already taken

### DIFF
--- a/lib/native/pill.dart
+++ b/lib/native/pill.dart
@@ -28,6 +28,9 @@ Future<void> recordPill() async {
   if (activedPillSheet == null) {
     return Future.value();
   }
+  if (activedPillSheet.todayPillIsAlreadyTaken) {
+    return Future.value();
+  }
 
   final takenDate = now();
   final batchFactory = BatchFactory(database);


### PR DESCRIPTION
## Abstract
すでに服用済みの場合は記録しないようにする

## Why
通知から服用のアクションをとると服用日時が上書きされる & 履歴が重複してできる

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した