### PR TITLE
Refactor Navigator.of(context).pop timing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@
 
 ## Checked
 - [ ] Analyticsのログを入れたか
+- [ ] Navigator.of(context).pop() の後にContextを使用したメソッドを実行していない
 - [ ] 境界値に対してのUnitTestを書いた
 - [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
 - [ ] リリースノートを追加した

--- a/lib/domain/menstruation/components/menstruation_record_button.dart
+++ b/lib/domain/menstruation/components/menstruation_record_button.dart
@@ -5,6 +5,7 @@ import 'package:pilll/domain/menstruation/menstruation_state.codegen.dart';
 import 'package:pilll/domain/menstruation_edit/menstruation_edit_page.dart';
 import 'package:pilll/domain/menstruation/menstruation_select_modify_type_sheet.dart';
 import 'package:pilll/domain/menstruation/menstruation_page_state_notifier.dart';
+import 'package:pilll/entity/menstruation.codegen.dart';
 import 'package:pilll/util/datetime/day.dart';
 import 'package:pilll/util/formatter/date_time_formatter.dart';
 
@@ -13,10 +14,12 @@ class MenstruationRecordButton extends StatelessWidget {
     Key? key,
     required this.state,
     required this.store,
+    required this.onRecord,
   }) : super(key: key);
 
   final MenstruationState state;
   final MenstruationPageStateNotifier store;
+  final Function(Menstruation) onRecord;
 
   @override
   Widget build(BuildContext context) {
@@ -42,30 +45,18 @@ class MenstruationRecordButton extends StatelessWidget {
             switch (type) {
               case MenstruationSelectModifyType.today:
                 analytics.logEvent(name: "tapped_menstruation_record_today");
-                Navigator.of(context).pop();
                 final created =
                     await store.asyncAction.recordFromToday(setting: setting);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    duration: const Duration(seconds: 2),
-                    content: Text(
-                        "${DateTimeFormatter.monthAndDay(created.beginDate)}から生理開始で記録しました"),
-                  ),
-                );
+                onRecord(created);
+                Navigator.of(context).pop();
                 return;
               case MenstruationSelectModifyType.yesterday:
                 analytics.logEvent(
                     name: "tapped_menstruation_record_yesterday");
-                Navigator.of(context).pop();
                 final created = await store.asyncAction
                     .recordFromYesterday(setting: setting);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    duration: const Duration(seconds: 2),
-                    content: Text(
-                        "${DateTimeFormatter.monthAndDay(created.beginDate)}から生理開始で記録しました"),
-                  ),
-                );
+                onRecord(created);
+                Navigator.of(context).pop();
                 return;
               case MenstruationSelectModifyType.begin:
                 analytics.logEvent(name: "tapped_menstruation_record_begin");

--- a/lib/domain/menstruation/menstruation_page.dart
+++ b/lib/domain/menstruation/menstruation_page.dart
@@ -14,6 +14,7 @@ import 'package:pilll/domain/record/weekday_badge.dart';
 import 'package:pilll/domain/menstruation/menstruation_page_state_notifier.dart';
 import 'package:pilll/error/universal_error_page.dart';
 import 'package:pilll/hooks/automatic_keep_alive_client_mixin.dart';
+import 'package:pilll/util/formatter/date_time_formatter.dart';
 
 abstract class MenstruationPageConst {
   static const double calendarHeaderDropShadowOffset = 2;
@@ -100,7 +101,18 @@ class MenstruationPageBody extends StatelessWidget {
               alignment: Alignment.bottomCenter,
               child: Padding(
                 padding: const EdgeInsets.only(bottom: 20.0),
-                child: MenstruationRecordButton(state: state, store: store),
+                child: MenstruationRecordButton(
+                    state: state,
+                    store: store,
+                    onRecord: (menstruation) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          duration: const Duration(seconds: 2),
+                          content: Text(
+                              "${DateTimeFormatter.monthAndDay(menstruation.beginDate)}から生理開始で記録しました"),
+                        ),
+                      );
+                    }),
               ),
             ),
           ],

--- a/lib/domain/menstruation_edit/menstruation_edit_page.dart
+++ b/lib/domain/menstruation_edit/menstruation_edit_page.dart
@@ -140,13 +140,13 @@ void showMenstruationEditPage(
         Navigator.of(context).pop();
       },
       onDeleted: () {
-        Navigator.of(context).pop();
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             duration: Duration(seconds: 2),
             content: Text("生理期間を削除しました"),
           ),
         );
+        Navigator.of(context).pop();
       },
     ),
     backgroundColor: Colors.transparent,

--- a/lib/domain/menstruation_edit/menstruation_edit_page.dart
+++ b/lib/domain/menstruation_edit/menstruation_edit_page.dart
@@ -121,7 +121,6 @@ void showMenstruationEditPage(
     builder: (context) => MenstruationEditPage(
       menstruation: menstruation,
       onSaved: (savedMenstruation) {
-        Navigator.of(context).pop();
         if (menstruation == null) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -138,6 +137,7 @@ void showMenstruationEditPage(
             ),
           );
         }
+        Navigator.of(context).pop();
       },
       onDeleted: () {
         Navigator.of(context).pop();

--- a/lib/domain/premium_introduction/premium_complete_dialog.dart
+++ b/lib/domain/premium_introduction/premium_complete_dialog.dart
@@ -4,6 +4,7 @@ import 'package:pilll/components/atoms/buttons.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 
+
 class PremiumCompleteDialog extends StatelessWidget {
   final VoidCallback onClose;
 

--- a/lib/domain/record/components/supports/components/rest_duration/begin_manual_rest_duration_button.dart
+++ b/lib/domain/record/components/supports/components/rest_duration/begin_manual_rest_duration_button.dart
@@ -48,7 +48,6 @@ class BeginManualRestDurationButton extends StatelessWidget {
                 analytics.logEvent(name: "done_rest_duration");
                 // NOTE: batch.commit でリモートのDBに書き込む時間がかかるので事前にバッジを0にする
                 FlutterAppBadger.removeBadge();
-                Navigator.of(context).pop();
                 await store.asyncAction.beginRestDuration(
                   pillSheetGroup: pillSheetGroup,
                   activedPillSheet: activedPillSheet,

--- a/lib/domain/record/components/supports/record_page_pill_sheet_support_actions.dart
+++ b/lib/domain/record/components/supports/record_page_pill_sheet_support_actions.dart
@@ -86,6 +86,7 @@ class RecordPagePillSheetSupportActions extends StatelessWidget {
                     content: Text("休薬期間が始まりました"),
                   ),
                 );
+                Navigator.of(context).pop();
               },
             ),
           ],

--- a/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/domain/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -90,8 +90,6 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
                                     name: 'a_c_l_apple_long_press_result',
                                     parameters: {"success": isSuccess});
 
-                                Navigator.of(context).pop();
-
                                 ScaffoldMessenger.of(context).showSnackBar(
                                   SnackBar(
                                     duration: const Duration(seconds: 2),
@@ -100,6 +98,7 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
                                         : "認証情報を更新に失敗しました"),
                                   ),
                                 );
+                                Navigator.of(context).pop();
                               } catch (error) {
                                 showErrorAlert(context, error);
                               }
@@ -147,8 +146,6 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
                                     name: 'a_c_l_google_long_press_result',
                                     parameters: {"success": isSuccess});
 
-                                Navigator.of(context).pop();
-
                                 ScaffoldMessenger.of(context).showSnackBar(
                                   SnackBar(
                                     duration: const Duration(seconds: 2),
@@ -157,6 +154,7 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
                                         : "認証情報を更新に失敗しました"),
                                   ),
                                 );
+                                Navigator.of(context).pop();
                               } catch (error) {
                                 showErrorAlert(context, error);
                               }


### PR DESCRIPTION
## Abstract
Navigator.of(context).pop()を利用した後でcontextを使用している処理が無いようにする
回避策としてはNavigator.of(context).pop()の前で行う。もしくは、final navigator = Navigator.of(context); を作って必要な処理が済んだら pop メソッドを呼ぶ。になるが今回は後者の必要はなさそうだったので前者のみで調整する

## Why
popされた後に、popずみのContextを見ることで挙動が変になる

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した