### PR TITLE
Add delay while begin main

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -171,12 +171,15 @@ extension AppDelegate {
         case .pillReminder:
             switch response.actionIdentifier {
             case "RECORD_PILL":
+                // 先にバッジをクリアしてしまう。後述の理由でQuickRecordが多少遅延するため操作に違和感が出る。この部分は楽観的UIとして更新してしまう
+                UIApplication.shared.applicationIconBadgeNumber = 0
+
                 // application(_:didFinishLaunchingWithOptions:)が終了してからFlutterのmainの開始は非同期的でFlutterのmainの完了までラグがある
                 // 特にアプリのプロセスがKillされている状態では、先にuserNotificationCenter(_:didReceive:withCompletionHandler:)の処理が走り
                 // Flutter側でのMethodChannelが確立される前にQuickRecordの呼び出しをおこなってしまう。この場合次にChanelが確立するまでFlutter側の処理の実行は遅延される。これは次のアプリの起動時まで遅延されるとほぼ同義になる
-                // よって対処療法的ではあるが、3秒待つことでほぼ間違いなくmain(の中でもMethodChanelの確立までは)の処理はすべて終えているとしてここではdelayを設けている。
+                // よって対処療法的ではあるが、5秒待つことでほぼ間違いなくmain(の中でもMethodChanelの確立までは)の処理はすべて終えているとしてここではdelayを設けている。
                 // ちなみに通常は1秒前後あれば十分であるが念のためくらいの間を持たせている
-                DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [self] in
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [self] in
                     channel?.invokeMethod("recordPill", arguments: nil, result: { result in
                         end()
                     })

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -174,9 +174,9 @@ extension AppDelegate {
                 // application(_:didFinishLaunchingWithOptions:)が終了してからFlutterのmainの開始は非同期的でFlutterのmainの完了までラグがある
                 // 特にアプリのプロセスがKillされている状態では、先にuserNotificationCenter(_:didReceive:withCompletionHandler:)の処理が走り
                 // Flutter側でのMethodChannelが確立される前にQuickRecordの呼び出しをおこなってしまう。この場合次にChanelが確立するまでFlutter側の処理の実行は遅延される。これは次のアプリの起動時まで遅延されるとほぼ同義になる
-                // よって対処療法的ではあるが、5秒待つことでほぼ間違いなくmain(の中でもMethodChanelの確立までは)の処理はすべて終えているとしてここではdelayを設けている。
+                // よって対処療法的ではあるが、3秒待つことでほぼ間違いなくmain(の中でもMethodChanelの確立までは)の処理はすべて終えているとしてここではdelayを設けている。
                 // ちなみに通常は1秒前後あれば十分であるが念のためくらいの間を持たせている
-                DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [self] in
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [self] in
                     channel?.invokeMethod("recordPill", arguments: nil, result: { result in
                         end()
                     })

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -15,7 +15,7 @@ import HealthKit
             name: "method.channel.MizukiOhashi.Pilll",
             binaryMessenger: viewController.binaryMessenger
         )
-        // DO NOT OVERRIDE AGAIN
+        // DO NOT OVERRIDE
         channel?.setMethodCallHandler({ call, _completionHandler in
             let completionHandler: (Dictionary<String, Any>) -> Void = {
                 _completionHandler($0)
@@ -150,7 +150,6 @@ extension AppDelegate {
         UNUserNotificationCenter.current().setNotificationCategories([category])
     }
 
-
     override func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         func end() {
             var isCompleted: Bool = false
@@ -172,9 +171,16 @@ extension AppDelegate {
         case .pillReminder:
             switch response.actionIdentifier {
             case "RECORD_PILL":
-                channel?.invokeMethod("recordPill", arguments: nil, result: { result in
-                    end()
-                })
+                // application(_:didFinishLaunchingWithOptions:)が終了してからFlutterのmainの開始は非同期的でFlutterのmainの完了までラグがある
+                // 特にアプリのプロセスがKillされている状態では、先にuserNotificationCenter(_:didReceive:withCompletionHandler:)の処理が走り
+                // Flutter側でのMethodChannelが確立される前にQuickRecordの呼び出しをおこなってしまう。この場合次にChanelが確立するまでFlutter側の処理の実行は遅延される。これは次のアプリの起動時まで遅延されるとほぼ同義になる
+                // よって対処療法的ではあるが、5秒待つことでほぼ間違いなくmain(の中でもMethodChanelの確立までは)の処理はすべて終えているとしてここではdelayを設けている。
+                // ちなみに通常は1秒前後あれば十分であるが念のためくらいの間を持たせている
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [self] in
+                    channel?.invokeMethod("recordPill", arguments: nil, result: { result in
+                        end()
+                    })
+                }
             default:
                 end()
             }

--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -25,6 +25,7 @@ Future<void> entrypoint() async {
     WidgetsFlutterBinding.ensureInitialized();
     await Firebase.initializeApp();
     // QuickRecordの処理などFirebaseを使用するのでFirebase.initializeApp()の後に時刻する
+    // また、同じくQuickRecordの処理開始までにMethodChannelが確立されていてほしいのでこの処理はなるべく早く実行する
     definedChannel();
 
     if (kDebugMode) {

--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -24,6 +24,9 @@ Future<void> entrypoint() async {
   runZonedGuarded(() async {
     WidgetsFlutterBinding.ensureInitialized();
     await Firebase.initializeApp();
+    // QuickRecordの処理などFirebaseを使用するのでFirebase.initializeApp()の後に時刻する
+    definedChannel();
+
     if (kDebugMode) {
       overrideDebugPrint();
     }
@@ -42,8 +45,6 @@ Future<void> entrypoint() async {
     };
     // MEMO: FirebaseCrashlytics#recordFlutterError called dumpErrorToConsole in function.
     FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
-
-    definedChannel();
     runApp(ProviderScope(child: App()));
   }, (error, stack) => FirebaseCrashlytics.instance.recordError(error, stack));
 }

--- a/lib/native/channel.dart
+++ b/lib/native/channel.dart
@@ -3,7 +3,7 @@ import 'package:pilll/native/legacy.dart';
 import 'package:pilll/native/pill.dart';
 
 final methodChannel = const MethodChannel("method.channel.MizukiOhashi.Pilll");
-definedChannel() {
+void definedChannel() {
   methodChannel.setMethodCallHandler((MethodCall call) async {
     switch (call.method) {
       case 'recordPill':

--- a/lib/native/pill.dart
+++ b/lib/native/pill.dart
@@ -51,6 +51,9 @@ Future<void> recordPill() async {
     isQuickRecord: true,
   );
 
+  // NOTE: iOSではAppDelegate.swiftの方で先にバッジのカウントはクリアしている
+  FlutterAppBadger.removeBadge();
+
   // NOTE: Firebase initializeが成功しているかが定かでは無いので一番最後にログを送る
   analytics.logEvent(name: "quick_recorded");
 }

--- a/lib/native/pill.dart
+++ b/lib/native/pill.dart
@@ -51,7 +51,6 @@ Future<void> recordPill() async {
     isQuickRecord: true,
   );
 
-  FlutterAppBadger.removeBadge();
   // NOTE: Firebase initializeが成功しているかが定かでは無いので一番最後にログを送る
   analytics.logEvent(name: "quick_recorded");
 }


### PR DESCRIPTION
## Abstract
特にアプリがKilledな状態でQuickRecordが不発する現象があったので修正する

> // application(_:didFinishLaunchingWithOptions:)が終了してからFlutterのmainの開始は非同期的でFlutterのmainの完了までラグがある
> // 特にアプリのプロセスがKillされている状態では、先にuserNotificationCenter(_:didReceive:withCompletionHandler:)の処理が走り
> // Flutter側でのMethodChannelが確立される前にQuickRecordの呼び出しをおこなってしまう。この場合次にChanelが確立するまでFlutter側の処理の実行は遅延される。これは次のアプリの起動時まで遅延されるとほぼ同義になる
> // よって対処療法的ではあるが、3秒待つことでほぼ間違いなくmain(の中でもMethodChanelの確立までは)の処理はすべて終えているとしてここではdelayを設けている。
> // ちなみに通常は1秒前後あれば十分であるが念のためくらいの間を持たせている

Androidでは現象未確認なのでノータッチ
## Why

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した