### PR TITLE
休薬終了時に最後に飲んだピル番号が無い場合はピル番号調整のモーダルを出さない

### DIFF
--- a/lib/analytics.dart
+++ b/lib/analytics.dart
@@ -6,7 +6,7 @@ final firebaseAnalytics = FirebaseAnalytics.instance;
 
 class Analytics {
   logEvent({required String name, Map<String, dynamic>? parameters}) async {
-    assert(name.length < 40,
+    assert(name.length <= 40,
         "firebase analytics log event name limit length up to 40");
     print("[INFO] logEvent name: $name, parameters: $parameters");
 

--- a/lib/domain/record/components/supports/components/rest_duration/end_manual_rest_duration_button.dart
+++ b/lib/domain/record/components/supports/components/rest_duration/end_manual_rest_duration_button.dart
@@ -155,11 +155,7 @@ void showEndRestDurationModal(
   BuildContext context, {
   required PillSheetGroup pillSheetGroup,
   required RecordPageStore store,
-  required PillSheet activedPillSheet,
 }) {
-  if (activedPillSheet.lastTakenPillNumber <= 0) {
-    return;
-  }
   showDialog(
     context: context,
     builder: (context) => EndRestDurationModal(

--- a/lib/domain/record/components/supports/record_page_pill_sheet_support_actions.dart
+++ b/lib/domain/record/components/supports/record_page_pill_sheet_support_actions.dart
@@ -49,10 +49,24 @@ class RecordPagePillSheetSupportActions extends StatelessWidget {
               pillSheetGroup: pillSheetGroup,
               store: store,
               didEndRestDuration: () {
-                showEndRestDurationModal(context,
+                if (pillSheetGroup.sequentialLastTakenPillNumber > 0 &&
+                    setting.pillSheetAppearanceMode ==
+                        PillSheetAppearanceMode.sequential) {
+                  showEndRestDurationModal(
+                    context,
                     pillSheetGroup: pillSheetGroup,
                     store: store,
-                    activedPillSheet: activedPillSheet);
+                  );
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      duration: Duration(
+                        seconds: 2,
+                      ),
+                      content: Text("休薬期間が終了しました"),
+                    ),
+                  );
+                }
               },
             ),
           ] else ...[


### PR DESCRIPTION
## Abstract
- 休薬終了時に最後に飲んだピル番号が無い場合はピル番号調整のモーダルを出さない
- 服用日数表示以外にもモーダルが出ていたのでないようにした
- analyticsの境界値条件が間違えていたので修正

## Why

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した