### PR TITLE
Bugfix

### DIFF
--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -245,8 +245,10 @@ class RecordPagePillSheet extends StatelessWidget {
       return left <= pillNumberIntoPillSheet &&
           pillNumberIntoPillSheet <= right;
     }
-    final passedCount = summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
-        pillSheets: pillSheetGroup.pillSheets, endIndex: pageIndex);
+    final passedCount = summarizedPillCountWithPillSheetTypesToEndIndex(
+        pillSheetTypes:
+            pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList(),
+        endIndex: pageIndex);
     final serialiedPillNumber = passedCount + pillNumberIntoPillSheet;
 
     final menstruationRangeList =

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -168,7 +168,8 @@ class RecordPagePillSheet extends StatelessWidget {
       }
     } else if (setting.pillSheetAppearanceMode ==
         PillSheetAppearanceMode.sequential) {
-      final pageOffset = summarizedPillDayCountWithPillSheetsToEndIndex(
+      final pageOffset =
+          summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
         pillSheets: pillSheetGroup.pillSheets,
         endIndex: pageIndex,
       );
@@ -244,7 +245,7 @@ class RecordPagePillSheet extends StatelessWidget {
       return left <= pillNumberIntoPillSheet &&
           pillNumberIntoPillSheet <= right;
     }
-    final passedCount = summarizedPillDayCountWithPillSheetsToEndIndex(
+    final passedCount = summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
         pillSheets: pillSheetGroup.pillSheets, endIndex: pageIndex);
     final serialiedPillNumber = passedCount + pillNumberIntoPillSheet;
 

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -168,9 +168,9 @@ class RecordPagePillSheet extends StatelessWidget {
       }
     } else if (setting.pillSheetAppearanceMode ==
         PillSheetAppearanceMode.sequential) {
-      final pageOffset =
-          summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
-        pillSheets: pillSheetGroup.pillSheets,
+      final pageOffset = summarizedPillCountWithPillSheetTypesToEndIndex(
+        pillSheetTypes:
+            pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList(),
         endIndex: pageIndex,
       );
       if (setting.pillNumberForFromMenstruation == 0 ||

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -168,7 +168,7 @@ class RecordPagePillSheet extends StatelessWidget {
       }
     } else if (setting.pillSheetAppearanceMode ==
         PillSheetAppearanceMode.sequential) {
-      final pageOffset = summarizedPillCountWithPillSheetsToEndIndex(
+      final pageOffset = summarizedPillDayCountWithPillSheetsToEndIndex(
         pillSheets: pillSheetGroup.pillSheets,
         endIndex: pageIndex,
       );
@@ -244,7 +244,7 @@ class RecordPagePillSheet extends StatelessWidget {
       return left <= pillNumberIntoPillSheet &&
           pillNumberIntoPillSheet <= right;
     }
-    final passedCount = summarizedPillCountWithPillSheetsToEndIndex(
+    final passedCount = summarizedPillDayCountWithPillSheetsToEndIndex(
         pillSheets: pillSheetGroup.pillSheets, endIndex: pageIndex);
     final serialiedPillNumber = passedCount + pillNumberIntoPillSheet;
 

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -228,7 +228,7 @@ int pillSheetPillNumber({
       1;
 }
 
-int summarizedPillCountWithPillSheetsToEndIndex(
+int summarizedPillDayCountWithPillSheetsToEndIndex(
     {required List<PillSheet> pillSheets, required int endIndex}) {
   if (endIndex == 0) {
     return 0;

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -227,16 +227,3 @@ int pillSheetPillNumber({
           restDurations: pillSheet.restDurations, upperDate: targetDate) +
       1;
 }
-
-int summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
-    {required List<PillSheet> pillSheets, required int endIndex}) {
-  if (endIndex == 0) {
-    return 0;
-  }
-
-  return pillSheets.sublist(0, endIndex).fold(0, (int result, pillSheet) {
-    return result +
-        daysBetween(pillSheet.beginingDate, pillSheet.estimatedEndTakenDate) +
-        1;
-  });
-}

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -228,7 +228,7 @@ int pillSheetPillNumber({
       1;
 }
 
-int summarizedPillDayCountWithPillSheetsToEndIndex(
+int summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
     {required List<PillSheet> pillSheets, required int endIndex}) {
   if (endIndex == 0) {
     return 0;

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -240,16 +240,3 @@ int summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
         1;
   });
 }
-
-int summarizedPillCountWithPillSheetsToEndIndex(
-    {required List<PillSheet> pillSheets, required int endIndex}) {
-  if (endIndex == 0) {
-    return 0;
-  }
-
-  return pillSheets.sublist(0, endIndex).fold(0, (int result, pillSheet) {
-    return result +
-        daysBetween(pillSheet.beginingDate, pillSheet.estimatedEndTakenDate) +
-        1;
-  });
-}

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -240,3 +240,16 @@ int summarizedPillDayCountWithPillSheetsToEndIndex(
         1;
   });
 }
+
+int summarizedPillCountWithPillSheetsToEndIndex(
+    {required List<PillSheet> pillSheets, required int endIndex}) {
+  if (endIndex == 0) {
+    return 0;
+  }
+
+  return pillSheets.sublist(0, endIndex).fold(0, (int result, pillSheet) {
+    return result +
+        daysBetween(pillSheet.beginingDate, pillSheet.estimatedEndTakenDate) +
+        1;
+  });
+}

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -68,7 +68,7 @@ class PillSheetGroup with _$PillSheetGroup {
     }
 
     final passedPillCountForPillSheetTypes =
-        summarizedPillCountWithPillSheetsToEndIndex(
+        summarizedPillDayCountWithPillSheetsToEndIndex(
             pillSheets: pillSheets, endIndex: activedPillSheet.groupIndex);
 
     var sequentialTodayPillNumber =
@@ -103,7 +103,7 @@ class PillSheetGroup with _$PillSheetGroup {
     }
 
     final passedPillCountForPillSheetTypes =
-        summarizedPillCountWithPillSheetsToEndIndex(
+        summarizedPillDayCountWithPillSheetsToEndIndex(
             pillSheets: pillSheets, endIndex: activedPillSheet.groupIndex);
 
     var sequentialLastTakenPillNumber =
@@ -129,7 +129,7 @@ class PillSheetGroup with _$PillSheetGroup {
   }
 
   int get estimatedEndPillNumber {
-    var estimatedEndPillNumber = summarizedPillCountWithPillSheetsToEndIndex(
+    var estimatedEndPillNumber = summarizedPillDayCountWithPillSheetsToEndIndex(
         pillSheets: pillSheets, endIndex: pillSheets.length);
 
     final displayNumberSetting = this.displayNumberSetting;

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -133,8 +133,9 @@ class PillSheetGroup with _$PillSheetGroup {
 
   int get estimatedEndPillNumber {
     var estimatedEndPillNumber =
-        summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
-            pillSheets: pillSheets, endIndex: pillSheets.length);
+        summarizedPillCountWithPillSheetTypesToEndIndex(
+            pillSheetTypes: pillSheets.map((e) => e.pillSheetType).toList(),
+            endIndex: pillSheets.length);
 
     final displayNumberSetting = this.displayNumberSetting;
     if (displayNumberSetting != null) {

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -68,7 +68,7 @@ class PillSheetGroup with _$PillSheetGroup {
     }
 
     final passedPillCountForPillSheetTypes =
-        summarizedPillDayCountWithPillSheetsToEndIndex(
+        summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
             pillSheets: pillSheets, endIndex: activedPillSheet.groupIndex);
 
     var sequentialTodayPillNumber =
@@ -103,7 +103,7 @@ class PillSheetGroup with _$PillSheetGroup {
     }
 
     final passedPillCountForPillSheetTypes =
-        summarizedPillDayCountWithPillSheetsToEndIndex(
+        summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
             pillSheets: pillSheets, endIndex: activedPillSheet.groupIndex);
 
     var sequentialLastTakenPillNumber =
@@ -129,8 +129,9 @@ class PillSheetGroup with _$PillSheetGroup {
   }
 
   int get estimatedEndPillNumber {
-    var estimatedEndPillNumber = summarizedPillDayCountWithPillSheetsToEndIndex(
-        pillSheets: pillSheets, endIndex: pillSheets.length);
+    var estimatedEndPillNumber =
+        summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
+            pillSheets: pillSheets, endIndex: pillSheets.length);
 
     final displayNumberSetting = this.displayNumberSetting;
     if (displayNumberSetting != null) {

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -3,6 +3,7 @@ import 'package:pilll/entity/firestore_timestamp_converter.dart';
 import 'package:pilll/entity/pill_sheet.codegen.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pilll/entity/pill_sheet_type.dart';
 
 part 'pill_sheet_group.codegen.g.dart';
 part 'pill_sheet_group.codegen.freezed.dart';
@@ -68,8 +69,9 @@ class PillSheetGroup with _$PillSheetGroup {
     }
 
     final passedPillCountForPillSheetTypes =
-        summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
-            pillSheets: pillSheets, endIndex: activedPillSheet.groupIndex);
+        summarizedPillCountWithPillSheetTypesToEndIndex(
+            pillSheetTypes: pillSheets.map((e) => e.pillSheetType).toList(),
+            endIndex: activedPillSheet.groupIndex);
 
     var sequentialTodayPillNumber =
         passedPillCountForPillSheetTypes + activedPillSheet.todayPillNumber;
@@ -103,8 +105,9 @@ class PillSheetGroup with _$PillSheetGroup {
     }
 
     final passedPillCountForPillSheetTypes =
-        summarizedPillSheetPillDayCountWithPillSheetsToEndIndex(
-            pillSheets: pillSheets, endIndex: activedPillSheet.groupIndex);
+        summarizedPillCountWithPillSheetTypesToEndIndex(
+            pillSheetTypes: pillSheets.map((e) => e.pillSheetType).toList(),
+            endIndex: activedPillSheet.groupIndex);
 
     var sequentialLastTakenPillNumber =
         passedPillCountForPillSheetTypes + activedPillSheet.lastTakenPillNumber;


### PR DESCRIPTION
## Abstract
ピルシートの集計関数が間違えていた。単純に過去のピルシートの合計値を使う部分は置き換える。休薬期間分も合計する部分が不要だった

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [ ] リリースノートを追加した