### PR TITLE
初期設定の設定時間の初期値を現在開いているアプリの時間にする

### DIFF
--- a/lib/domain/initial_setting/initial_setting_state.codegen.dart
+++ b/lib/domain/initial_setting/initial_setting_state.codegen.dart
@@ -21,7 +21,7 @@ class InitialSettingState with _$InitialSettingState {
   const factory InitialSettingState({
     @Default([]) List<PillSheetType> pillSheetTypes,
     InitialSettingTodayPillNumber? todayPillNumber,
-    @Default([]) List<ReminderTime> reminderTimes,
+    required List<ReminderTime> reminderTimes,
     @Default(true) bool isOnReminder,
     @Default(false) bool isLoading,
     @Default(false) bool userIsNotAnonymous,

--- a/lib/domain/initial_setting/initial_setting_state.codegen.dart
+++ b/lib/domain/initial_setting/initial_setting_state.codegen.dart
@@ -19,22 +19,13 @@ class InitialSettingTodayPillNumber with _$InitialSettingTodayPillNumber {
 class InitialSettingState with _$InitialSettingState {
   const InitialSettingState._();
   const factory InitialSettingState({
-    @Default([])
-        List<PillSheetType> pillSheetTypes,
+    @Default([]) List<PillSheetType> pillSheetTypes,
     InitialSettingTodayPillNumber? todayPillNumber,
-    @Default([
-      ReminderTime(hour: 20, minute: 0),
-      ReminderTime(hour: 21, minute: 0),
-    ])
-        List<ReminderTime> reminderTimes,
-    @Default(true)
-        bool isOnReminder,
-    @Default(false)
-        bool isLoading,
-    @Default(false)
-        bool userIsNotAnonymous,
-    @Default(false)
-        bool settingIsExist,
+    @Default([]) List<ReminderTime> reminderTimes,
+    @Default(true) bool isOnReminder,
+    @Default(false) bool isLoading,
+    @Default(false) bool userIsNotAnonymous,
+    @Default(false) bool settingIsExist,
     LinkAccountType? accountType,
   }) = _InitialSettingState;
 

--- a/lib/domain/initial_setting/initial_setting_state.codegen.dart
+++ b/lib/domain/initial_setting/initial_setting_state.codegen.dart
@@ -29,7 +29,7 @@ class InitialSettingState with _$InitialSettingState {
     LinkAccountType? accountType,
   }) = _InitialSettingState;
 
-  DateTime? reminderTimeOrDefault(int index) {
+  DateTime? reminderTimeOrNull(int index) {
     if (index < reminderTimes.length) {
       return reminderDateTime(index);
     }

--- a/lib/domain/initial_setting/initial_setting_state.codegen.dart
+++ b/lib/domain/initial_setting/initial_setting_state.codegen.dart
@@ -35,10 +35,10 @@ class InitialSettingState with _$InitialSettingState {
     }
     final n = now();
     if (index == 0) {
-      return DateTime(n.year, n.month, n.day, 20, 0, 0);
+      return DateTime(n.year, n.month, n.day, n.hour, 0, 0);
     }
     if (index == 1) {
-      return DateTime(n.year, n.month, n.day, 21, 0, 0);
+      return DateTime(n.year, n.month, n.day, n.hour + 1, 0, 0);
     }
     return null;
   }

--- a/lib/domain/initial_setting/initial_setting_state.codegen.freezed.dart
+++ b/lib/domain/initial_setting/initial_setting_state.codegen.freezed.dart
@@ -183,10 +183,7 @@ class _$InitialSettingStateTearOff {
   _InitialSettingState call(
       {List<PillSheetType> pillSheetTypes = const [],
       InitialSettingTodayPillNumber? todayPillNumber,
-      List<ReminderTime> reminderTimes = const [
-        ReminderTime(hour: 20, minute: 0),
-        ReminderTime(hour: 21, minute: 0)
-      ],
+      required List<ReminderTime> reminderTimes,
       bool isOnReminder = true,
       bool isLoading = false,
       bool userIsNotAnonymous = false,
@@ -398,10 +395,7 @@ class _$_InitialSettingState extends _InitialSettingState {
   const _$_InitialSettingState(
       {this.pillSheetTypes = const [],
       this.todayPillNumber,
-      this.reminderTimes = const [
-        ReminderTime(hour: 20, minute: 0),
-        ReminderTime(hour: 21, minute: 0)
-      ],
+      required this.reminderTimes,
       this.isOnReminder = true,
       this.isLoading = false,
       this.userIsNotAnonymous = false,
@@ -414,7 +408,6 @@ class _$_InitialSettingState extends _InitialSettingState {
   final List<PillSheetType> pillSheetTypes;
   @override
   final InitialSettingTodayPillNumber? todayPillNumber;
-  @JsonKey()
   @override
   final List<ReminderTime> reminderTimes;
   @JsonKey()
@@ -482,7 +475,7 @@ abstract class _InitialSettingState extends InitialSettingState {
   const factory _InitialSettingState(
       {List<PillSheetType> pillSheetTypes,
       InitialSettingTodayPillNumber? todayPillNumber,
-      List<ReminderTime> reminderTimes,
+      required List<ReminderTime> reminderTimes,
       bool isOnReminder,
       bool isLoading,
       bool userIsNotAnonymous,

--- a/lib/domain/initial_setting/initial_setting_store.dart
+++ b/lib/domain/initial_setting/initial_setting_store.dart
@@ -57,7 +57,7 @@ class InitialSettingStateStore extends StateNotifier<InitialSettingState> {
   ) : super(const InitialSettingState());
 
   StreamSubscription? _authServiceCanceller;
-  fetch() {
+  void fetch() {
     _authServiceCanceller = _authService.stream().listen((user) async {
       print("watch sign state user: $user");
 
@@ -186,11 +186,11 @@ class InitialSettingStateStore extends StateNotifier<InitialSettingState> {
     await _userDatastore.trial(setting);
   }
 
-  showHUD() {
+  void showHUD() {
     state = state.copyWith(isLoading: true);
   }
 
-  hideHUD() {
+  void hideHUD() {
     state = state.copyWith(isLoading: false);
   }
 }

--- a/lib/domain/initial_setting/initial_setting_store.dart
+++ b/lib/domain/initial_setting/initial_setting_store.dart
@@ -31,6 +31,7 @@ final initialSettingStoreProvider = StateNotifierProvider.autoDispose<
     ref.watch(pillSheetModifiedHistoryDatastoreProvider),
     ref.watch(pillSheetGroupDatastoreProvider),
     ref.watch(authServiceProvider),
+    now(),
   ),
 );
 
@@ -54,7 +55,13 @@ class InitialSettingStateStore extends StateNotifier<InitialSettingState> {
     this._pillSheetModifiedHistoryDatastore,
     this._pillSheetGroupDatastore,
     this._authService,
-  ) : super(const InitialSettingState());
+    DateTime _now,
+  ) : super(
+          InitialSettingState(reminderTimes: [
+            ReminderTime(hour: _now.hour, minute: 0),
+            ReminderTime(hour: _now.hour + 1, minute: 0),
+          ]),
+        );
 
   StreamSubscription? _authServiceCanceller;
   void fetch() {

--- a/lib/domain/initial_setting/reminder_times/initial_setting_reminder_times_page.dart
+++ b/lib/domain/initial_setting/reminder_times/initial_setting_reminder_times_page.dart
@@ -128,7 +128,7 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
     InitialSettingStateStore store,
   ) {
     analytics.logEvent(name: "show_initial_setting_reminder_picker");
-    final reminderDateTime = state.reminderTimeOrDefault(index);
+    final reminderDateTime = state.reminderTimeOrNull(index);
     final n = now();
     DateTime initialDateTime = reminderDateTime != null
         ? reminderDateTime
@@ -157,7 +157,7 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
     InitialSettingState state,
     int index,
   ) {
-    final reminderTime = state.reminderTimeOrDefault(index);
+    final reminderTime = state.reminderTimeOrNull(index);
     final formValue = reminderTime == null
         ? "--:--"
         : DateTimeFormatter.militaryTime(reminderTime);

--- a/lib/domain/initial_setting/reminder_times/initial_setting_reminder_times_page.dart
+++ b/lib/domain/initial_setting/reminder_times/initial_setting_reminder_times_page.dart
@@ -132,7 +132,7 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
     final n = now();
     DateTime initialDateTime = reminderDateTime != null
         ? reminderDateTime
-        : DateTime(n.year, n.month, n.day, 22, 0, 0);
+        : DateTime(n.year, n.month, n.day, n.hour, 0, 0);
     showModalBottomSheet(
       context: context,
       builder: (BuildContext context) {

--- a/lib/domain/initial_setting/reminder_times/initial_setting_reminder_times_page.dart
+++ b/lib/domain/initial_setting/reminder_times/initial_setting_reminder_times_page.dart
@@ -16,7 +16,7 @@ import 'package:flutter_svg/svg.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class InitialSettingReminderTimesPage extends HookConsumerWidget {
-  void _showDurationModalSheet(
+  void _showTimePicker(
     BuildContext context,
     int index,
     InitialSettingState state,
@@ -70,7 +70,7 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
           ),
           const SizedBox(height: 8),
           GestureDetector(
-            onTap: () => _showDurationModalSheet(context, index, state, store),
+            onTap: () => _showTimePicker(context, index, state, store),
             child: Container(
               width: 81,
               height: 48,

--- a/lib/domain/initial_setting/reminder_times/initial_setting_reminder_times_page.dart
+++ b/lib/domain/initial_setting/reminder_times/initial_setting_reminder_times_page.dart
@@ -16,82 +16,6 @@ import 'package:flutter_svg/svg.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class InitialSettingReminderTimesPage extends HookConsumerWidget {
-  void _showTimePicker(
-    BuildContext context,
-    int index,
-    InitialSettingState state,
-    InitialSettingStateStore store,
-  ) {
-    analytics.logEvent(name: "show_initial_setting_reminder_picker");
-    final reminderDateTime = state.reminderTimeOrDefault(index);
-    final n = now();
-    DateTime initialDateTime = reminderDateTime != null
-        ? reminderDateTime
-        : DateTime(n.year, n.month, n.day, 22, 0, 0);
-    showModalBottomSheet(
-      context: context,
-      builder: (BuildContext context) {
-        return TimePicker(
-          initialDateTime: initialDateTime,
-          done: (dateTime) {
-            analytics.logEvent(
-                name: "selected_times_initial_setting",
-                parameters: {"hour": dateTime.hour, "minute": dateTime.minute});
-            store.setReminderTime(
-                index: index, hour: dateTime.hour, minute: dateTime.minute);
-            Navigator.pop(context);
-          },
-        );
-      },
-    );
-  }
-
-  Widget _form(
-    BuildContext context,
-    InitialSettingStateStore store,
-    InitialSettingState state,
-    int index,
-  ) {
-    final reminderTime = state.reminderTimeOrDefault(index);
-    final formValue = reminderTime == null
-        ? "--:--"
-        : DateTimeFormatter.militaryTime(reminderTime);
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
-      child: Column(
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              SvgPicture.asset("images/alerm.svg"),
-              Text("通知${index + 1}",
-                  style: FontType.assisting.merge(TextColorStyle.main))
-            ],
-          ),
-          const SizedBox(height: 8),
-          GestureDetector(
-            onTap: () => _showTimePicker(context, index, state, store),
-            child: Container(
-              width: 81,
-              height: 48,
-              decoration: BoxDecoration(
-                borderRadius: const BorderRadius.all(Radius.circular(4)),
-                border: Border.all(
-                  width: 1,
-                  color: PilllColors.border,
-                ),
-              ),
-              child: Center(
-                child: Text(formValue,
-                    style: FontType.inputNumber.merge(TextColorStyle.gray)),
-              ),
-            ),
-          )
-        ],
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(initialSettingStoreProvider.notifier);
@@ -193,6 +117,82 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
             ),
           ),
         ),
+      ),
+    );
+  }
+
+  void _showTimePicker(
+    BuildContext context,
+    int index,
+    InitialSettingState state,
+    InitialSettingStateStore store,
+  ) {
+    analytics.logEvent(name: "show_initial_setting_reminder_picker");
+    final reminderDateTime = state.reminderTimeOrDefault(index);
+    final n = now();
+    DateTime initialDateTime = reminderDateTime != null
+        ? reminderDateTime
+        : DateTime(n.year, n.month, n.day, 22, 0, 0);
+    showModalBottomSheet(
+      context: context,
+      builder: (BuildContext context) {
+        return TimePicker(
+          initialDateTime: initialDateTime,
+          done: (dateTime) {
+            analytics.logEvent(
+                name: "selected_times_initial_setting",
+                parameters: {"hour": dateTime.hour, "minute": dateTime.minute});
+            store.setReminderTime(
+                index: index, hour: dateTime.hour, minute: dateTime.minute);
+            Navigator.pop(context);
+          },
+        );
+      },
+    );
+  }
+
+  Widget _form(
+    BuildContext context,
+    InitialSettingStateStore store,
+    InitialSettingState state,
+    int index,
+  ) {
+    final reminderTime = state.reminderTimeOrDefault(index);
+    final formValue = reminderTime == null
+        ? "--:--"
+        : DateTimeFormatter.militaryTime(reminderTime);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              SvgPicture.asset("images/alerm.svg"),
+              Text("通知${index + 1}",
+                  style: FontType.assisting.merge(TextColorStyle.main))
+            ],
+          ),
+          const SizedBox(height: 8),
+          GestureDetector(
+            onTap: () => _showTimePicker(context, index, state, store),
+            child: Container(
+              width: 81,
+              height: 48,
+              decoration: BoxDecoration(
+                borderRadius: const BorderRadius.all(Radius.circular(4)),
+                border: Border.all(
+                  width: 1,
+                  color: PilllColors.border,
+                ),
+              ),
+              child: Center(
+                child: Text(formValue,
+                    style: FontType.inputNumber.merge(TextColorStyle.gray)),
+              ),
+            ),
+          )
+        ],
       ),
     );
   }

--- a/test/domain/initial_setting/initial_setting_store_test.dart
+++ b/test/domain/initial_setting/initial_setting_store_test.dart
@@ -219,6 +219,11 @@ void main() {
   });
   group("#setReminderTime", () {
     test("replace default reminderTime", () {
+      final mockTodayRepository = MockTodayService();
+      todayRepository = mockTodayRepository;
+      when(mockTodayRepository.now())
+          .thenReturn(DateTime(2020, 9, 29, 20, 0, 0));
+
       final userDatastore = MockUserDatastore();
       final batchFactory = MockBatchFactory();
       final authService = MockAuthService();
@@ -255,7 +260,7 @@ void main() {
       final mockTodayRepository = MockTodayService();
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.now())
-          .thenReturn(DateTime(2020, 9, 29, 21, 0, 0));
+          .thenReturn(DateTime(2020, 9, 29, 20, 0, 0));
 
       final userDatastore = MockUserDatastore();
       final batchFactory = MockBatchFactory();

--- a/test/domain/initial_setting/initial_setting_store_test.dart
+++ b/test/domain/initial_setting/initial_setting_store_test.dart
@@ -252,6 +252,11 @@ void main() {
       ]);
     });
     test("add reminderTime", () {
+      final mockTodayRepository = MockTodayService();
+      todayRepository = mockTodayRepository;
+      when(mockTodayRepository.now())
+          .thenReturn(DateTime(2020, 9, 29, 21, 0, 0));
+
       final userDatastore = MockUserDatastore();
       final batchFactory = MockBatchFactory();
       final authService = MockAuthService();

--- a/test/entity/pill_sheet_test.dart
+++ b/test/entity/pill_sheet_test.dart
@@ -251,7 +251,6 @@ void main() {
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.now())
           .thenReturn(DateTime(2020, 9, 29, 23, 59, 59));
-      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-29"));
 
       final sheetType = PillSheetType.pillsheet_21;
       final model = PillSheet(
@@ -278,7 +277,6 @@ void main() {
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.now())
           .thenReturn(DateTime(2020, 9, 29, 23, 59, 59));
-      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-29"));
 
       final sheetType = PillSheetType.pillsheet_21;
       final model = PillSheet(
@@ -340,7 +338,6 @@ void main() {
       todayRepository = mockTodayRepository;
       when(mockTodayRepository.now())
           .thenReturn(DateTime(2020, 9, 30, 23, 59, 59));
-      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2020-09-30"));
 
       final sheetType = PillSheetType.pillsheet_21;
       final model = PillSheet(
@@ -497,8 +494,6 @@ void main() {
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2020-09-28"));
-        when(mockTodayRepository.now())
-            .thenReturn(DateTime.parse("2020-09-28"));
 
         final sheetType = PillSheetType.pillsheet_21;
         final model = PillSheet(
@@ -576,8 +571,6 @@ void main() {
         test("last rest duration is not ended", () {
           final mockTodayRepository = MockTodayService();
           todayRepository = mockTodayRepository;
-          when(mockTodayRepository.now())
-              .thenReturn(DateTime.parse("2020-09-28"));
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2020-09-28"));
 
@@ -665,8 +658,6 @@ void main() {
         todayRepository = mockTodayRepository;
         when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2022-05-10"));
-        when(mockTodayRepository.now())
-            .thenReturn(DateTime.parse("2022-05-10"));
 
         final sheetType = PillSheetType.pillsheet_21;
         final pillSheet = PillSheet(
@@ -720,8 +711,6 @@ void main() {
           todayRepository = mockTodayRepository;
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2022-05-10"));
-          when(mockTodayRepository.now())
-              .thenReturn(DateTime.parse("2022-05-10"));
 
           final sheetType = PillSheetType.pillsheet_21;
           final pillSheet = PillSheet(
@@ -752,8 +741,6 @@ void main() {
         test("last rest duration is ended", () {
           final mockTodayRepository = MockTodayService();
           todayRepository = mockTodayRepository;
-          when(mockTodayRepository.now())
-              .thenReturn(DateTime.parse("2022-05-10"));
           when(mockTodayRepository.now())
               .thenReturn(DateTime.parse("2022-05-10"));
 
@@ -790,8 +777,6 @@ void main() {
       test("restDurations isEmpty", () {
         final mockTodayRepository = MockTodayService();
         todayRepository = mockTodayRepository;
-        when(mockTodayRepository.now())
-            .thenReturn(DateTime.parse("2022-05-10"));
         when(mockTodayRepository.now())
             .thenReturn(DateTime.parse("2022-05-10"));
 


### PR DESCRIPTION
## Abstract
初期設定の設定時間の初期値を現在開いているアプリの時間にする。8時にアプリを開いていたら 8:00 と 9:00 が初期値として入っている

## Why
以前に仮決めで22:00で固定していた。だが、この時間帯に服用時刻の通知設定をするユーザーが多すぎるため負荷がこの時間帯だけやけに高くなっている。設定する時刻を散らすという意味で入れた対応であると同時に、よく考えたらPilllのアプリを触っている時刻に合わせておけば良いのでは。なぜならユーザーにとってその時刻がピルについて考えている or アプリに触れている時間ということになるから。と思ったのでこの対策を入れる

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した