### PR TITLE
runZonedGuardedで初期化処理を実行する

### DIFF
--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -21,28 +21,29 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 Future<void> entrypoint() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp();
-  if (kDebugMode) {
-    overrideDebugPrint();
-  }
-
-  if (Environment.isLocal) {
-    connectToEmulator();
-  }
-  ErrorWidget.builder = (FlutterErrorDetails details) {
-    return UniversalErrorPage(
-      error: details.exception.toString(),
-      child: null,
-      reload: () {
-        rootKey.currentState?.reload();
-      },
-    );
-  };
-  // MEMO: FirebaseCrashlytics#recordFlutterError called dumpErrorToConsole in function.
-  FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
-  definedChannel();
   runZonedGuarded(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    await Firebase.initializeApp();
+    if (kDebugMode) {
+      overrideDebugPrint();
+    }
+    if (Environment.isLocal) {
+      connectToEmulator();
+    }
+
+    ErrorWidget.builder = (FlutterErrorDetails details) {
+      return UniversalErrorPage(
+        error: details.exception.toString(),
+        child: null,
+        reload: () {
+          rootKey.currentState?.reload();
+        },
+      );
+    };
+    // MEMO: FirebaseCrashlytics#recordFlutterError called dumpErrorToConsole in function.
+    FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
+
+    definedChannel();
     runApp(ProviderScope(child: App()));
   }, (error, stack) => FirebaseCrashlytics.instance.recordError(error, stack));
 }


### PR DESCRIPTION
## Abstract
runZonedGuardedで初期化処理を実行する。主にFirebaseCrashlyticsを利用するために変更

## Why
https://firebase.google.com/docs/crashlytics/get-started?platform=flutter#add-sdk
よく見たら宣言位置が違った。全部runZonedGuardedに入れても問題なさそうだったのでそうする

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した