### PR TITLE
Reflecting update provider value when user begin/end manual rest duration

### DIFF
--- a/lib/domain/record/record_page_state.codegen.dart
+++ b/lib/domain/record/record_page_state.codegen.dart
@@ -5,6 +5,7 @@ import 'package:pilll/entity/pill_sheet_group.codegen.dart';
 import 'package:pilll/entity/setting.codegen.dart';
 import 'package:pilll/error_log.dart';
 import 'package:pilll/provider/premium_and_trial.codegen.dart';
+import 'package:pilll/util/datetime/day.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:pilll/provider/shared_preference.dart';
 import 'package:pilll/service/auth.dart';
@@ -14,7 +15,7 @@ import 'package:pilll/util/shared_preference/keys.dart';
 part 'record_page_state.codegen.freezed.dart';
 
 final recordPageAsyncStateProvider =
-    Provider<AsyncValue<RecordPageState>>((ref) {
+    Provider.autoDispose<AsyncValue<RecordPageState>>((ref) {
   final latestPillSheetGroup = ref.watch(latestPillSheetGroupStreamProvider);
   final premiumAndTrial = ref.watch(premiumAndTrialProvider);
   final setting = ref.watch(settingStreamProvider);
@@ -54,6 +55,7 @@ final recordPageAsyncStateProvider =
               .getBool(BoolKey.premiumTrialBeginAnouncementIsClosed) ??
           false,
       isLinkedLoginProvider: ref.watch(isLinkedProvider),
+      timestamp: now(),
     ));
   } catch (error, stackTrace) {
     errorLogger.recordError(error, stackTrace);
@@ -76,6 +78,7 @@ class RecordPageState with _$RecordPageState {
     required bool premiumTrialGuideNotificationIsClosed,
     required bool premiumTrialBeginAnouncementIsClosed,
     required bool isLinkedLoginProvider,
+    required DateTime timestamp,
   }) = _RecordPageState;
 
   int get initialPageIndex {

--- a/lib/domain/record/record_page_state.codegen.dart
+++ b/lib/domain/record/record_page_state.codegen.dart
@@ -78,6 +78,7 @@ class RecordPageState with _$RecordPageState {
     required bool premiumTrialGuideNotificationIsClosed,
     required bool premiumTrialBeginAnouncementIsClosed,
     required bool isLinkedLoginProvider,
+    // Workaround for no update RecordPageStateNotifier when pillSheetGroup.activedPillSheet.restDurations is change
     required DateTime timestamp,
   }) = _RecordPageState;
 

--- a/lib/domain/record/record_page_state.codegen.dart
+++ b/lib/domain/record/record_page_state.codegen.dart
@@ -79,6 +79,7 @@ class RecordPageState with _$RecordPageState {
     required bool premiumTrialBeginAnouncementIsClosed,
     required bool isLinkedLoginProvider,
     // Workaround for no update RecordPageStateNotifier when pillSheetGroup.activedPillSheet.restDurations is change
+    // Add and always update timestamp when every stream or provider changed to avoid this issue
     required DateTime timestamp,
   }) = _RecordPageState;
 

--- a/lib/domain/record/record_page_state.codegen.freezed.dart
+++ b/lib/domain/record/record_page_state.codegen.freezed.dart
@@ -69,7 +69,9 @@ mixin _$RecordPageState {
       throw _privateConstructorUsedError;
   bool get premiumTrialBeginAnouncementIsClosed =>
       throw _privateConstructorUsedError;
-  bool get isLinkedLoginProvider => throw _privateConstructorUsedError;
+  bool get isLinkedLoginProvider =>
+      throw _privateConstructorUsedError; // Workaround for no update RecordPageStateNotifier when pillSheetGroup.activedPillSheet.restDurations is change
+// Add and always update timestamp when every stream or provider changed to avoid this issue
   DateTime get timestamp => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -357,7 +359,8 @@ class _$_RecordPageState extends _RecordPageState {
   final bool premiumTrialBeginAnouncementIsClosed;
   @override
   final bool isLinkedLoginProvider;
-  @override
+  @override // Workaround for no update RecordPageStateNotifier when pillSheetGroup.activedPillSheet.restDurations is change
+// Add and always update timestamp when every stream or provider changed to avoid this issue
   final DateTime timestamp;
 
   @override
@@ -460,7 +463,8 @@ abstract class _RecordPageState extends RecordPageState {
   bool get premiumTrialBeginAnouncementIsClosed;
   @override
   bool get isLinkedLoginProvider;
-  @override
+  @override // Workaround for no update RecordPageStateNotifier when pillSheetGroup.activedPillSheet.restDurations is change
+// Add and always update timestamp when every stream or provider changed to avoid this issue
   DateTime get timestamp;
   @override
   @JsonKey(ignore: true)

--- a/lib/domain/record/record_page_state.codegen.freezed.dart
+++ b/lib/domain/record/record_page_state.codegen.freezed.dart
@@ -29,7 +29,8 @@ class _$RecordPageStateTearOff {
       required bool recommendedSignupNotificationIsAlreadyShow,
       required bool premiumTrialGuideNotificationIsClosed,
       required bool premiumTrialBeginAnouncementIsClosed,
-      required bool isLinkedLoginProvider}) {
+      required bool isLinkedLoginProvider,
+      required DateTime timestamp}) {
     return _RecordPageState(
       pillSheetGroup: pillSheetGroup,
       setting: setting,
@@ -45,6 +46,7 @@ class _$RecordPageStateTearOff {
       premiumTrialBeginAnouncementIsClosed:
           premiumTrialBeginAnouncementIsClosed,
       isLinkedLoginProvider: isLinkedLoginProvider,
+      timestamp: timestamp,
     );
   }
 }
@@ -68,6 +70,7 @@ mixin _$RecordPageState {
   bool get premiumTrialBeginAnouncementIsClosed =>
       throw _privateConstructorUsedError;
   bool get isLinkedLoginProvider => throw _privateConstructorUsedError;
+  DateTime get timestamp => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $RecordPageStateCopyWith<RecordPageState> get copyWith =>
@@ -90,7 +93,8 @@ abstract class $RecordPageStateCopyWith<$Res> {
       bool recommendedSignupNotificationIsAlreadyShow,
       bool premiumTrialGuideNotificationIsClosed,
       bool premiumTrialBeginAnouncementIsClosed,
-      bool isLinkedLoginProvider});
+      bool isLinkedLoginProvider,
+      DateTime timestamp});
 
   $PillSheetGroupCopyWith<$Res>? get pillSheetGroup;
   $SettingCopyWith<$Res> get setting;
@@ -119,6 +123,7 @@ class _$RecordPageStateCopyWithImpl<$Res>
     Object? premiumTrialGuideNotificationIsClosed = freezed,
     Object? premiumTrialBeginAnouncementIsClosed = freezed,
     Object? isLinkedLoginProvider = freezed,
+    Object? timestamp = freezed,
   }) {
     return _then(_value.copyWith(
       pillSheetGroup: pillSheetGroup == freezed
@@ -168,6 +173,10 @@ class _$RecordPageStateCopyWithImpl<$Res>
           ? _value.isLinkedLoginProvider
           : isLinkedLoginProvider // ignore: cast_nullable_to_non_nullable
               as bool,
+      timestamp: timestamp == freezed
+          ? _value.timestamp
+          : timestamp // ignore: cast_nullable_to_non_nullable
+              as DateTime,
     ));
   }
 
@@ -215,7 +224,8 @@ abstract class _$RecordPageStateCopyWith<$Res>
       bool recommendedSignupNotificationIsAlreadyShow,
       bool premiumTrialGuideNotificationIsClosed,
       bool premiumTrialBeginAnouncementIsClosed,
-      bool isLinkedLoginProvider});
+      bool isLinkedLoginProvider,
+      DateTime timestamp});
 
   @override
   $PillSheetGroupCopyWith<$Res>? get pillSheetGroup;
@@ -249,6 +259,7 @@ class __$RecordPageStateCopyWithImpl<$Res>
     Object? premiumTrialGuideNotificationIsClosed = freezed,
     Object? premiumTrialBeginAnouncementIsClosed = freezed,
     Object? isLinkedLoginProvider = freezed,
+    Object? timestamp = freezed,
   }) {
     return _then(_RecordPageState(
       pillSheetGroup: pillSheetGroup == freezed
@@ -298,6 +309,10 @@ class __$RecordPageStateCopyWithImpl<$Res>
           ? _value.isLinkedLoginProvider
           : isLinkedLoginProvider // ignore: cast_nullable_to_non_nullable
               as bool,
+      timestamp: timestamp == freezed
+          ? _value.timestamp
+          : timestamp // ignore: cast_nullable_to_non_nullable
+              as DateTime,
     ));
   }
 }
@@ -316,7 +331,8 @@ class _$_RecordPageState extends _RecordPageState {
       required this.recommendedSignupNotificationIsAlreadyShow,
       required this.premiumTrialGuideNotificationIsClosed,
       required this.premiumTrialBeginAnouncementIsClosed,
-      required this.isLinkedLoginProvider})
+      required this.isLinkedLoginProvider,
+      required this.timestamp})
       : super._();
 
   @override
@@ -341,10 +357,12 @@ class _$_RecordPageState extends _RecordPageState {
   final bool premiumTrialBeginAnouncementIsClosed;
   @override
   final bool isLinkedLoginProvider;
+  @override
+  final DateTime timestamp;
 
   @override
   String toString() {
-    return 'RecordPageState(pillSheetGroup: $pillSheetGroup, setting: $setting, premiumAndTrial: $premiumAndTrial, totalCountOfActionForTakenPill: $totalCountOfActionForTakenPill, isAlreadyShowTiral: $isAlreadyShowTiral, isAlreadyShowPremiumSurvey: $isAlreadyShowPremiumSurvey, shouldShowMigrateInfo: $shouldShowMigrateInfo, recommendedSignupNotificationIsAlreadyShow: $recommendedSignupNotificationIsAlreadyShow, premiumTrialGuideNotificationIsClosed: $premiumTrialGuideNotificationIsClosed, premiumTrialBeginAnouncementIsClosed: $premiumTrialBeginAnouncementIsClosed, isLinkedLoginProvider: $isLinkedLoginProvider)';
+    return 'RecordPageState(pillSheetGroup: $pillSheetGroup, setting: $setting, premiumAndTrial: $premiumAndTrial, totalCountOfActionForTakenPill: $totalCountOfActionForTakenPill, isAlreadyShowTiral: $isAlreadyShowTiral, isAlreadyShowPremiumSurvey: $isAlreadyShowPremiumSurvey, shouldShowMigrateInfo: $shouldShowMigrateInfo, recommendedSignupNotificationIsAlreadyShow: $recommendedSignupNotificationIsAlreadyShow, premiumTrialGuideNotificationIsClosed: $premiumTrialGuideNotificationIsClosed, premiumTrialBeginAnouncementIsClosed: $premiumTrialBeginAnouncementIsClosed, isLinkedLoginProvider: $isLinkedLoginProvider, timestamp: $timestamp)';
   }
 
   @override
@@ -376,7 +394,8 @@ class _$_RecordPageState extends _RecordPageState {
                 other.premiumTrialBeginAnouncementIsClosed,
                 premiumTrialBeginAnouncementIsClosed) &&
             const DeepCollectionEquality()
-                .equals(other.isLinkedLoginProvider, isLinkedLoginProvider));
+                .equals(other.isLinkedLoginProvider, isLinkedLoginProvider) &&
+            const DeepCollectionEquality().equals(other.timestamp, timestamp));
   }
 
   @override
@@ -394,7 +413,8 @@ class _$_RecordPageState extends _RecordPageState {
       const DeepCollectionEquality()
           .hash(premiumTrialGuideNotificationIsClosed),
       const DeepCollectionEquality().hash(premiumTrialBeginAnouncementIsClosed),
-      const DeepCollectionEquality().hash(isLinkedLoginProvider));
+      const DeepCollectionEquality().hash(isLinkedLoginProvider),
+      const DeepCollectionEquality().hash(timestamp));
 
   @JsonKey(ignore: true)
   @override
@@ -414,7 +434,8 @@ abstract class _RecordPageState extends RecordPageState {
       required bool recommendedSignupNotificationIsAlreadyShow,
       required bool premiumTrialGuideNotificationIsClosed,
       required bool premiumTrialBeginAnouncementIsClosed,
-      required bool isLinkedLoginProvider}) = _$_RecordPageState;
+      required bool isLinkedLoginProvider,
+      required DateTime timestamp}) = _$_RecordPageState;
   const _RecordPageState._() : super._();
 
   @override
@@ -439,6 +460,8 @@ abstract class _RecordPageState extends RecordPageState {
   bool get premiumTrialBeginAnouncementIsClosed;
   @override
   bool get isLinkedLoginProvider;
+  @override
+  DateTime get timestamp;
   @override
   @JsonKey(ignore: true)
   _$RecordPageStateCopyWith<_RecordPageState> get copyWith =>

--- a/lib/domain/record/record_page_state_notifier.dart
+++ b/lib/domain/record/record_page_state_notifier.dart
@@ -10,8 +10,8 @@ import 'package:pilll/util/shared_preference/keys.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-final recordPageStateNotifierProvider =
-    StateNotifierProvider<RecordPageStateNotifier, AsyncValue<RecordPageState>>(
+final recordPageStateNotifierProvider = StateNotifierProvider.autoDispose<
+    RecordPageStateNotifier, AsyncValue<RecordPageState>>(
   (ref) => RecordPageStateNotifier(
     asyncAction: ref.watch(recordPageAsyncActionProvider),
     initialState: ref.watch(recordPageAsyncStateProvider),

--- a/test/domain/record/record_page_button_state_test.dart
+++ b/test/domain/record/record_page_button_state_test.dart
@@ -41,7 +41,8 @@ void main() {
         ProviderScope(
           overrides: [
             recordPageStateNotifierProvider.overrideWithProvider(
-                StateNotifierProvider((ref) => MockRecordPageStateNotifier())),
+                StateNotifierProvider.autoDispose(
+                    (ref) => MockRecordPageStateNotifier())),
           ],
           child: MaterialApp(
             home: RecordPageButton(
@@ -70,7 +71,8 @@ void main() {
       ProviderScope(
         overrides: [
           recordPageStateNotifierProvider.overrideWithProvider(
-              StateNotifierProvider((ref) => MockRecordPageStateNotifier())),
+              StateNotifierProvider.autoDispose(
+                  (ref) => MockRecordPageStateNotifier())),
         ],
         child: MaterialApp(
           home: RecordPageButton(

--- a/test/domain/record/record_page_store_test.dart
+++ b/test/domain/record/record_page_store_test.dart
@@ -94,6 +94,7 @@ void main() {
         premiumTrialGuideNotificationIsClosed: false,
         premiumTrialBeginAnouncementIsClosed: false,
         isLinkedLoginProvider: false,
+        timestamp: now(),
       );
 
       final container = ProviderContainer(
@@ -193,6 +194,7 @@ void main() {
         premiumTrialGuideNotificationIsClosed: false,
         premiumTrialBeginAnouncementIsClosed: false,
         isLinkedLoginProvider: false,
+        timestamp: now(),
       );
 
       final container = ProviderContainer(


### PR DESCRIPTION
## Abstract
手動での休薬を開始/終了した場合にRecordPageStateが更新されない

トレースしてみたところ、recordPageAsyncStateProviderには変更が2回きている(1回多い気がするけどそれは気にしない)。その後の recordPageStateNotifierProvider に変更通知が来てないためページが更新されていなかった
なお、休薬開始→UI変わらない→休薬開始をした場合にはUIは更新される。その場合に restDuration.endDate が nullのデータが2つ作られる。

原因がRiverpodのコードを読んでもパッとわからなかった。暫定策として、DateTime timestampをStateに追加する。この予想としてはネストした値だとうまくいかない(RiverpodがStateの比較を行なっている。freezedの比較がネストした場合にうまくいってない)と仮定して修正を行い実行したところ、期待通り作動した。ただ、コード読んだ限りだとselectでしか比較は使われてない気もするので関係なさそう。とりあえず治ったのでこのままで行く

ついでにRecordPageSateNotifier,RecordPageStateにautoDisposeをつけた。よく考えたらほしかった。↑の修正と一緒に行ってしまったため、因果関係は正確なところは不明

## Why

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した