### PR TITLE
Change premium trial communication

### DIFF
--- a/lib/domain/initial_setting/premium_trial/initial_setting_premium_trial_start_page.dart
+++ b/lib/domain/initial_setting/premium_trial/initial_setting_premium_trial_start_page.dart
@@ -26,7 +26,6 @@ class IntiialSettingPremiumTrialStartPage extends HookConsumerWidget {
         child: Column(
           children: [
             const Spacer(),
-            SvgPicture.asset("images/premium_trial_ribbon.svg"),
             Column(
               children: [
                 Container(
@@ -37,20 +36,11 @@ class IntiialSettingPremiumTrialStartPage extends HookConsumerWidget {
                   color: PilllColors.mat,
                   child: Column(
                     children: [
-                      const Text(
-                        "PRESENT",
-                        style: TextStyle(
-                          fontSize: 24,
-                          fontWeight: FontWeight.bold,
-                          color: TextColor.primaryDarkBlue,
-                          fontFamily: FontFamily.alphabet,
-                        ),
-                      ),
                       const SizedBox(height: 1),
                       Column(
                         children: [
                           const Text(
-                            "プレミアム体験プレゼント中",
+                            "\\ 通知から服用記録ができます /",
                             style: TextStyle(
                               fontSize: 20,
                               fontWeight: FontWeight.bold,
@@ -114,12 +104,11 @@ class IntiialSettingPremiumTrialStartPage extends HookConsumerWidget {
                 const SizedBox(height: 16),
                 const Text(
                   '''
-自動課金はされません。安心してお使いください
-30日後、自動で無料版に移行します
+30日間すべての機能が使えます！
 ''',
                   style: TextStyle(
                     color: TextColor.main,
-                    fontWeight: FontWeight.bold,
+                    fontWeight: FontWeight.w700,
                     fontFamily: FontFamily.japanese,
                     fontSize: 12,
                   ),

--- a/lib/domain/premium_trial/premium_trial_modal.dart
+++ b/lib/domain/premium_trial/premium_trial_modal.dart
@@ -132,7 +132,7 @@ class PremiumTrialModal extends HookConsumerWidget {
                           onPressed: () async {
                             analytics.logEvent(name: "pressed_trial_start");
                             try {
-                              await store.trial();
+                              store.trial();
                               Navigator.of(context).pop();
                               didEndTrial();
                             } catch (exception) {

--- a/lib/domain/premium_trial/premium_trial_modal_store.dart
+++ b/lib/domain/premium_trial/premium_trial_modal_store.dart
@@ -48,19 +48,19 @@ class PremiumTrialModalStateStore
     super.dispose();
   }
 
-  handleException(Object exception) {
+  void handleException(Object exception) {
     state = state.copyWith(exception: exception);
   }
 
-  showHUD() {
+  void showHUD() {
     state = state.copyWith(isLoading: true);
   }
 
-  hideHUD() {
+  void hideHUD() {
     state = state.copyWith(isLoading: false);
   }
 
-  trial() async {
+  void trial() async {
     if (state.isTrial && state.beginTrialDate != null) {
       state = state.copyWith(
           exception: "すでにトライアル中になっています。もし解決しない場合は設定>お問い合わせよりご連絡ください");

--- a/lib/domain/record/components/notification_bar/components/discount_price_deadline.dart
+++ b/lib/domain/record/components/notification_bar/components/discount_price_deadline.dart
@@ -30,7 +30,10 @@ class DiscountPriceDeadline extends HookConsumerWidget {
             Align(
               alignment: Alignment.center,
               child: Text(
-                "プレミアムお試し終了\n$countdown内の購入で48%OFFで購入できます",
+                """
+プレミアム登録で引き続きすべての機能が利用できます
+$countdown内の購入で48%OFF!
+""",
                 style: FontType.assistingBold.merge(TextColorStyle.white),
                 textAlign: TextAlign.center,
               ),

--- a/lib/domain/record/components/notification_bar/components/premium_trial_begin.dart
+++ b/lib/domain/record/components/notification_bar/components/premium_trial_begin.dart
@@ -46,7 +46,7 @@ class PremiumTrialBegin extends HookConsumerWidget {
             ),
             const Spacer(),
             Text(
-              "プレミアムお試し体験中（残り$latestDay日）",
+              "$latestDay日後まですべての機能を使えます",
               style: TextColorStyle.white.merge(FontType.descriptionBold),
               textAlign: TextAlign.center,
             ),

--- a/lib/domain/record/components/notification_bar/notification_bar_state.codegen.dart
+++ b/lib/domain/record/components/notification_bar/notification_bar_state.codegen.dart
@@ -82,6 +82,6 @@ class NotificationBarState with _$NotificationBarState {
     if (diff > 10) {
       return null;
     }
-    return "プレミアムお試し体験中（残り$diff日）";
+    return "$diff日後まですべての機能を使えます";
   }
 }

--- a/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
+++ b/lib/domain/record/components/pill_sheet/record_page_pill_sheet.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:pilll/analytics.dart';
 import 'package:pilll/components/organisms/pill_mark/pill_mark.dart';
 import 'package:pilll/components/organisms/pill_mark/pill_mark_line.dart';


### PR DESCRIPTION
## Abstract
プレミアムの `トライアル` を提供者側からのプレゼントとしてではなく、アプリの全機能を使用できる期間と位置付ける。そのためのワーディング調整

## Why

## Links
resolved: https://github.com/bannzai/_Pilll/issues/397


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した