### PR TITLE
ログイン処理周りのanalyticsを追加。currentUserが無い場合はFirebaseAuthのinitializeを待つ

### DIFF
--- a/lib/domain/root/root.dart
+++ b/lib/domain/root/root.dart
@@ -145,7 +145,7 @@ class RootState extends State<Root> {
       return ScreenType.initialSetting;
     }
 
-    return screenType = ScreenType.home;
+    return ScreenType.home;
   }
 
   Future<User> _mutateUserWithLaunchInfoAnd(
@@ -167,7 +167,7 @@ class RootState extends State<Root> {
       await userService.setFlutterMigrationFlag();
       return ScreenType.initialSetting;
     } else if (user.setting == null) {
-      return screenType = ScreenType.initialSetting;
+      return ScreenType.initialSetting;
     }
     return null;
   }

--- a/lib/service/auth.dart
+++ b/lib/service/auth.dart
@@ -41,7 +41,9 @@ Stream<User?> _userAuthStateChanges() {
 }
 
 // Obtain the latest users form FirebaseAuth.
-// If it is not exists, return result of signin anonymous;
+// If it is not exists:
+//   -> wait userAuthStateChanges stream complete that firebase auth setup complete:
+//     -> return result of signin anonymous;
 Future<User> cachedUserOrSignInAnonymously() async {
   analytics.logEvent(name: "call_sign_in");
   final currentUser = FirebaseAuth.instance.currentUser;

--- a/test/domain/initial_setting/initial_setting_store_test.dart
+++ b/test/domain/initial_setting/initial_setting_store_test.dart
@@ -1,5 +1,4 @@
 import 'package:pilll/database/batch.dart';
-import 'package:pilll/domain/initial_setting/initial_setting_state.codegen.dart';
 import 'package:pilll/domain/initial_setting/initial_setting_store.dart';
 import 'package:pilll/entity/pill_sheet.codegen.dart';
 import 'package:pilll/entity/pill_sheet_group.codegen.dart';


### PR DESCRIPTION
## Abstract
- 起動処理周りにanalyticsを追加
- Firebase Authのinitializeが遅い場合に、currentUserがnullになる可能性がありそうだったので、initializeが終わるまでwaitするようにした

## Why

## Links
ref: https://stackoverflow.com/questions/37883981/cant-get-currentuser-on-load


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した