### PR TITLE
Remove unnecessary option

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,7 +7,6 @@ analyzer:
     missing_return: error
     invalid_annotation_target: ignore
   exclude:
-    - "lib/**/*.g.dart"
     - "lib/**/*.freezed.dart"
 
 linter:


### PR DESCRIPTION
## Abstract
ref: https://twitter.com/_mono/status/1536907414490222593?s=21&t=HpRWbx-Y8tCLLe88dpPwGA

*.g.dartに対してanalysis/excludeの指定が不要になったらしい

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [ ] リリースノートを追加した