### PR TITLE
Bugfix for record pill sheet history to non active pill sheet last pill number

### DIFF
--- a/lib/domain/record/util/take.dart
+++ b/lib/domain/record/util/take.dart
@@ -83,11 +83,23 @@ Future<PillSheetGroup?> take({
 
   final updatedPillSheetGroup =
       pillSheetGroup.copyWith(pillSheets: updatedPillSheets);
-  final updatedIndexses = pillSheetGroup.pillSheets.asMap().keys.where(
-        (index) =>
-            pillSheetGroup.pillSheets[index] !=
-            updatedPillSheetGroup.pillSheets[index],
-      );
+  final updatedIndexses = pillSheetGroup.pillSheets.asMap().keys.where((index) {
+    final updatedPillSheet = updatedPillSheetGroup.pillSheets[index];
+    if (pillSheetGroup.pillSheets[index] == updatedPillSheet) {
+      return false;
+    }
+
+    // 例えば2枚目のピルシート(groupIndex:1)がアクティブで、1枚目のピルシート(groupIndex:0)が最終日を記録した場合(28番目)、2枚目のピルシートのlastTakenDateが1枚目の28番目のピルシートのlastTakenDateと同じになる。
+    // その場合後続の処理で決定する履歴のafter: PillSheetの値が2枚目のピルシートの値になってしまう。これを避けるための条件式になっている
+    final updatedPillSheetLastTakenDate = updatedPillSheet.lastTakenDate;
+    if (updatedPillSheet.groupIndex == activedPillSheet.groupIndex &&
+        updatedPillSheetLastTakenDate != null &&
+        updatedPillSheet.beginingDate.isAfter(updatedPillSheetLastTakenDate)) {
+      return false;
+    }
+
+    return true;
+  }).toList();
 
   if (updatedIndexses.isEmpty) {
     return null;


### PR DESCRIPTION
## Abstract
アクティブなピルシートよりも過去のピルシートの最後のピル番号に対して服用した場合にafterLastTakenNumberの表記が0になってしまう問題を回避する

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [ ] リリースノートを追加した