### PR TITLE
Fix native record pill method

### DIFF
--- a/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
@@ -5,20 +5,37 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import androidx.core.app.NotificationManagerCompat
+import com.aboutyou.dart_packages.sign_in_with_apple.TAG
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.dart.DartExecutor
 import io.flutter.plugin.common.MethodChannel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 
 public class BroadCastActionReceiver: BroadcastReceiver() {
+    private val scope = CoroutineScope(SupervisorJob())
+
     override fun onReceive(context: Context?, intent: Intent?) {
         Log.d("android message: ", "onReceive")
         if (context != null && intent != null) {
             if (intent.action == "PILL_REMINDER") {
-                callRecordPill(context)
+                val pendingResult: PendingResult = goAsync()
+                val result = RecordPillResult(pendingResult)
+                scope.launch(Dispatchers.Default) {
+                    methodChannel(context).invokeMethod("recordPill", "", result)
+
+                    // Remove notification badge
+                    with(NotificationManagerCompat.from(context)) {
+                        cancel(PilllFirebaseMessagingService.regularlyMessageID)
+                    }
+                }
             }
         }
     }
+
     private fun methodChannel(context: Context): MethodChannel {
         val flutterEngine = FlutterEngine(context)
         flutterEngine
@@ -28,10 +45,22 @@ public class BroadCastActionReceiver: BroadcastReceiver() {
                 )
         return MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "method.channel.MizukiOhashi.Pilll")
     }
-    private fun callRecordPill(context: Context) {
-        methodChannel(context).invokeMethod("recordPill", "")
-        with(NotificationManagerCompat.from(context)) {
-            cancel(PilllFirebaseMessagingService.regularlyMessageID)
+
+    private class RecordPillResult(private val pendingResult: PendingResult): MethodChannel.Result {
+        override fun success(result: Any?) {
+            Log.d(TAG, "successfully record pill $result")
+            pendingResult.finish();
         }
+
+        override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+            Log.d(TAG, "errorCode: $errorCode, errorMessage: $errorMessage, errorDetails: $errorDetails")
+            pendingResult.finish();
+        }
+
+        override fun notImplemented() {
+            Log.d(TAG, "unexpected not implement method about record pill")
+            pendingResult.finish();
+        }
+
     }
 }

--- a/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
@@ -16,21 +16,17 @@ import kotlinx.coroutines.launch
 
 
 public class BroadCastActionReceiver: BroadcastReceiver() {
-    private val scope = CoroutineScope(SupervisorJob())
-
     override fun onReceive(context: Context?, intent: Intent?) {
         Log.d("android message: ", "onReceive")
         if (context != null && intent != null) {
             if (intent.action == "PILL_REMINDER") {
                 val pendingResult: PendingResult = goAsync()
                 val result = RecordPillResult(pendingResult)
-                scope.launch(Dispatchers.Default) {
-                    methodChannel(context).invokeMethod("recordPill", "", result)
+                methodChannel(context).invokeMethod("recordPill", "", result)
 
-                    // Remove notification from tray and remove notification badge
-                    with(NotificationManagerCompat.from(context)) {
-                        cancel(PilllFirebaseMessagingService.regularlyMessageID)
-                    }
+                // Remove notification from tray and remove notification badge
+                with(NotificationManagerCompat.from(context)) {
+                    cancel(PilllFirebaseMessagingService.regularlyMessageID)
                 }
             }
         }

--- a/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
@@ -27,7 +27,7 @@ public class BroadCastActionReceiver: BroadcastReceiver() {
                 scope.launch(Dispatchers.Default) {
                     methodChannel(context).invokeMethod("recordPill", "", result)
 
-                    // Remove notification badge
+                    // Remove notification from tray and remove notification badge
                     with(NotificationManagerCompat.from(context)) {
                         cancel(PilllFirebaseMessagingService.regularlyMessageID)
                     }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -107,16 +107,6 @@ import HealthKit
     }
 }
 
-// MARK: - Syntax Sugar
-extension AppDelegate {
-    static var instance: AppDelegate? {
-        UIApplication.shared.delegate as? AppDelegate
-    }
-    func invokeFlutterMethod(method: String, arguments: [String: Any]?) {
-        channel?.invokeMethod(method, arguments: arguments)
-    }
-}
-
 // MARK: - Avoid bug for flutter app badger
 // ref: https://github.com/g123k/flutter_app_badger/pull/52
 extension UNUserNotificationCenter {
@@ -144,7 +134,7 @@ extension UNUserNotificationCenter {
 extension AppDelegate {
     func migrateFrom_1_3_2() {
         if let salvagedValue = UserDefaults.standard.string(forKey: "startSavedDate"), let lastTakenDate = UserDefaults.standard.string(forKey: "savedDate") {
-            invokeFlutterMethod(method: "salvagedOldStartTakenDate", arguments: ["salvagedOldStartTakenDate": salvagedValue, "salvagedOldLastTakenDate": lastTakenDate])
+            channel?.invokeMethod("salvagedOldStartTakenDate", arguments: ["salvagedOldStartTakenDate": salvagedValue, "salvagedOldLastTakenDate": lastTakenDate])
         }
     }
 
@@ -182,8 +172,9 @@ extension AppDelegate {
         case .pillReminder:
             switch response.actionIdentifier {
             case "RECORD_PILL":
-                invokeFlutterMethod(method: "recordPill", arguments: nil)
-                end()
+                channel?.invokeMethod("recordPill", arguments: nil, result: { result in
+                    end()
+                })
             default:
                 end()
             }

--- a/lib/domain/settings/reminder_times_page.dart
+++ b/lib/domain/settings/reminder_times_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:pilll/domain/settings/setting_page_state.codegen.dart';
 import 'package:pilll/entity/setting.codegen.dart';
 import 'package:pilll/domain/settings/setting_page_state_notifier.dart';
@@ -160,21 +162,21 @@ class ReminderTimesPage extends HookConsumerWidget {
               : const ReminderTime(hour: 20, minute: 0).dateTime(),
           done: (dateTime) {
             if (isEditing) {
-              store.asyncAction
+              unawaited(store.asyncAction
                   .editReminderTime(
                     index: index,
                     reminderTime: ReminderTime(
                         hour: dateTime.hour, minute: dateTime.minute),
                     setting: setting,
                   )
-                  .catchError((error) => showErrorAlertFor(context, error));
+                  .catchError((error) => showErrorAlertFor(context, error)));
             } else {
-              store.asyncAction
+              unawaited(store.asyncAction
                   .addReminderTimes(
                       reminderTime: ReminderTime(
                           hour: dateTime.hour, minute: dateTime.minute),
                       setting: setting)
-                  .catchError((error) => showErrorAlertFor(context, error));
+                  .catchError((error) => showErrorAlertFor(context, error)));
             }
 
             Navigator.pop(context);

--- a/lib/domain/settings/reminder_times_page.dart
+++ b/lib/domain/settings/reminder_times_page.dart
@@ -159,7 +159,6 @@ class ReminderTimesPage extends HookConsumerWidget {
               ? setting.reminderTimes[index].dateTime()
               : const ReminderTime(hour: 20, minute: 0).dateTime(),
           done: (dateTime) {
-            Navigator.pop(context);
             if (isEditing) {
               store.asyncAction
                   .editReminderTime(
@@ -177,6 +176,8 @@ class ReminderTimesPage extends HookConsumerWidget {
                       setting: setting)
                   .catchError((error) => showErrorAlertFor(context, error));
             }
+
+            Navigator.pop(context);
           },
         );
       },

--- a/lib/domain/settings/today_pill_number/setting_today_pill_number_page.dart
+++ b/lib/domain/settings/today_pill_number/setting_today_pill_number_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/components/atoms/buttons.dart';
 import 'package:pilll/components/atoms/color.dart';
@@ -85,10 +87,10 @@ class SettingTodayPillNumberPage extends HookConsumerWidget {
                     children: [
                       PrimaryButton(
                         onPressed: () async {
-                          await store.modifiyTodayPillNumber(
+                          unawaited(store.modifiyTodayPillNumber(
                             pillSheetGroup: pillSheetGroup,
                             activedPillSheet: activedPillSheet,
-                          );
+                          ));
                           Navigator.of(context).pop();
                         },
                         text: "変更する",

--- a/lib/native/channel.dart
+++ b/lib/native/channel.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/services.dart';
-import 'package:pilll/error_log.dart';
 import 'package:pilll/native/legacy.dart';
 import 'package:pilll/native/pill.dart';
 
@@ -8,16 +7,9 @@ definedChannel() {
   methodChannel.setMethodCallHandler((MethodCall call) async {
     switch (call.method) {
       case 'recordPill':
-        await recordPill();
-        return;
+        return recordPill();
       case "salvagedOldStartTakenDate":
-        try {
-          await salvagedOldStartTakenDate(call.arguments);
-        } catch (error, stack) {
-          errorLogger.recordError(error, stack);
-          print(error);
-        }
-        return;
+        return salvagedOldStartTakenDate(call.arguments);
       default:
         break;
     }


### PR DESCRIPTION
## Abstract
.swift,.kotlinの方のピルのクイックレコードのメソッドの修正。callback引数があったのでそれを指定して処理完了までプロセス終了を待つようにする

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [ ] リリースノートを追加した