### PR TITLE
Fix intent flag

### DIFF
--- a/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/PilllFirebaseMessagingService.kt
@@ -22,7 +22,7 @@ public class PilllFirebaseMessagingService: FirebaseMessagingService() {
         val mainActivityIntent = Intent(this, MainActivity::class.java).also {
             it.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
-        val openAppPendingIntent = PendingIntent.getActivity(this,1, mainActivityIntent, PendingIntent.FLAG_CANCEL_CURRENT)
+        val openAppPendingIntent = PendingIntent.getActivity(this, 1, mainActivityIntent, PendingIntent.FLAG_IMMUTABLE)
         val title = remoteMessage.data["title"]
         val body = remoteMessage.data["body"]
         val builder = NotificationCompat.Builder(this, getString(R.string.reminder_channel_id))
@@ -41,7 +41,7 @@ public class PilllFirebaseMessagingService: FirebaseMessagingService() {
                 action = "PILL_REMINDER"
             }
             val pendingIntent: PendingIntent =
-                    PendingIntent.getBroadcast(this, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT)
+                    PendingIntent.getBroadcast(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
 
             builder.addAction(0, "飲んだ", pendingIntent)
         }


### PR DESCRIPTION
## Abstract
Android 12以降のOSでプッシュ通知が受け取れなくなっていた

## Why


## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [ ] リリースノートを追加した