### PR TITLE
Refactor calc pill numbers

### DIFF
--- a/lib/components/organisms/calendar/utility.dart
+++ b/lib/components/organisms/calendar/utility.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:pilll/components/organisms/calendar/band/calendar_band_model.dart';
 import 'package:pilll/domain/calendar/date_range.dart';
 import 'package:pilll/entity/menstruation.codegen.dart';
-import 'package:pilll/entity/pill_sheet.codegen.dart';
 import 'package:pilll/entity/pill_sheet_group.codegen.dart';
 import 'package:pilll/entity/pill_sheet_type.dart';
 import 'package:pilll/entity/setting.codegen.dart';
@@ -35,8 +34,10 @@ List<DateRange> scheduledOrInTheMiddleMenstruationDateRanges(
         pageIndex < pillSheetGroup.pillSheets.length;
         pageIndex++) {
       final pillSheet = pillSheetGroup.pillSheets[pageIndex];
-      final passedCount = summarizedPillSheetsCountToEndIndex(
-          pillSheets: pillSheetGroup.pillSheets, endIndex: pageIndex);
+      final pillSheetTypes =
+          pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
+      final passedCount = summarizedPillSheetTypesCountToEndIndex(
+          pillSheetTypes: pillSheetTypes, endIndex: pageIndex);
       final serializedTotalPillNumber =
           passedCount + pillSheet.typeInfo.totalCount;
       if (serializedTotalPillNumber < setting.pillNumberForFromMenstruation) {

--- a/lib/components/organisms/calendar/utility.dart
+++ b/lib/components/organisms/calendar/utility.dart
@@ -34,10 +34,8 @@ List<DateRange> scheduledOrInTheMiddleMenstruationDateRanges(
         pageIndex < pillSheetGroup.pillSheets.length;
         pageIndex++) {
       final pillSheet = pillSheetGroup.pillSheets[pageIndex];
-      final pillSheetTypes =
-          pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
       final passedCount = summarizedPillSheetsCountToEndIndex(
-          pillSheets: pillSheetTypes, endIndex: pageIndex);
+          pillSheets: pillSheetGroup.pillSheets, endIndex: pageIndex);
       final serializedTotalPillNumber =
           passedCount + pillSheet.typeInfo.totalCount;
       if (serializedTotalPillNumber < setting.pillNumberForFromMenstruation) {
@@ -102,7 +100,8 @@ List<DateRange> nextPillSheetDateRanges(
   return List.generate(count.toInt(), (groupPageIndex) {
     return pillSheetGroup.pillSheets.map((pillSheet) {
       final offset = groupPageIndex * totalPillCount;
-      final begin = pillSheet.estimatedLastTakenDate.add(const Duration(days: 1));
+      final begin =
+          pillSheet.estimatedLastTakenDate.add(const Duration(days: 1));
       final end = begin.add(Duration(days: Weekday.values.length - 1));
       return DateRange(
           begin.add(Duration(days: offset)), end.add(Duration(days: offset)));

--- a/lib/components/organisms/calendar/utility.dart
+++ b/lib/components/organisms/calendar/utility.dart
@@ -37,7 +37,7 @@ List<DateRange> scheduledOrInTheMiddleMenstruationDateRanges(
       final pillSheetTypes =
           pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
       final passedCount = summarizedPillSheetsCountToEndIndex(
-          pillSheetTypes: pillSheetTypes, endIndex: pageIndex);
+          pillSheets: pillSheetTypes, endIndex: pageIndex);
       final serializedTotalPillNumber =
           passedCount + pillSheet.typeInfo.totalCount;
       if (serializedTotalPillNumber < setting.pillNumberForFromMenstruation) {

--- a/lib/components/organisms/calendar/utility.dart
+++ b/lib/components/organisms/calendar/utility.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:pilll/components/organisms/calendar/band/calendar_band_model.dart';
 import 'package:pilll/domain/calendar/date_range.dart';
 import 'package:pilll/entity/menstruation.codegen.dart';
+import 'package:pilll/entity/pill_sheet.codegen.dart';
 import 'package:pilll/entity/pill_sheet_group.codegen.dart';
 import 'package:pilll/entity/pill_sheet_type.dart';
 import 'package:pilll/entity/setting.codegen.dart';

--- a/lib/components/organisms/calendar/utility.dart
+++ b/lib/components/organisms/calendar/utility.dart
@@ -36,7 +36,7 @@ List<DateRange> scheduledOrInTheMiddleMenstruationDateRanges(
       final pillSheet = pillSheetGroup.pillSheets[pageIndex];
       final pillSheetTypes =
           pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
-      final passedCount = summarizedPillSheetTypesCountToEndIndex(
+      final passedCount = summarizedPillCountWithPillSheetTypesToEndIndex(
           pillSheetTypes: pillSheetTypes, endIndex: pageIndex);
       final serializedTotalPillNumber =
           passedCount + pillSheet.typeInfo.totalCount;

--- a/lib/components/organisms/calendar/utility.dart
+++ b/lib/components/organisms/calendar/utility.dart
@@ -36,8 +36,8 @@ List<DateRange> scheduledOrInTheMiddleMenstruationDateRanges(
       final pillSheet = pillSheetGroup.pillSheets[pageIndex];
       final pillSheetTypes =
           pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
-      final passedCount = summarizedPillSheetTypeTotalCountToPageIndex(
-          pillSheetTypes: pillSheetTypes, pageIndex: pageIndex);
+      final passedCount = summarizedPillSheetsCountToEndIndex(
+          pillSheetTypes: pillSheetTypes, endIndex: pageIndex);
       final serializedTotalPillNumber =
           passedCount + pillSheet.typeInfo.totalCount;
       if (serializedTotalPillNumber < setting.pillNumberForFromMenstruation) {

--- a/lib/components/organisms/pill_sheet/setting_pill_sheet_view.dart
+++ b/lib/components/organisms/pill_sheet/setting_pill_sheet_view.dart
@@ -59,8 +59,8 @@ class SettingPillSheetView extends StatelessWidget {
       final pillNumberIntoPillSheet =
           PillMarkWithNumberLayoutHelper.calcPillNumberIntoPillSheet(
               index, lineIndex);
-      final offset = summarizedPillSheetTypeTotalCountToPageIndex(
-          pillSheetTypes: pillSheetTypes, pageIndex: pageIndex);
+      final offset = summarizedPillSheetsCountToEndIndex(
+          pillSheetTypes: pillSheetTypes, endIndex: pageIndex);
 
       return Container(
         width: PillSheetViewLayout.componentWidth,

--- a/lib/components/organisms/pill_sheet/setting_pill_sheet_view.dart
+++ b/lib/components/organisms/pill_sheet/setting_pill_sheet_view.dart
@@ -60,7 +60,7 @@ class SettingPillSheetView extends StatelessWidget {
           PillMarkWithNumberLayoutHelper.calcPillNumberIntoPillSheet(
               index, lineIndex);
       final offset = summarizedPillSheetsCountToEndIndex(
-          pillSheetTypes: pillSheetTypes, endIndex: pageIndex);
+          pillSheets: pillSheetTypes, endIndex: pageIndex);
 
       return Container(
         width: PillSheetViewLayout.componentWidth,

--- a/lib/components/organisms/pill_sheet/setting_pill_sheet_view.dart
+++ b/lib/components/organisms/pill_sheet/setting_pill_sheet_view.dart
@@ -59,8 +59,8 @@ class SettingPillSheetView extends StatelessWidget {
       final pillNumberIntoPillSheet =
           PillMarkWithNumberLayoutHelper.calcPillNumberIntoPillSheet(
               index, lineIndex);
-      final offset = summarizedPillSheetsCountToEndIndex(
-          pillSheets: pillSheetTypes, endIndex: pageIndex);
+      final offset = summarizedPillSheetTypesCountToEndIndex(
+          pillSheetTypes: pillSheetTypes, endIndex: pageIndex);
 
       return Container(
         width: PillSheetViewLayout.componentWidth,

--- a/lib/components/organisms/pill_sheet/setting_pill_sheet_view.dart
+++ b/lib/components/organisms/pill_sheet/setting_pill_sheet_view.dart
@@ -59,7 +59,7 @@ class SettingPillSheetView extends StatelessWidget {
       final pillNumberIntoPillSheet =
           PillMarkWithNumberLayoutHelper.calcPillNumberIntoPillSheet(
               index, lineIndex);
-      final offset = summarizedPillSheetTypesCountToEndIndex(
+      final offset = summarizedPillCountWithPillSheetTypesToEndIndex(
           pillSheetTypes: pillSheetTypes, endIndex: pageIndex);
 
       return Container(

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -163,7 +163,7 @@ class RecordPagePillSheet extends StatelessWidget {
         return PlainPillDate(date: date);
       }
     } else if (state.appearanceMode == PillSheetAppearanceMode.sequential) {
-      final offset = summarizedPillSheetsCountContainRestDurationToEndIndex(
+      final offset = summarizedPillCountWithPillSheetsToEndIndex(
         pillSheets: pillSheetGroup.pillSheets,
         endIndex: pageIndex,
       );
@@ -231,7 +231,7 @@ class RecordPagePillSheet extends StatelessWidget {
       return left <= pillNumberIntoPillSheet &&
           pillNumberIntoPillSheet <= right;
     }
-    final passedCount = summarizedPillSheetsCountContainRestDurationToEndIndex(
+    final passedCount = summarizedPillCountWithPillSheetsToEndIndex(
         pillSheets: pillSheetGroup.pillSheets, endIndex: pageIndex);
     final serialiedPillNumber = passedCount + pillNumberIntoPillSheet;
 

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -164,7 +164,7 @@ class RecordPagePillSheet extends StatelessWidget {
       }
     } else if (state.appearanceMode == PillSheetAppearanceMode.sequential) {
       final offset = summarizedPillSheetsCountToEndIndex(
-        pillSheetTypes:
+        pillSheets:
             pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList(),
         endIndex: pageIndex,
       );
@@ -235,7 +235,7 @@ class RecordPagePillSheet extends StatelessWidget {
     final pillSheetTypes =
         pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
     final passedCount = summarizedPillSheetsCountToEndIndex(
-        pillSheetTypes: pillSheetTypes, endIndex: pageIndex);
+        pillSheets: pillSheetTypes, endIndex: pageIndex);
     final serialiedPillNumber = passedCount + pillNumberIntoPillSheet;
 
     final menstruationRangeList =

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -163,7 +163,7 @@ class RecordPagePillSheet extends StatelessWidget {
         return PlainPillDate(date: date);
       }
     } else if (state.appearanceMode == PillSheetAppearanceMode.sequential) {
-      final offset = summarizedPillSheetsCountToEndIndex(
+      final offset = summarizedPillSheetsCountContainRestDurationToEndIndex(
         pillSheets: pillSheetGroup.pillSheets,
         endIndex: pageIndex,
       );
@@ -231,7 +231,7 @@ class RecordPagePillSheet extends StatelessWidget {
       return left <= pillNumberIntoPillSheet &&
           pillNumberIntoPillSheet <= right;
     }
-    final passedCount = summarizedPillSheetsCountToEndIndex(
+    final passedCount = summarizedPillSheetsCountContainRestDurationToEndIndex(
         pillSheets: pillSheetGroup.pillSheets, endIndex: pageIndex);
     final serialiedPillNumber = passedCount + pillNumberIntoPillSheet;
 

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -163,10 +163,10 @@ class RecordPagePillSheet extends StatelessWidget {
         return PlainPillDate(date: date);
       }
     } else if (state.appearanceMode == PillSheetAppearanceMode.sequential) {
-      final offset = summarizedPillSheetTypeTotalCountToPageIndex(
+      final offset = summarizedPillSheetsCountToEndIndex(
         pillSheetTypes:
             pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList(),
-        pageIndex: pageIndex,
+        endIndex: pageIndex,
       );
       if (setting.pillNumberForFromMenstruation == 0 ||
           setting.durationMenstruation == 0) {
@@ -234,8 +234,8 @@ class RecordPagePillSheet extends StatelessWidget {
     }
     final pillSheetTypes =
         pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
-    final passedCount = summarizedPillSheetTypeTotalCountToPageIndex(
-        pillSheetTypes: pillSheetTypes, pageIndex: pageIndex);
+    final passedCount = summarizedPillSheetsCountToEndIndex(
+        pillSheetTypes: pillSheetTypes, endIndex: pageIndex);
     final serialiedPillNumber = passedCount + pillNumberIntoPillSheet;
 
     final menstruationRangeList =

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -164,8 +164,7 @@ class RecordPagePillSheet extends StatelessWidget {
       }
     } else if (state.appearanceMode == PillSheetAppearanceMode.sequential) {
       final offset = summarizedPillSheetsCountToEndIndex(
-        pillSheets:
-            pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList(),
+        pillSheets: pillSheetGroup.pillSheets,
         endIndex: pageIndex,
       );
       if (setting.pillNumberForFromMenstruation == 0 ||
@@ -232,10 +231,8 @@ class RecordPagePillSheet extends StatelessWidget {
       return left <= pillNumberIntoPillSheet &&
           pillNumberIntoPillSheet <= right;
     }
-    final pillSheetTypes =
-        pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
     final passedCount = summarizedPillSheetsCountToEndIndex(
-        pillSheets: pillSheetTypes, endIndex: pageIndex);
+        pillSheets: pillSheetGroup.pillSheets, endIndex: pageIndex);
     final serialiedPillNumber = passedCount + pillNumberIntoPillSheet;
 
     final menstruationRangeList =

--- a/lib/domain/record/record_page_store.dart
+++ b/lib/domain/record/record_page_store.dart
@@ -180,8 +180,8 @@ class RecordPageStore extends StateNotifier<RecordPageState> {
       batch,
       setting.pillSheetTypes.asMap().keys.map((pageIndex) {
         final pillSheetType = setting.pillSheetEnumTypes[pageIndex];
-        final offset = summarizedPillSheetsCountToEndIndex(
-            pillSheets: setting.pillSheetEnumTypes, endIndex: pageIndex);
+        final offset = summarizedPillSheetTypesCountToEndIndex(
+            pillSheetTypes: setting.pillSheetEnumTypes, endIndex: pageIndex);
         return PillSheet(
           typeInfo: pillSheetType.typeInfo,
           beginingDate: n.add(

--- a/lib/domain/record/record_page_store.dart
+++ b/lib/domain/record/record_page_store.dart
@@ -181,7 +181,7 @@ class RecordPageStore extends StateNotifier<RecordPageState> {
       setting.pillSheetTypes.asMap().keys.map((pageIndex) {
         final pillSheetType = setting.pillSheetEnumTypes[pageIndex];
         final offset = summarizedPillSheetsCountToEndIndex(
-            pillSheetTypes: setting.pillSheetEnumTypes, endIndex: pageIndex);
+            pillSheets: setting.pillSheetEnumTypes, endIndex: pageIndex);
         return PillSheet(
           typeInfo: pillSheetType.typeInfo,
           beginingDate: n.add(

--- a/lib/domain/record/record_page_store.dart
+++ b/lib/domain/record/record_page_store.dart
@@ -180,7 +180,7 @@ class RecordPageStore extends StateNotifier<RecordPageState> {
       batch,
       setting.pillSheetTypes.asMap().keys.map((pageIndex) {
         final pillSheetType = setting.pillSheetEnumTypes[pageIndex];
-        final offset = summarizedPillSheetTypesCountToEndIndex(
+        final offset = summarizedPillCountWithPillSheetTypesToEndIndex(
             pillSheetTypes: setting.pillSheetEnumTypes, endIndex: pageIndex);
         return PillSheet(
           typeInfo: pillSheetType.typeInfo,

--- a/lib/domain/record/record_page_store.dart
+++ b/lib/domain/record/record_page_store.dart
@@ -180,8 +180,8 @@ class RecordPageStore extends StateNotifier<RecordPageState> {
       batch,
       setting.pillSheetTypes.asMap().keys.map((pageIndex) {
         final pillSheetType = setting.pillSheetEnumTypes[pageIndex];
-        final offset = summarizedPillSheetTypeTotalCountToPageIndex(
-            pillSheetTypes: setting.pillSheetEnumTypes, pageIndex: pageIndex);
+        final offset = summarizedPillSheetsCountToEndIndex(
+            pillSheetTypes: setting.pillSheetEnumTypes, endIndex: pageIndex);
         return PillSheet(
           typeInfo: pillSheetType.typeInfo,
           beginingDate: n.add(

--- a/lib/domain/settings/menstruation/setting_menstruation_store.dart
+++ b/lib/domain/settings/menstruation/setting_menstruation_store.dart
@@ -23,8 +23,8 @@ class SettingMenstruationStateStore
     required int pageIndex,
     required int fromMenstruation,
   }) {
-    final offset = summarizedPillSheetsCountToEndIndex(
-        pillSheets: setting.pillSheetEnumTypes, endIndex: pageIndex);
+    final offset = summarizedPillSheetTypesCountToEndIndex(
+        pillSheetTypes: setting.pillSheetEnumTypes, endIndex: pageIndex);
     return _settingService.update(setting.copyWith(
         pillNumberForFromMenstruation: fromMenstruation + offset));
   }
@@ -49,8 +49,8 @@ class SettingMenstruationStateStore
     Setting setting,
     int pageIndex,
   ) {
-    final _passedTotalCount = summarizedPillSheetsCountToEndIndex(
-        pillSheets: setting.pillSheetEnumTypes, endIndex: pageIndex);
+    final _passedTotalCount = summarizedPillSheetTypesCountToEndIndex(
+        pillSheetTypes: setting.pillSheetEnumTypes, endIndex: pageIndex);
     if (_passedTotalCount >= setting.pillNumberForFromMenstruation) {
       return setting.pillNumberForFromMenstruation;
     }

--- a/lib/domain/settings/menstruation/setting_menstruation_store.dart
+++ b/lib/domain/settings/menstruation/setting_menstruation_store.dart
@@ -24,7 +24,7 @@ class SettingMenstruationStateStore
     required int fromMenstruation,
   }) {
     final offset = summarizedPillSheetsCountToEndIndex(
-        pillSheetTypes: setting.pillSheetEnumTypes, endIndex: pageIndex);
+        pillSheets: setting.pillSheetEnumTypes, endIndex: pageIndex);
     return _settingService.update(setting.copyWith(
         pillNumberForFromMenstruation: fromMenstruation + offset));
   }
@@ -50,7 +50,7 @@ class SettingMenstruationStateStore
     int pageIndex,
   ) {
     final _passedTotalCount = summarizedPillSheetsCountToEndIndex(
-        pillSheetTypes: setting.pillSheetEnumTypes, endIndex: pageIndex);
+        pillSheets: setting.pillSheetEnumTypes, endIndex: pageIndex);
     if (_passedTotalCount >= setting.pillNumberForFromMenstruation) {
       return setting.pillNumberForFromMenstruation;
     }

--- a/lib/domain/settings/menstruation/setting_menstruation_store.dart
+++ b/lib/domain/settings/menstruation/setting_menstruation_store.dart
@@ -23,8 +23,8 @@ class SettingMenstruationStateStore
     required int pageIndex,
     required int fromMenstruation,
   }) {
-    final offset = summarizedPillSheetTypeTotalCountToPageIndex(
-        pillSheetTypes: setting.pillSheetEnumTypes, pageIndex: pageIndex);
+    final offset = summarizedPillSheetsCountToEndIndex(
+        pillSheetTypes: setting.pillSheetEnumTypes, endIndex: pageIndex);
     return _settingService.update(setting.copyWith(
         pillNumberForFromMenstruation: fromMenstruation + offset));
   }
@@ -49,8 +49,8 @@ class SettingMenstruationStateStore
     Setting setting,
     int pageIndex,
   ) {
-    final _passedTotalCount = summarizedPillSheetTypeTotalCountToPageIndex(
-        pillSheetTypes: setting.pillSheetEnumTypes, pageIndex: pageIndex);
+    final _passedTotalCount = summarizedPillSheetsCountToEndIndex(
+        pillSheetTypes: setting.pillSheetEnumTypes, endIndex: pageIndex);
     if (_passedTotalCount >= setting.pillNumberForFromMenstruation) {
       return setting.pillNumberForFromMenstruation;
     }

--- a/lib/domain/settings/menstruation/setting_menstruation_store.dart
+++ b/lib/domain/settings/menstruation/setting_menstruation_store.dart
@@ -23,7 +23,7 @@ class SettingMenstruationStateStore
     required int pageIndex,
     required int fromMenstruation,
   }) {
-    final offset = summarizedPillSheetTypesCountToEndIndex(
+    final offset = summarizedPillCountWithPillSheetTypesToEndIndex(
         pillSheetTypes: setting.pillSheetEnumTypes, endIndex: pageIndex);
     return _settingService.update(setting.copyWith(
         pillNumberForFromMenstruation: fromMenstruation + offset));
@@ -49,7 +49,7 @@ class SettingMenstruationStateStore
     Setting setting,
     int pageIndex,
   ) {
-    final _passedTotalCount = summarizedPillSheetTypesCountToEndIndex(
+    final _passedTotalCount = summarizedPillCountWithPillSheetTypesToEndIndex(
         pillSheetTypes: setting.pillSheetEnumTypes, endIndex: pageIndex);
     if (_passedTotalCount >= setting.pillNumberForFromMenstruation) {
       return setting.pillNumberForFromMenstruation;

--- a/lib/domain/settings/today_pill_number/setting_today_pill_number_store.dart
+++ b/lib/domain/settings/today_pill_number/setting_today_pill_number_store.dart
@@ -67,9 +67,9 @@ class SettingTodayPillNumberStateStore
     final pillSheetTypes =
         pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
     final nextSerializedPillNumber =
-        summarizedPillSheetTypeTotalCountToPageIndex(
+        summarizedPillSheetsCountToEndIndex(
               pillSheetTypes: pillSheetTypes,
-              pageIndex: state.selectedPillSheetPageIndex,
+              endIndex: state.selectedPillSheetPageIndex,
             ) +
             state.selectedPillMarkNumberIntoPillSheet;
     final firstPilSheetBeginDate =
@@ -83,8 +83,8 @@ class SettingTodayPillNumberStateStore
       if (index == 0) {
         beginDate = firstPilSheetBeginDate;
       } else {
-        final passedTotalCount = summarizedPillSheetTypeTotalCountToPageIndex(
-            pillSheetTypes: pillSheetTypes, pageIndex: index);
+        final passedTotalCount = summarizedPillSheetsCountToEndIndex(
+            pillSheetTypes: pillSheetTypes, endIndex: index);
         beginDate =
             firstPilSheetBeginDate.add(Duration(days: passedTotalCount));
       }
@@ -131,8 +131,8 @@ int _pillNumberIntoPillSheet({
 }) {
   final pillSheetTypes =
       pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
-  final _passedTotalCount = summarizedPillSheetTypeTotalCountToPageIndex(
-      pillSheetTypes: pillSheetTypes, pageIndex: activedPillSheet.groupIndex);
+  final _passedTotalCount = summarizedPillSheetsCountToEndIndex(
+      pillSheetTypes: pillSheetTypes, endIndex: activedPillSheet.groupIndex);
   if (_passedTotalCount >= activedPillSheet.todayPillNumber) {
     return activedPillSheet.todayPillNumber;
   }

--- a/lib/domain/settings/today_pill_number/setting_today_pill_number_store.dart
+++ b/lib/domain/settings/today_pill_number/setting_today_pill_number_store.dart
@@ -64,8 +64,10 @@ class SettingTodayPillNumberStateStore
   }) async {
     final batch = _batchFactory.batch();
 
-    final nextSerializedPillNumber = summarizedPillSheetsCountToEndIndex(
-          pillSheets: pillSheetGroup.pillSheets,
+    final pillSheetTypes =
+        pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
+    final nextSerializedPillNumber = summarizedPillSheetTypesCountToEndIndex(
+          pillSheetTypes: pillSheetTypes,
           endIndex: state.selectedPillSheetPageIndex,
         ) +
         state.selectedPillMarkNumberIntoPillSheet;
@@ -80,8 +82,8 @@ class SettingTodayPillNumberStateStore
       if (index == 0) {
         beginDate = firstPilSheetBeginDate;
       } else {
-        final passedTotalCount = summarizedPillSheetsCountToEndIndex(
-            pillSheets: pillSheetGroup.pillSheets, endIndex: index);
+        final passedTotalCount = summarizedPillSheetTypesCountToEndIndex(
+            pillSheetTypes: pillSheetTypes, endIndex: index);
         beginDate =
             firstPilSheetBeginDate.add(Duration(days: passedTotalCount));
       }
@@ -126,9 +128,10 @@ int _pillNumberIntoPillSheet({
   required PillSheet activedPillSheet,
   required PillSheetGroup pillSheetGroup,
 }) {
-  final _passedTotalCount = summarizedPillSheetsCountToEndIndex(
-      pillSheets: pillSheetGroup.pillSheets,
-      endIndex: activedPillSheet.groupIndex);
+  final pillSheetTypes =
+      pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
+  final _passedTotalCount = summarizedPillSheetTypesCountToEndIndex(
+      pillSheetTypes: pillSheetTypes, endIndex: activedPillSheet.groupIndex);
   if (_passedTotalCount >= activedPillSheet.todayPillNumber) {
     return activedPillSheet.todayPillNumber;
   }

--- a/lib/domain/settings/today_pill_number/setting_today_pill_number_store.dart
+++ b/lib/domain/settings/today_pill_number/setting_today_pill_number_store.dart
@@ -68,7 +68,7 @@ class SettingTodayPillNumberStateStore
         pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
     final nextSerializedPillNumber =
         summarizedPillSheetsCountToEndIndex(
-              pillSheetTypes: pillSheetTypes,
+              pillSheets: pillSheetTypes,
               endIndex: state.selectedPillSheetPageIndex,
             ) +
             state.selectedPillMarkNumberIntoPillSheet;
@@ -84,7 +84,7 @@ class SettingTodayPillNumberStateStore
         beginDate = firstPilSheetBeginDate;
       } else {
         final passedTotalCount = summarizedPillSheetsCountToEndIndex(
-            pillSheetTypes: pillSheetTypes, endIndex: index);
+            pillSheets: pillSheetTypes, endIndex: index);
         beginDate =
             firstPilSheetBeginDate.add(Duration(days: passedTotalCount));
       }
@@ -132,7 +132,7 @@ int _pillNumberIntoPillSheet({
   final pillSheetTypes =
       pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
   final _passedTotalCount = summarizedPillSheetsCountToEndIndex(
-      pillSheetTypes: pillSheetTypes, endIndex: activedPillSheet.groupIndex);
+      pillSheets: pillSheetTypes, endIndex: activedPillSheet.groupIndex);
   if (_passedTotalCount >= activedPillSheet.todayPillNumber) {
     return activedPillSheet.todayPillNumber;
   }

--- a/lib/domain/settings/today_pill_number/setting_today_pill_number_store.dart
+++ b/lib/domain/settings/today_pill_number/setting_today_pill_number_store.dart
@@ -64,14 +64,11 @@ class SettingTodayPillNumberStateStore
   }) async {
     final batch = _batchFactory.batch();
 
-    final pillSheetTypes =
-        pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
-    final nextSerializedPillNumber =
-        summarizedPillSheetsCountToEndIndex(
-              pillSheets: pillSheetTypes,
-              endIndex: state.selectedPillSheetPageIndex,
-            ) +
-            state.selectedPillMarkNumberIntoPillSheet;
+    final nextSerializedPillNumber = summarizedPillSheetsCountToEndIndex(
+          pillSheets: pillSheetGroup.pillSheets,
+          endIndex: state.selectedPillSheetPageIndex,
+        ) +
+        state.selectedPillMarkNumberIntoPillSheet;
     final firstPilSheetBeginDate =
         today().subtract(Duration(days: nextSerializedPillNumber - 1));
 
@@ -84,7 +81,7 @@ class SettingTodayPillNumberStateStore
         beginDate = firstPilSheetBeginDate;
       } else {
         final passedTotalCount = summarizedPillSheetsCountToEndIndex(
-            pillSheets: pillSheetTypes, endIndex: index);
+            pillSheets: pillSheetGroup.pillSheets, endIndex: index);
         beginDate =
             firstPilSheetBeginDate.add(Duration(days: passedTotalCount));
       }
@@ -129,10 +126,9 @@ int _pillNumberIntoPillSheet({
   required PillSheet activedPillSheet,
   required PillSheetGroup pillSheetGroup,
 }) {
-  final pillSheetTypes =
-      pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
   final _passedTotalCount = summarizedPillSheetsCountToEndIndex(
-      pillSheets: pillSheetTypes, endIndex: activedPillSheet.groupIndex);
+      pillSheets: pillSheetGroup.pillSheets,
+      endIndex: activedPillSheet.groupIndex);
   if (_passedTotalCount >= activedPillSheet.todayPillNumber) {
     return activedPillSheet.todayPillNumber;
   }

--- a/lib/domain/settings/today_pill_number/setting_today_pill_number_store.dart
+++ b/lib/domain/settings/today_pill_number/setting_today_pill_number_store.dart
@@ -66,7 +66,7 @@ class SettingTodayPillNumberStateStore
 
     final pillSheetTypes =
         pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
-    final nextSerializedPillNumber = summarizedPillSheetTypesCountToEndIndex(
+    final nextSerializedPillNumber = summarizedPillCountWithPillSheetTypesToEndIndex(
           pillSheetTypes: pillSheetTypes,
           endIndex: state.selectedPillSheetPageIndex,
         ) +
@@ -82,7 +82,7 @@ class SettingTodayPillNumberStateStore
       if (index == 0) {
         beginDate = firstPilSheetBeginDate;
       } else {
-        final passedTotalCount = summarizedPillSheetTypesCountToEndIndex(
+        final passedTotalCount = summarizedPillCountWithPillSheetTypesToEndIndex(
             pillSheetTypes: pillSheetTypes, endIndex: index);
         beginDate =
             firstPilSheetBeginDate.add(Duration(days: passedTotalCount));
@@ -130,7 +130,7 @@ int _pillNumberIntoPillSheet({
 }) {
   final pillSheetTypes =
       pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList();
-  final _passedTotalCount = summarizedPillSheetTypesCountToEndIndex(
+  final _passedTotalCount = summarizedPillCountWithPillSheetTypesToEndIndex(
       pillSheetTypes: pillSheetTypes, endIndex: activedPillSheet.groupIndex);
   if (_passedTotalCount >= activedPillSheet.todayPillNumber) {
     return activedPillSheet.todayPillNumber;

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -127,21 +127,7 @@ class PillSheet with _$PillSheet {
       return lastTakenPillNumber;
     }
 
-    final summarizedRestDuration = restDurations.map((e) {
-      if (!e.beginDate.isBefore(lastTakenDate)) {
-        return 0;
-      }
-      final endDate = e.endDate;
-      if (endDate == null) {
-        return daysBetween(e.beginDate, today());
-      } else if (lastTakenDate.isAfter(e.beginDate)) {
-        return daysBetween(e.beginDate, endDate);
-      } else {
-        return 0;
-      }
-    }).reduce((value, element) => value + element);
-
-    return lastTakenPillNumber - summarizedRestDuration;
+    return lastTakenPillNumber - summarizedRestDuration(restDurations);
   }
 
   bool get todayPillIsAlreadyTaken => todayPillNumber == lastTakenPillNumber;

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -257,3 +257,15 @@ int? pillSheetPillNumber({
           restDurations: pillSheet.restDurations, upperDate: targetDate) +
       1;
 }
+
+int summarizedPillSheetsCountToEndIndex(
+    {required List<PillSheet> pillSheets, required int endIndex}) {
+  if (endIndex == 0) {
+    return 0;
+  }
+  final sublist = pillSheets.sublist(0, endIndex);
+  final passedTotalCount = sublist
+      .map((e) => e.typeInfo.totalCount)
+      .reduce((value, element) => value + element);
+  return passedTotalCount;
+}

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -108,8 +108,7 @@ class PillSheet with _$PillSheet {
 
   int get todayPillNumber {
     return daysBetween(beginingDate.date(), today()) -
-        summarizedRestDuration(
-            restDurations: restDurations, targetDate: today(), today: today()) +
+        summarizedRestDuration(restDurations) +
         1;
   }
 
@@ -128,21 +127,7 @@ class PillSheet with _$PillSheet {
       return lastTakenPillNumber;
     }
 
-    final summarizedRestDuration = restDurations.map((e) {
-      if (!e.beginDate.isBefore(lastTakenDate)) {
-        return 0;
-      }
-      final endDate = e.endDate;
-      if (endDate == null) {
-        return daysBetween(e.beginDate, today());
-      } else if (lastTakenDate.isAfter(e.beginDate)) {
-        return daysBetween(e.beginDate, endDate);
-      } else {
-        return 0;
-      }
-    }).reduce((value, element) => value + element);
-
-    return lastTakenPillNumber - summarizedRestDuration;
+    return lastTakenPillNumber - summarizedRestDuration(restDurations);
   }
 
   bool get todayPillIsAlreadyTaken => todayPillNumber == lastTakenPillNumber;
@@ -158,15 +143,7 @@ class PillSheet with _$PillSheet {
     final begin = beginingDate.date();
     final totalCount = typeInfo.totalCount;
     final end = begin.add(
-      Duration(
-        days: totalCount +
-            summarizedRestDuration(
-                restDurations: restDurations,
-                targetDate: today(),
-                today: today()) -
-            1,
-      ),
-    );
+        Duration(days: totalCount + summarizedRestDuration(restDurations) - 1));
     return DateRange(begin, end).inRange(n);
   }
 
@@ -220,27 +197,16 @@ class PillSheet with _$PillSheet {
   }
 }
 
-int summarizedRestDuration({
-  required List<RestDuration> restDurations,
-  required DateTime targetDate,
-  required DateTime today,
-}) {
+int summarizedRestDuration(List<RestDuration> restDurations) {
   if (restDurations.isEmpty) {
     return 0;
   }
-
   return restDurations.map((e) {
-    if (!e.beginDate.isBefore(targetDate)) {
-      return 0;
-    }
-
     final endDate = e.endDate;
     if (endDate == null) {
-      return daysBetween(e.beginDate, today);
-    } else if (targetDate.isAfter(e.beginDate)) {
-      return daysBetween(e.beginDate, endDate);
+      return daysBetween(e.beginDate, today());
     } else {
-      return 0;
+      return daysBetween(e.beginDate, endDate);
     }
   }).reduce((value, element) => value + element);
 }

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -107,10 +107,7 @@ class PillSheet with _$PillSheet {
       PillSheetTypeFunctions.fromRawPath(typeInfo.pillSheetTypeReferencePath);
 
   int get todayPillNumber {
-    return daysBetween(beginingDate.date(), today()) -
-        summarizedRestDuration(
-            restDurations: restDurations, upperDate: today()) +
-        1;
+    return pillSheetPillNumber(pillSheet: this, targetDate: today());
   }
 
   // NOTE: if pill sheet is not yet taken, lastTakenNumber return 0;
@@ -122,28 +119,7 @@ class PillSheet with _$PillSheet {
       return 0;
     }
 
-    final lastTakenPillNumber =
-        daysBetween(beginingDate.date(), lastTakenDate.date()) + 1;
-    if (restDurations.isEmpty) {
-      return lastTakenPillNumber;
-    }
-
-    final summarizedRestDuration = restDurations.map((e) {
-      if (!lastTakenDate.isAfter(e.beginDate)) {
-        // ignore summarized
-        return 0;
-      }
-      final endDate = e.endDate;
-      if (endDate == null) {
-        // when lastTakenDate.isAfter(e.beginDate) and endDate is not null is unexpected pattern
-        assert(false);
-        return 0;
-      }
-
-      return daysBetween(e.beginDate, endDate);
-    }).reduce((value, element) => value + element);
-
-    return lastTakenPillNumber - summarizedRestDuration;
+    return pillSheetPillNumber(pillSheet: this, targetDate: lastTakenDate);
   }
 
   bool get todayPillIsAlreadyTaken => todayPillNumber == lastTakenPillNumber;
@@ -244,14 +220,10 @@ int summarizedRestDuration({
   }).reduce((value, element) => value + element);
 }
 
-int? pillSheetPillNumber({
+int pillSheetPillNumber({
   required PillSheet pillSheet,
-  required DateTime? targetDate,
+  required DateTime targetDate,
 }) {
-  if (targetDate == null) {
-    return null;
-  }
-
   return daysBetween(pillSheet.beginingDate.date(), targetDate) -
       summarizedRestDuration(
           restDurations: pillSheet.restDurations, upperDate: targetDate) +

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -244,8 +244,10 @@ int summarizedRestDuration({
   }).reduce((value, element) => value + element);
 }
 
-int? pillSheetPillNumber(
-    {required PillSheet pillSheet, required DateTime? targetDate}) {
+int? pillSheetPillNumber({
+  required PillSheet pillSheet,
+  required DateTime? targetDate,
+}) {
   if (targetDate == null) {
     return null;
   }

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -258,7 +258,7 @@ int? pillSheetPillNumber({
       1;
 }
 
-int summarizedPillSheetsCountToEndIndex(
+int summarizedPillSheetsCountContainRestDurationToEndIndex(
     {required List<PillSheet> pillSheets, required int endIndex}) {
   if (endIndex == 0) {
     return 0;

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -263,9 +263,14 @@ int summarizedPillSheetsCountToEndIndex(
   if (endIndex == 0) {
     return 0;
   }
+
   final sublist = pillSheets.sublist(0, endIndex);
   final passedTotalCount = sublist
       .map((e) => e.typeInfo.totalCount)
       .reduce((value, element) => value + element);
-  return passedTotalCount;
+  final restDurationCount = sublist
+      .map((e) => summarizedRestDuration(
+          restDurations: e.restDurations, upperDate: e.estimatedLastTakenDate))
+      .reduce((value, element) => value + element);
+  return passedTotalCount + restDurationCount;
 }

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -128,17 +128,18 @@ class PillSheet with _$PillSheet {
     }
 
     final summarizedRestDuration = restDurations.map((e) {
-      if (!e.beginDate.isBefore(lastTakenDate)) {
+      if (!lastTakenDate.isAfter(e.beginDate)) {
+        // ignore summarized
         return 0;
       }
       final endDate = e.endDate;
       if (endDate == null) {
-        return daysBetween(e.beginDate, today());
-      } else if (lastTakenDate.isAfter(e.beginDate)) {
-        return daysBetween(e.beginDate, endDate);
-      } else {
+        // when lastTakenDate.isAfter(e.beginDate) and endDate is not null is unexpected pattern
+        assert(false);
         return 0;
       }
+
+      return daysBetween(e.beginDate, endDate);
     }).reduce((value, element) => value + element);
 
     return lastTakenPillNumber - summarizedRestDuration;

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -230,7 +230,7 @@ int pillSheetPillNumber({
       1;
 }
 
-int summarizedPillSheetsCountContainRestDurationToEndIndex(
+int summarizedPillCountWithPillSheetsToEndIndex(
     {required List<PillSheet> pillSheets, required int endIndex}) {
   if (endIndex == 0) {
     return 0;

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -218,7 +218,8 @@ class PillSheet with _$PillSheet {
   }
 }
 
-// upperDate is assumed to be lastTakenDate(when calculate lastTakenPillNumber) or today(when calculate todayPillNumber).
+// upperDate までの休薬期間を集計する
+// upperDate にはlastTakenDate(lastTakenPillNumberを集計したい時)やtoday(todayPillNumberを集計したい時）が入る想定
 int summarizedRestDuration({
   required List<RestDuration> restDurations,
   required DateTime upperDate,
@@ -227,13 +228,16 @@ int summarizedRestDuration({
     return 0;
   }
   return restDurations.map((e) {
-    if (!upperDate.isAfter(e.beginDate)) {
-      // ignore summarized
+    // upperDate よりも後の休薬期間の場合は無視する。同一日は無視しないので、!upperDate.isAfter(e.beginDate)では無い
+    if (!e.beginDate.isBefore(upperDate)) {
       return 0;
     }
+
     final endDate = e.endDate;
     if (endDate == null) {
-      return daysBetween(e.beginDate, today());
+      // 実質upperDate == todayの場合にのみここを通る。本来であれば別の関数にした方が良いかも
+      assert(isSameDay(today(), upperDate));
+      return daysBetween(e.beginDate, upperDate);
     }
 
     return daysBetween(e.beginDate, endDate);

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -224,3 +224,14 @@ int summarizedRestDuration(List<RestDuration> restDurations) {
     }
   }).reduce((value, element) => value + element);
 }
+
+int? pillSheetPillNumber(
+    {required PillSheet pillSheet, required DateTime? targetDate}) {
+  if (targetDate == null) {
+    return null;
+  }
+
+  return daysBetween(pillSheet.beginingDate.date(), targetDate) -
+      summarizedRestDuration(pillSheet.restDurations) +
+      1;
+}

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -127,7 +127,21 @@ class PillSheet with _$PillSheet {
       return lastTakenPillNumber;
     }
 
-    return lastTakenPillNumber - summarizedRestDuration(restDurations);
+    final summarizedRestDuration = restDurations.map((e) {
+      if (!e.beginDate.isBefore(lastTakenDate)) {
+        return 0;
+      }
+      final endDate = e.endDate;
+      if (endDate == null) {
+        return daysBetween(e.beginDate, today());
+      } else if (lastTakenDate.isAfter(e.beginDate)) {
+        return daysBetween(e.beginDate, endDate);
+      } else {
+        return 0;
+      }
+    }).reduce((value, element) => value + element);
+
+    return lastTakenPillNumber - summarizedRestDuration;
   }
 
   bool get todayPillIsAlreadyTaken => todayPillNumber == lastTakenPillNumber;

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -67,7 +67,7 @@ class PillSheetGroup with _$PillSheetGroup {
     }
 
     final passedPillCountForPillSheetTypes =
-        summarizedPillSheetsCountContainRestDurationToEndIndex(
+        summarizedPillCountWithPillSheetsToEndIndex(
             pillSheets: pillSheets, endIndex: activedPillSheet.groupIndex);
     return passedPillCountForPillSheetTypes + activedPillSheet.todayPillNumber;
   }
@@ -82,7 +82,7 @@ class PillSheetGroup with _$PillSheetGroup {
     }
 
     final passedPillCountForPillSheetTypes =
-        summarizedPillSheetsCountContainRestDurationToEndIndex(
+        summarizedPillCountWithPillSheetsToEndIndex(
             pillSheets: pillSheets, endIndex: activedPillSheet.groupIndex);
     return passedPillCountForPillSheetTypes +
         activedPillSheet.lastTakenPillNumber;

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -67,12 +67,9 @@ class PillSheetGroup with _$PillSheetGroup {
       return 0;
     }
 
-    final passedPillSheets = pillSheets.sublist(0, activedPillSheet.groupIndex);
     final passedPillCountForPillSheetTypes =
         summarizedPillSheetsCountToEndIndex(
-            pillSheets:
-                passedPillSheets.map((e) => e.pillSheetType).toList(),
-            endIndex: activedPillSheet.groupIndex);
+            pillSheets: pillSheets, endIndex: activedPillSheet.groupIndex);
     return passedPillCountForPillSheetTypes + activedPillSheet.todayPillNumber;
   }
 
@@ -85,12 +82,9 @@ class PillSheetGroup with _$PillSheetGroup {
       return 0;
     }
 
-    final passedPillSheets = pillSheets.sublist(0, activedPillSheet.groupIndex);
     final passedPillCountForPillSheetTypes =
         summarizedPillSheetsCountToEndIndex(
-            pillSheets:
-                passedPillSheets.map((e) => e.pillSheetType).toList(),
-            endIndex: activedPillSheet.groupIndex);
+            pillSheets: pillSheets, endIndex: activedPillSheet.groupIndex);
     return passedPillCountForPillSheetTypes +
         activedPillSheet.lastTakenPillNumber;
   }

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -67,7 +67,7 @@ class PillSheetGroup with _$PillSheetGroup {
     }
 
     final passedPillCountForPillSheetTypes =
-        summarizedPillSheetsCountToEndIndex(
+        summarizedPillSheetsCountContainRestDurationToEndIndex(
             pillSheets: pillSheets, endIndex: activedPillSheet.groupIndex);
     return passedPillCountForPillSheetTypes + activedPillSheet.todayPillNumber;
   }
@@ -82,7 +82,7 @@ class PillSheetGroup with _$PillSheetGroup {
     }
 
     final passedPillCountForPillSheetTypes =
-        summarizedPillSheetsCountToEndIndex(
+        summarizedPillSheetsCountContainRestDurationToEndIndex(
             pillSheets: pillSheets, endIndex: activedPillSheet.groupIndex);
     return passedPillCountForPillSheetTypes +
         activedPillSheet.lastTakenPillNumber;

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -69,10 +69,10 @@ class PillSheetGroup with _$PillSheetGroup {
 
     final passedPillSheets = pillSheets.sublist(0, activedPillSheet.groupIndex);
     final passedPillCountForPillSheetTypes =
-        summarizedPillSheetTypeTotalCountToPageIndex(
+        summarizedPillSheetsCountToEndIndex(
             pillSheetTypes:
                 passedPillSheets.map((e) => e.pillSheetType).toList(),
-            pageIndex: activedPillSheet.groupIndex);
+            endIndex: activedPillSheet.groupIndex);
     return passedPillCountForPillSheetTypes + activedPillSheet.todayPillNumber;
   }
 
@@ -87,10 +87,10 @@ class PillSheetGroup with _$PillSheetGroup {
 
     final passedPillSheets = pillSheets.sublist(0, activedPillSheet.groupIndex);
     final passedPillCountForPillSheetTypes =
-        summarizedPillSheetTypeTotalCountToPageIndex(
+        summarizedPillSheetsCountToEndIndex(
             pillSheetTypes:
                 passedPillSheets.map((e) => e.pillSheetType).toList(),
-            pageIndex: activedPillSheet.groupIndex);
+            endIndex: activedPillSheet.groupIndex);
     return passedPillCountForPillSheetTypes +
         activedPillSheet.lastTakenPillNumber;
   }

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -1,7 +1,6 @@
 import 'package:pilll/entity/firestore_document_id_escaping_to_json.dart';
 import 'package:pilll/entity/firestore_timestamp_converter.dart';
 import 'package:pilll/entity/pill_sheet.codegen.dart';
-import 'package:pilll/entity/pill_sheet_type.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -70,7 +70,7 @@ class PillSheetGroup with _$PillSheetGroup {
     final passedPillSheets = pillSheets.sublist(0, activedPillSheet.groupIndex);
     final passedPillCountForPillSheetTypes =
         summarizedPillSheetsCountToEndIndex(
-            pillSheetTypes:
+            pillSheets:
                 passedPillSheets.map((e) => e.pillSheetType).toList(),
             endIndex: activedPillSheet.groupIndex);
     return passedPillCountForPillSheetTypes + activedPillSheet.todayPillNumber;
@@ -88,7 +88,7 @@ class PillSheetGroup with _$PillSheetGroup {
     final passedPillSheets = pillSheets.sublist(0, activedPillSheet.groupIndex);
     final passedPillCountForPillSheetTypes =
         summarizedPillSheetsCountToEndIndex(
-            pillSheetTypes:
+            pillSheets:
                 passedPillSheets.map((e) => e.pillSheetType).toList(),
             endIndex: activedPillSheet.groupIndex);
     return passedPillCountForPillSheetTypes +

--- a/lib/entity/pill_sheet_type.dart
+++ b/lib/entity/pill_sheet_type.dart
@@ -181,3 +181,15 @@ int summarizedPillSheetsCountToEndIndex(
       .reduce((value, element) => value + element);
   return passedTotalCount;
 }
+
+int summarizedPillSheetTypesCountToEndIndex(
+    {required List<PillSheetType> pillSheetTypes, required int endIndex}) {
+  if (endIndex == 0) {
+    return 0;
+  }
+  final passed = pillSheetTypes.sublist(0, endIndex);
+  final passedTotalCount = passed
+      .map((e) => e.totalCount)
+      .reduce((value, element) => value + element);
+  return passedTotalCount;
+}

--- a/lib/entity/pill_sheet_type.dart
+++ b/lib/entity/pill_sheet_type.dart
@@ -170,18 +170,6 @@ extension PillSheetTypeFunctions on PillSheetType {
       (totalCount / Weekday.values.length).ceil();
 }
 
-int summarizedPillSheetsCountToEndIndex(
-    {required List<PillSheet> pillSheets, required int endIndex}) {
-  if (endIndex == 0) {
-    return 0;
-  }
-  final sublist = pillSheets.sublist(0, endIndex);
-  final passedTotalCount = sublist
-      .map((e) => e.typeInfo.totalCount)
-      .reduce((value, element) => value + element);
-  return passedTotalCount;
-}
-
 int summarizedPillSheetTypesCountToEndIndex(
     {required List<PillSheetType> pillSheetTypes, required int endIndex}) {
   if (endIndex == 0) {

--- a/lib/entity/pill_sheet_type.dart
+++ b/lib/entity/pill_sheet_type.dart
@@ -171,11 +171,11 @@ extension PillSheetTypeFunctions on PillSheetType {
 }
 
 int summarizedPillSheetsCountToEndIndex(
-    {required List<PillSheetType> pillSheetTypes, required int endIndex}) {
+    {required List<PillSheetType> pillSheets, required int endIndex}) {
   if (endIndex == 0) {
     return 0;
   }
-  final passed = pillSheetTypes.sublist(0, endIndex);
+  final passed = pillSheets.sublist(0, endIndex);
   final passedTotalCount = passed
       .map((e) => e.totalCount)
       .reduce((value, element) => value + element);

--- a/lib/entity/pill_sheet_type.dart
+++ b/lib/entity/pill_sheet_type.dart
@@ -170,7 +170,7 @@ extension PillSheetTypeFunctions on PillSheetType {
       (totalCount / Weekday.values.length).ceil();
 }
 
-int summarizedPillSheetTypesCountToEndIndex(
+int summarizedPillCountWithPillSheetTypesToEndIndex(
     {required List<PillSheetType> pillSheetTypes, required int endIndex}) {
   if (endIndex == 0) {
     return 0;

--- a/lib/entity/pill_sheet_type.dart
+++ b/lib/entity/pill_sheet_type.dart
@@ -171,13 +171,13 @@ extension PillSheetTypeFunctions on PillSheetType {
 }
 
 int summarizedPillSheetsCountToEndIndex(
-    {required List<PillSheetType> pillSheets, required int endIndex}) {
+    {required List<PillSheet> pillSheets, required int endIndex}) {
   if (endIndex == 0) {
     return 0;
   }
-  final passed = pillSheets.sublist(0, endIndex);
-  final passedTotalCount = passed
-      .map((e) => e.totalCount)
+  final sublist = pillSheets.sublist(0, endIndex);
+  final passedTotalCount = sublist
+      .map((e) => e.typeInfo.totalCount)
       .reduce((value, element) => value + element);
   return passedTotalCount;
 }

--- a/lib/entity/pill_sheet_type.dart
+++ b/lib/entity/pill_sheet_type.dart
@@ -170,12 +170,12 @@ extension PillSheetTypeFunctions on PillSheetType {
       (totalCount / Weekday.values.length).ceil();
 }
 
-int summarizedPillSheetTypeTotalCountToPageIndex(
-    {required List<PillSheetType> pillSheetTypes, required int pageIndex}) {
-  if (pageIndex == 0) {
+int summarizedPillSheetsCountToEndIndex(
+    {required List<PillSheetType> pillSheetTypes, required int endIndex}) {
+  if (endIndex == 0) {
     return 0;
   }
-  final passed = pillSheetTypes.sublist(0, pageIndex);
+  final passed = pillSheetTypes.sublist(0, endIndex);
   final passedTotalCount = passed
       .map((e) => e.totalCount)
       .reduce((value, element) => value + element);

--- a/lib/service/day.dart
+++ b/lib/service/day.dart
@@ -1,5 +1,3 @@
-import 'package:pilll/util/datetime/day.dart';
-
 class TodayService {
   DateTime now() => DateTime.now();
 }

--- a/lib/service/day.dart
+++ b/lib/service/day.dart
@@ -1,7 +1,6 @@
 import 'package:pilll/util/datetime/day.dart';
 
 class TodayService {
-  DateTime today() => DateTime.now().date();
   DateTime now() => DateTime.now();
 }
 

--- a/lib/util/datetime/day.dart
+++ b/lib/util/datetime/day.dart
@@ -2,7 +2,7 @@ import 'package:pilll/entity/weekday.dart';
 import 'package:pilll/service/day.dart';
 
 DateTime today() {
-  return todayRepository.today();
+  return todayRepository.now().date();
 }
 
 DateTime now() {

--- a/test/domain/calendar/util_test.dart
+++ b/test/domain/calendar/util_test.dart
@@ -28,7 +28,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -84,7 +84,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -140,7 +140,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -222,7 +222,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -268,7 +268,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -319,7 +319,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -373,7 +373,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2021-01-18"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2021-01-18"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -419,7 +419,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2021-01-01"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2021-01-01"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -469,7 +469,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2021-01-18"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2021-01-18"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -513,7 +513,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -578,7 +578,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -612,7 +612,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -650,7 +650,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -709,7 +709,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-01"));
           addTearDown(() {
             todayRepository = originalTodayRepository;

--- a/test/domain/initial_setting/initial_setting_state_test.dart
+++ b/test/domain/initial_setting/initial_setting_state_test.dart
@@ -20,7 +20,7 @@ void main() {
       final today = DateTime.parse("2020-11-23");
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.now()).thenReturn(today);
-      when(mockTodayRepository.today()).thenReturn(today);
+      when(mockTodayRepository.now()).thenReturn(today);
 
       final pillSheet = InitialSettingState.buildPillSheet(
         pageIndex: 0,
@@ -42,7 +42,7 @@ void main() {
       final today = DateTime.parse("2020-11-23");
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.now()).thenReturn(today);
-      when(mockTodayRepository.today()).thenReturn(today);
+      when(mockTodayRepository.now()).thenReturn(today);
 
       final pillSheet = InitialSettingState.buildPillSheet(
         pageIndex: 1,
@@ -69,7 +69,7 @@ void main() {
       final today = DateTime.parse("2020-11-23");
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.now()).thenReturn(today);
-      when(mockTodayRepository.today()).thenReturn(today);
+      when(mockTodayRepository.now()).thenReturn(today);
 
       final pillSheet = InitialSettingState.buildPillSheet(
         pageIndex: 0,

--- a/test/domain/initial_setting/initial_setting_store_test.dart
+++ b/test/domain/initial_setting/initial_setting_store_test.dart
@@ -292,7 +292,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2020-09-19");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -365,7 +365,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2020-09-19");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -479,7 +479,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2020-09-19");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();

--- a/test/domain/menstruation/menstruation_store_test.dart
+++ b/test/domain/menstruation/menstruation_store_test.dart
@@ -59,7 +59,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
         final today = DateTime(2021, 04, 29);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;
@@ -154,7 +154,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
         final today = DateTime(2021, 04, 29);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;
@@ -234,7 +234,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
         final today = DateTime(2021, 04, 29);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;
@@ -317,7 +317,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
         final today = DateTime(2021, 04, 29);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;

--- a/test/domain/premium_introduction/premium_introduction_sheet_test.dart
+++ b/test/domain/premium_introduction/premium_introduction_sheet_test.dart
@@ -92,9 +92,10 @@ void main() {
   group('#PremiumIntroductionSheet', () {
     final mockTodayRepository = MockTodayService();
     final today = DateTime(2021, 04, 29);
-    final discountEntitlementDeadlineDate = today.subtract(const Duration(days: 1));
+    final discountEntitlementDeadlineDate =
+        today.subtract(const Duration(days: 1));
 
-    when(mockTodayRepository.today()).thenReturn(today);
+    when(mockTodayRepository.now()).thenReturn(today);
     todayRepository = mockTodayRepository;
 
     group('user is premium', () {
@@ -187,7 +188,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         final today = DateTime(2021, 04, 29);
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         todayRepository = mockTodayRepository;
 
         final state = _FakePremiumIntroductionState(
@@ -233,7 +234,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         final today = DateTime(2021, 04, 29);
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         todayRepository = mockTodayRepository;
 
         final state = _FakePremiumIntroductionState(
@@ -278,7 +279,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         final today = DateTime(2021, 04, 29);
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         todayRepository = mockTodayRepository;
 
         var state = _FakePremiumIntroductionState(

--- a/test/domain/record/components/record_page_pill_sheet_test.dart
+++ b/test/domain/record/components/record_page_pill_sheet_test.dart
@@ -26,7 +26,7 @@ void main() {
         final today = DateTime.parse("2020-09-01");
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now()).thenReturn(today);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;
         });
@@ -79,7 +79,7 @@ void main() {
         final today = DateTime.parse("2020-09-01");
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now()).thenReturn(today);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;
         });
@@ -135,7 +135,7 @@ void main() {
         final today = DateTime.parse("2020-09-01");
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now()).thenReturn(today);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;
         });
@@ -192,7 +192,7 @@ void main() {
         final today = DateTime.parse("2020-09-01");
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now()).thenReturn(today);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;
         });
@@ -248,7 +248,7 @@ void main() {
         final today = DateTime.parse("2020-09-01");
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now()).thenReturn(today);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;
         });
@@ -304,7 +304,7 @@ void main() {
         final today = DateTime.parse("2020-09-01");
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now()).thenReturn(today);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;
         });
@@ -361,7 +361,7 @@ void main() {
         final today = DateTime.parse("2020-09-01");
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now()).thenReturn(today);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;
         });
@@ -414,7 +414,7 @@ void main() {
         final today = DateTime.parse("2020-09-01");
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now()).thenReturn(today);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;
         });
@@ -470,7 +470,7 @@ void main() {
         final today = DateTime.parse("2020-09-01");
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now()).thenReturn(today);
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         addTearDown(() {
           todayRepository = originalTodayRepository;
         });
@@ -526,8 +526,7 @@ void main() {
       final mockTodayRepository = MockTodayService();
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-01"));
-      when(mockTodayRepository.today())
-          .thenReturn(DateTime.parse("2020-09-01"));
+      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-01"));
       addTearDown(() {
         todayRepository = originalTodayRepository;
       });
@@ -558,7 +557,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-11"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-11"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -605,7 +604,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-12"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-12"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -654,7 +653,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-11"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-11"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -703,7 +702,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-12"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-12"));
           addTearDown(() {
             todayRepository = originalTodayRepository;
@@ -755,7 +754,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2022-01-14"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2022-01-14"));
           addTearDown(() {
             todayRepository = originalTodayRepository;

--- a/test/domain/record/notification_bar/notification_bar_test.dart
+++ b/test/domain/record/notification_bar/notification_bar_test.dart
@@ -49,7 +49,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         final today = DateTime(2021, 04, 29);
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(today);
         todayRepository = mockTodayRepository;
 
@@ -114,7 +114,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         final today = DateTime(2021, 04, 29);
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(today);
         todayRepository = mockTodayRepository;
 
@@ -180,7 +180,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         final today = DateTime(2021, 04, 29);
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(today);
         todayRepository = mockTodayRepository;
 
@@ -244,7 +244,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         final today = DateTime(2021, 04, 29);
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(today);
         todayRepository = mockTodayRepository;
 
@@ -307,7 +307,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         final today = DateTime(2021, 04, 29);
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(today);
         todayRepository = mockTodayRepository;
 
@@ -371,7 +371,7 @@ void main() {
         final today = DateTime(2021, 04, 29);
         final n = today;
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(n);
         todayRepository = mockTodayRepository;
 
@@ -434,7 +434,7 @@ void main() {
         final today = DateTime(2021, 04, 29);
         final n = today;
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(n);
         todayRepository = mockTodayRepository;
 
@@ -499,7 +499,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         final today = DateTime(2021, 04, 29);
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(today);
         todayRepository = mockTodayRepository;
 
@@ -562,7 +562,7 @@ void main() {
         final mockTodayRepository = MockTodayService();
         final today = DateTime(2021, 04, 29);
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(today);
         todayRepository = mockTodayRepository;
 
@@ -625,7 +625,7 @@ void main() {
         final today = DateTime(2021, 04, 29);
         final n = today;
 
-        when(mockTodayRepository.today()).thenReturn(today);
+        when(mockTodayRepository.now()).thenReturn(today);
         when(mockTodayRepository.now()).thenReturn(n);
         todayRepository = mockTodayRepository;
 
@@ -690,7 +690,7 @@ void main() {
       final today = DateTime(2021, 04, 29);
       final n = today;
 
-      when(mockTodayRepository.today()).thenReturn(today);
+      when(mockTodayRepository.now()).thenReturn(today);
       when(mockTodayRepository.now()).thenReturn(n);
       todayRepository = mockTodayRepository;
 

--- a/test/domain/record/record_page_state_test.dart
+++ b/test/domain/record/record_page_state_test.dart
@@ -59,7 +59,7 @@ void main() {
       final today = DateTime.parse("2020-11-23");
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.now()).thenReturn(today);
-      when(mockTodayRepository.today()).thenReturn(today);
+      when(mockTodayRepository.now()).thenReturn(today);
 
       final pillSheetEntity =
           PillSheet.create(PillSheetType.pillsheet_21).copyWith(
@@ -133,7 +133,7 @@ void main() {
       final mockTodayRepository = MockTodayService();
       final today = DateTime.parse("2020-11-23");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(today);
+      when(mockTodayRepository.now()).thenReturn(today);
       when(mockTodayRepository.now()).thenReturn(today);
 
       final pillSheetEntity =
@@ -211,7 +211,7 @@ void main() {
       final mockTodayRepository = MockTodayService();
       final today = DateTime.parse("2020-11-23");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(today);
+      when(mockTodayRepository.now()).thenReturn(today);
       when(mockTodayRepository.now()).thenReturn(today);
 
       final pillSheetEntity =
@@ -283,7 +283,7 @@ void main() {
       final mockTodayRepository = MockTodayService();
       final today = DateTime.parse("2020-11-23");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(today);
+      when(mockTodayRepository.now()).thenReturn(today);
       when(mockTodayRepository.now()).thenReturn(today);
 
       final pillSheetEntity =

--- a/test/domain/record/record_page_store_test.dart
+++ b/test/domain/record/record_page_store_test.dart
@@ -31,7 +31,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2020-09-19");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -124,7 +124,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2020-09-19");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -230,7 +230,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2020-09-19");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -339,7 +339,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2020-09-19");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -461,7 +461,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2022-05-29");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -583,7 +583,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2020-09-19");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -711,7 +711,7 @@ void main() {
         var mockTodayRepository = MockTodayService();
         final _today = DateTime.parse("2022-01-17");
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today()).thenReturn(_today);
+        when(mockTodayRepository.now()).thenReturn(_today);
         when(mockTodayRepository.now()).thenReturn(_today);
         final yesterday = DateTime.parse("2022-01-16");
 
@@ -826,7 +826,7 @@ void main() {
         var mockTodayRepository = MockTodayService();
         final _today = DateTime.parse("2022-01-17");
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today()).thenReturn(_today);
+        when(mockTodayRepository.now()).thenReturn(_today);
         when(mockTodayRepository.now()).thenReturn(_today);
         final yesterday = DateTime.parse("2022-01-16");
 
@@ -939,7 +939,7 @@ void main() {
         var mockTodayRepository = MockTodayService();
         final _today = DateTime.parse("2022-01-17");
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today()).thenReturn(_today);
+        when(mockTodayRepository.now()).thenReturn(_today);
         when(mockTodayRepository.now()).thenReturn(_today);
         final beginDate = DateTime.parse("2022-01-06");
 
@@ -1067,7 +1067,7 @@ void main() {
         var mockTodayRepository = MockTodayService();
         final _today = DateTime.parse("2022-01-17");
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today()).thenReturn(_today);
+        when(mockTodayRepository.now()).thenReturn(_today);
         when(mockTodayRepository.now()).thenReturn(_today);
         final beginDate = DateTime.parse("2022-01-06");
         final yesterday = DateTime.parse("2022-01-16");
@@ -1189,7 +1189,7 @@ void main() {
         var mockTodayRepository = MockTodayService();
         final _today = DateTime.parse("2022-01-17");
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today()).thenReturn(_today);
+        when(mockTodayRepository.now()).thenReturn(_today);
         when(mockTodayRepository.now()).thenReturn(_today);
         final yesterday = DateTime.parse("2022-01-16");
 
@@ -1314,7 +1314,7 @@ void main() {
         var mockTodayRepository = MockTodayService();
         final _today = DateTime.parse("2022-01-31");
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today()).thenReturn(_today);
+        when(mockTodayRepository.now()).thenReturn(_today);
         when(mockTodayRepository.now()).thenReturn(_today);
         final yesterday = DateTime.parse("2022-01-30");
 
@@ -1441,7 +1441,7 @@ void main() {
         var mockTodayRepository = MockTodayService();
         final _today = DateTime.parse("2022-01-31");
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today()).thenReturn(_today);
+        when(mockTodayRepository.now()).thenReturn(_today);
         when(mockTodayRepository.now()).thenReturn(_today);
         final yesterday = DateTime.parse("2022-01-30");
 

--- a/test/domain/settings/components/today_pill_number/setting_today_pill_number_store_test.dart
+++ b/test/domain/settings/components/today_pill_number/setting_today_pill_number_store_test.dart
@@ -27,7 +27,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2020-09-19");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -92,8 +92,8 @@ void main() {
         pillSheetGroup: pillSheetGroup,
         activedPillSheet: pillSheet,
       );
-      final store =
-          container.read(settingTodayPillNumberStoreProvider(parameter).notifier);
+      final store = container
+          .read(settingTodayPillNumberStoreProvider(parameter).notifier);
 
       expect(pillSheet.todayPillNumber, 1);
 
@@ -111,7 +111,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2020-09-19");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -176,8 +176,8 @@ void main() {
         pillSheetGroup: pillSheetGroup,
         activedPillSheet: pillSheet,
       );
-      final store =
-          container.read(settingTodayPillNumberStoreProvider(parameter).notifier);
+      final store = container
+          .read(settingTodayPillNumberStoreProvider(parameter).notifier);
 
       expect(pillSheet.todayPillNumber, 1);
 
@@ -197,7 +197,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2022-05-01");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -287,8 +287,8 @@ void main() {
         pillSheetGroup: pillSheetGroup,
         activedPillSheet: middle,
       );
-      final store =
-          container.read(settingTodayPillNumberStoreProvider(parameter).notifier);
+      final store = container
+          .read(settingTodayPillNumberStoreProvider(parameter).notifier);
 
       expect(middle.todayPillNumber, 1);
 
@@ -307,7 +307,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2022-05-01");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -398,8 +398,8 @@ void main() {
         pillSheetGroup: pillSheetGroup,
         activedPillSheet: middle,
       );
-      final store =
-          container.read(settingTodayPillNumberStoreProvider(parameter).notifier);
+      final store = container
+          .read(settingTodayPillNumberStoreProvider(parameter).notifier);
 
       expect(middle.todayPillNumber, 1);
 
@@ -418,7 +418,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2022-05-01");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -510,8 +510,8 @@ void main() {
         pillSheetGroup: pillSheetGroup,
         activedPillSheet: middle,
       );
-      final store =
-          container.read(settingTodayPillNumberStoreProvider(parameter).notifier);
+      final store = container
+          .read(settingTodayPillNumberStoreProvider(parameter).notifier);
 
       expect(middle.todayPillNumber, 1);
 
@@ -532,7 +532,7 @@ void main() {
       var mockTodayRepository = MockTodayService();
       final _today = DateTime.parse("2022-05-02");
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today()).thenReturn(_today);
+      when(mockTodayRepository.now()).thenReturn(_today);
       when(mockTodayRepository.now()).thenReturn(_today);
 
       final batchFactory = MockBatchFactory();
@@ -630,8 +630,8 @@ void main() {
         pillSheetGroup: pillSheetGroup,
         activedPillSheet: middle,
       );
-      final store =
-          container.read(settingTodayPillNumberStoreProvider(parameter).notifier);
+      final store = container
+          .read(settingTodayPillNumberStoreProvider(parameter).notifier);
 
       expect(middle.todayPillNumber, 1);
 

--- a/test/entity/pill_sheet_group_test.dart
+++ b/test/entity/pill_sheet_group_test.dart
@@ -19,7 +19,7 @@ void main() {
       test("today: 2020-09-19, begin: 2020-09-14, end: 2020-09-18", () {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today())
+        when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2020-09-19"));
         when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2020-09-19"));
@@ -46,7 +46,7 @@ void main() {
       test("today: 2020-09-28, begin: 2020-09-01, end: 2020-09-28", () {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today())
+        when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2020-09-28"));
         when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2020-09-19"));
@@ -74,7 +74,7 @@ void main() {
         test("rest duration is not end", () {
           final mockTodayRepository = MockTodayService();
           todayRepository = mockTodayRepository;
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-28"));
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-19"));
@@ -108,7 +108,7 @@ void main() {
         test("rest duration is ended", () {
           final mockTodayRepository = MockTodayService();
           todayRepository = mockTodayRepository;
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-28"));
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-19"));
@@ -143,7 +143,7 @@ void main() {
           test("last rest duration is not ended", () {
             final mockTodayRepository = MockTodayService();
             todayRepository = mockTodayRepository;
-            when(mockTodayRepository.today())
+            when(mockTodayRepository.now())
                 .thenReturn(DateTime.parse("2020-09-28"));
             when(mockTodayRepository.now())
                 .thenReturn(DateTime.parse("2020-09-19"));
@@ -181,7 +181,7 @@ void main() {
           test("last rest duration is ended", () {
             final mockTodayRepository = MockTodayService();
             todayRepository = mockTodayRepository;
-            when(mockTodayRepository.today())
+            when(mockTodayRepository.now())
                 .thenReturn(DateTime.parse("2020-09-28"));
             when(mockTodayRepository.now())
                 .thenReturn(DateTime.parse("2020-09-19"));
@@ -224,7 +224,7 @@ void main() {
       test("it is plane pattern", () {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today())
+        when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2022-03-29"));
         when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2022-03-29"));
@@ -345,7 +345,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-28"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-28"));
 
           final sheetType = PillSheetType.pillsheet_21;
@@ -444,7 +444,7 @@ void main() {
             todayRepository = mockTodayRepository;
             when(mockTodayRepository.now())
                 .thenReturn(DateTime.parse("2020-09-28"));
-            when(mockTodayRepository.today())
+            when(mockTodayRepository.now())
                 .thenReturn(DateTime.parse("2020-09-28"));
 
             final sheetType = PillSheetType.pillsheet_21;
@@ -520,7 +520,7 @@ void main() {
         test("it is plane pattern", () {
           final mockTodayRepository = MockTodayService();
           todayRepository = mockTodayRepository;
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2022-03-30"));
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2022-03-30"));

--- a/test/entity/pill_sheet_group_test.dart
+++ b/test/entity/pill_sheet_group_test.dart
@@ -21,8 +21,6 @@ void main() {
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2020-09-19"));
-        when(mockTodayRepository.now())
-            .thenReturn(DateTime.parse("2020-09-19"));
 
         final sheetType = PillSheetType.pillsheet_21;
         final pillSheet = PillSheet(
@@ -48,8 +46,6 @@ void main() {
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2020-09-28"));
-        when(mockTodayRepository.now())
-            .thenReturn(DateTime.parse("2020-09-19"));
 
         final sheetType = PillSheetType.pillsheet_21;
         final pillSheet = PillSheet(
@@ -76,8 +72,6 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-28"));
-          when(mockTodayRepository.now())
-              .thenReturn(DateTime.parse("2020-09-19"));
 
           final sheetType = PillSheetType.pillsheet_21;
           final pillSheet = PillSheet(
@@ -110,8 +104,6 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-28"));
-          when(mockTodayRepository.now())
-              .thenReturn(DateTime.parse("2020-09-19"));
 
           final sheetType = PillSheetType.pillsheet_21;
           final pillSheet = PillSheet(
@@ -145,8 +137,6 @@ void main() {
             todayRepository = mockTodayRepository;
             when(mockTodayRepository.now())
                 .thenReturn(DateTime.parse("2020-09-28"));
-            when(mockTodayRepository.now())
-                .thenReturn(DateTime.parse("2020-09-19"));
 
             final sheetType = PillSheetType.pillsheet_21;
             final pillSheet = PillSheet(
@@ -183,8 +173,6 @@ void main() {
             todayRepository = mockTodayRepository;
             when(mockTodayRepository.now())
                 .thenReturn(DateTime.parse("2020-09-28"));
-            when(mockTodayRepository.now())
-                .thenReturn(DateTime.parse("2020-09-19"));
 
             final sheetType = PillSheetType.pillsheet_21;
             final pillSheet = PillSheet(
@@ -224,8 +212,6 @@ void main() {
       test("it is plane pattern", () {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.now())
-            .thenReturn(DateTime.parse("2022-03-29"));
         when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2022-03-29"));
 
@@ -345,8 +331,6 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-28"));
-          when(mockTodayRepository.now())
-              .thenReturn(DateTime.parse("2020-09-28"));
 
           final sheetType = PillSheetType.pillsheet_21;
           final pillSheet = PillSheet(
@@ -444,8 +428,6 @@ void main() {
             todayRepository = mockTodayRepository;
             when(mockTodayRepository.now())
                 .thenReturn(DateTime.parse("2020-09-28"));
-            when(mockTodayRepository.now())
-                .thenReturn(DateTime.parse("2020-09-28"));
 
             final sheetType = PillSheetType.pillsheet_21;
             final pillSheet = PillSheet(
@@ -520,8 +502,6 @@ void main() {
         test("it is plane pattern", () {
           final mockTodayRepository = MockTodayService();
           todayRepository = mockTodayRepository;
-          when(mockTodayRepository.now())
-              .thenReturn(DateTime.parse("2022-03-30"));
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2022-03-30"));
 

--- a/test/entity/pill_sheet_group_test.dart
+++ b/test/entity/pill_sheet_group_test.dart
@@ -536,6 +536,93 @@ void main() {
           );
           expect(pillSheetGroup.sequentialLastTakenPillNumber, 29);
         });
+
+        test("first pill sheet has rest duration", () {
+          final mockTodayRepository = MockTodayService();
+          todayRepository = mockTodayRepository;
+          when(mockTodayRepository.now())
+              .thenReturn(DateTime.parse("2022-03-30"));
+
+          final sheetType = PillSheetType.pillsheet_21;
+          final pillSheet1 = PillSheet(
+            beginingDate: DateTime.parse("2022-03-01"),
+            lastTakenDate: DateTime.parse("2022-03-29"),
+            restDurations: [
+              RestDuration(
+                beginDate: DateTime.parse("2022-03-02"),
+                createdDate: DateTime.parse("2022-03-02"),
+                endDate: DateTime.parse("2022-03-03"),
+              ),
+            ],
+            typeInfo: PillSheetTypeInfo(
+              dosingPeriod: sheetType.dosingPeriod,
+              name: sheetType.fullName,
+              totalCount: sheetType.totalCount,
+              pillSheetTypeReferencePath: sheetType.rawPath,
+            ),
+          );
+          final pillSheet2 = PillSheet(
+            beginingDate: DateTime.parse("2022-03-30"),
+            lastTakenDate: DateTime.parse("2022-03-30"),
+            groupIndex: 1,
+            typeInfo: PillSheetTypeInfo(
+              dosingPeriod: sheetType.dosingPeriod,
+              name: sheetType.fullName,
+              totalCount: sheetType.totalCount,
+              pillSheetTypeReferencePath: sheetType.rawPath,
+            ),
+          );
+          // created at and id are anything value
+          final pillSheetGroup = PillSheetGroup(
+            pillSheetIDs: ["sheet_id", "sheet_id2"],
+            pillSheets: [pillSheet1, pillSheet2],
+            createdAt: DateTime.now(),
+          );
+          expect(pillSheetGroup.sequentialLastTakenPillNumber, 30);
+        });
+        test("second pill sheet has rest duration", () {
+          final mockTodayRepository = MockTodayService();
+          todayRepository = mockTodayRepository;
+          when(mockTodayRepository.now())
+              .thenReturn(DateTime.parse("2022-03-30"));
+
+          final sheetType = PillSheetType.pillsheet_21;
+          final pillSheet1 = PillSheet(
+            beginingDate: DateTime.parse("2022-03-01"),
+            lastTakenDate: DateTime.parse("2022-03-28"),
+            typeInfo: PillSheetTypeInfo(
+              dosingPeriod: sheetType.dosingPeriod,
+              name: sheetType.fullName,
+              totalCount: sheetType.totalCount,
+              pillSheetTypeReferencePath: sheetType.rawPath,
+            ),
+          );
+          final pillSheet2 = PillSheet(
+            beginingDate: DateTime.parse("2022-03-29"),
+            lastTakenDate: DateTime.parse("2022-04-01"),
+            restDurations: [
+              RestDuration(
+                beginDate: DateTime.parse("2022-03-30"),
+                createdDate: DateTime.parse("2022-03-30"),
+                endDate: DateTime.parse("2022-03-31"),
+              ),
+            ],
+            groupIndex: 1,
+            typeInfo: PillSheetTypeInfo(
+              dosingPeriod: sheetType.dosingPeriod,
+              name: sheetType.fullName,
+              totalCount: sheetType.totalCount,
+              pillSheetTypeReferencePath: sheetType.rawPath,
+            ),
+          );
+          // created at and id are anything value
+          final pillSheetGroup = PillSheetGroup(
+            pillSheetIDs: ["sheet_id", "sheet_id2"],
+            pillSheets: [pillSheet1, pillSheet2],
+            createdAt: DateTime.now(),
+          );
+          expect(pillSheetGroup.sequentialLastTakenPillNumber, 31);
+        });
       });
     });
   });

--- a/test/entity/pill_sheet_test.dart
+++ b/test/entity/pill_sheet_test.dart
@@ -17,8 +17,7 @@ void main() {
     test("today: 2020-09-19, begin: 2020-09-14, end: 2020-09-18", () {
       final mockTodayRepository = MockTodayService();
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today())
-          .thenReturn(DateTime.parse("2020-09-19"));
+      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-19"));
 
       final sheetType = PillSheetType.pillsheet_21;
       final model = PillSheet(
@@ -36,8 +35,7 @@ void main() {
     test("today: 2020-09-28, begin: 2020-09-01, end: 2020-09-28", () {
       final mockTodayRepository = MockTodayService();
       todayRepository = mockTodayRepository;
-      when(mockTodayRepository.today())
-          .thenReturn(DateTime.parse("2020-09-28"));
+      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-28"));
 
       final sheetType = PillSheetType.pillsheet_21;
       final model = PillSheet(
@@ -56,7 +54,7 @@ void main() {
       test("rest duration is not end", () {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today())
+        when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2020-09-28"));
 
         final sheetType = PillSheetType.pillsheet_21;
@@ -82,7 +80,7 @@ void main() {
       test("rest duration is ended", () {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today())
+        when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2020-09-28"));
 
         final sheetType = PillSheetType.pillsheet_21;
@@ -109,7 +107,7 @@ void main() {
         test("last rest duration is not ended", () {
           final mockTodayRepository = MockTodayService();
           todayRepository = mockTodayRepository;
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-28"));
 
           final sheetType = PillSheetType.pillsheet_21;
@@ -139,7 +137,7 @@ void main() {
         test("last rest duration is ended", () {
           final mockTodayRepository = MockTodayService();
           todayRepository = mockTodayRepository;
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-28"));
 
           final sheetType = PillSheetType.pillsheet_21;
@@ -253,8 +251,7 @@ void main() {
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.now())
           .thenReturn(DateTime(2020, 9, 29, 23, 59, 59));
-      when(mockTodayRepository.today())
-          .thenReturn(DateTime.parse("2020-09-29"));
+      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-29"));
 
       final sheetType = PillSheetType.pillsheet_21;
       final model = PillSheet(
@@ -281,8 +278,7 @@ void main() {
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.now())
           .thenReturn(DateTime(2020, 9, 29, 23, 59, 59));
-      when(mockTodayRepository.today())
-          .thenReturn(DateTime.parse("2020-09-29"));
+      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-29"));
 
       final sheetType = PillSheetType.pillsheet_21;
       final model = PillSheet(
@@ -344,8 +340,7 @@ void main() {
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.now())
           .thenReturn(DateTime(2020, 9, 30, 23, 59, 59));
-      when(mockTodayRepository.today())
-          .thenReturn(DateTime.parse("2020-09-30"));
+      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-30"));
 
       final sheetType = PillSheetType.pillsheet_21;
       final model = PillSheet(
@@ -502,7 +497,7 @@ void main() {
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2020-09-28"));
-        when(mockTodayRepository.today())
+        when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2020-09-28"));
 
         final sheetType = PillSheetType.pillsheet_21;
@@ -583,7 +578,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-28"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-28"));
 
           final sheetType = PillSheetType.pillsheet_21;
@@ -670,7 +665,7 @@ void main() {
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2022-05-10"));
-        when(mockTodayRepository.today())
+        when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2022-05-10"));
 
         final sheetType = PillSheetType.pillsheet_21;
@@ -725,7 +720,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2022-05-10"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2022-05-10"));
 
           final sheetType = PillSheetType.pillsheet_21;
@@ -759,7 +754,7 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2022-05-10"));
-          when(mockTodayRepository.today())
+          when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2022-05-10"));
 
           final sheetType = PillSheetType.pillsheet_21;
@@ -797,7 +792,7 @@ void main() {
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2022-05-10"));
-        when(mockTodayRepository.today())
+        when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2022-05-10"));
 
         expect(
@@ -806,7 +801,7 @@ void main() {
       test("last restDuration is not ended", () {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.today())
+        when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2022-05-10"));
 
         final restDurations = [

--- a/test/entity/pill_sheet_test.dart
+++ b/test/entity/pill_sheet_test.dart
@@ -3,6 +3,7 @@ import 'package:pilll/entity/pill_sheet_type.dart';
 import 'package:pilll/service/day.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:pilll/util/datetime/day.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../helper/mock.mocks.dart';
@@ -799,7 +800,8 @@ void main() {
         when(mockTodayRepository.today())
             .thenReturn(DateTime.parse("2022-05-10"));
 
-        expect(summarizedRestDuration([]), 0);
+        expect(
+            summarizedRestDuration(restDurations: [], upperDate: today()), 0);
       });
       test("last restDuration is not ended", () {
         final mockTodayRepository = MockTodayService();
@@ -813,7 +815,10 @@ void main() {
             createdDate: DateTime.parse("2022-05-07"),
           ),
         ];
-        expect(summarizedRestDuration(restDurations), 3);
+        expect(
+            summarizedRestDuration(
+                restDurations: restDurations, upperDate: today()),
+            3);
       });
       test("last restDuration is ended", () {
         final mockTodayRepository = MockTodayService();
@@ -828,7 +833,10 @@ void main() {
             endDate: DateTime.parse("2022-05-08"),
           ),
         ];
-        expect(summarizedRestDuration(restDurations), 1);
+        expect(
+            summarizedRestDuration(
+                restDurations: restDurations, upperDate: today()),
+            1);
       });
     });
   });

--- a/test/helper/mock.mocks.dart
+++ b/test/helper/mock.mocks.dart
@@ -111,9 +111,6 @@ class MockTodayService extends _i1.Mock implements _i14.TodayService {
   }
 
   @override
-  DateTime today() => (super.noSuchMethod(Invocation.method(#today, []),
-      returnValue: _FakeDateTime_1()) as DateTime);
-  @override
   DateTime now() => (super.noSuchMethod(Invocation.method(#now, []),
       returnValue: _FakeDateTime_1()) as DateTime);
 }


### PR DESCRIPTION
## Abstract
ピルシートの番号を決めるロジックを統合・リファクタリングした。
グループ内にピルシートが複数枚ある場合、今飲んでいるシートの一つ前のシートに休薬期間がある場合に正しい番号表示にならなかったバグがあったのでついでに修正

## Why
https://github.com/bannzai/Pilll/pull/558 で LocalNotificationに文言を登録する際にピル番号が欲しかったため、日付に応じてピルシートの番号を求める関数を切り出すことにした

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した