### PR TITLE
Fix stream

### DIFF
--- a/lib/database/diary.dart
+++ b/lib/database/diary.dart
@@ -70,12 +70,11 @@ class DiaryDatastore {
     return _database.diaryReference(diary).delete().then((_) => diary);
   }
 
-  late final Stream<List<Diary>> _stream = _database
+  Stream<List<Diary>> stream() => _database
       .diariesReference()
       .snapshots()
       .map((event) => event.docs.map((e) => e.data()).toList())
       .map((diaries) => sortedDiaries(diaries));
-  Stream<List<Diary>> stream() => _stream;
 
   Stream<List<Diary>> streamForMonth({required DateTime dateForMonth}) {
     final firstDate = DateTime(dateForMonth.year, dateForMonth.month, 1);

--- a/lib/database/pill_sheet_group.dart
+++ b/lib/database/pill_sheet_group.dart
@@ -45,10 +45,8 @@ class PillSheetGroupDatastore {
     return snapshot.docs[0].data();
   }
 
-  late final Stream<PillSheetGroup?> _latestPillSheetGroupStream =
-      _latestQuery().snapshots().map(((event) => _filter(event)));
   Stream<PillSheetGroup?> latestPillSheetGroupStream() =>
-      _latestPillSheetGroupStream;
+      _latestQuery().snapshots().map(((event) => _filter(event)));
 
   // Return new PillSheet document id
   PillSheetGroup register(WriteBatch batch, PillSheetGroup pillSheetGroup) {

--- a/lib/database/setting.dart
+++ b/lib/database/setting.dart
@@ -23,13 +23,12 @@ class SettingDatastore {
         .then((event) => event.data()!.setting!);
   }
 
-  late final Stream<Setting> _stream = _database
+  Stream<Setting> stream() => _database
       .userReference()
       .snapshots()
       .map((event) => event.data()?.setting)
       .where((data) => data != null)
       .cast();
-  Stream<Setting> stream() => _stream;
 
   Future<Setting> update(Setting setting) {
     return _database

--- a/lib/database/user.dart
+++ b/lib/database/user.dart
@@ -51,9 +51,8 @@ class UserDatastore {
     return document.data()!;
   }
 
-  late final Stream<User> _stream =
+  Stream<User> stream() =>
       _database.userReference().snapshots().map((event) => event.data()!);
-  Stream<User> stream() => _stream;
 
   Future<void> updatePurchaseInfo({
     required bool? isActivated,

--- a/lib/domain/menstruation/components/menstruation_record_button.dart
+++ b/lib/domain/menstruation/components/menstruation_record_button.dart
@@ -7,7 +7,6 @@ import 'package:pilll/domain/menstruation/menstruation_select_modify_type_sheet.
 import 'package:pilll/domain/menstruation/menstruation_page_state_notifier.dart';
 import 'package:pilll/entity/menstruation.codegen.dart';
 import 'package:pilll/util/datetime/day.dart';
-import 'package:pilll/util/formatter/date_time_formatter.dart';
 
 class MenstruationRecordButton extends StatelessWidget {
   const MenstruationRecordButton({


### PR DESCRIPTION
## Abstract
Streamの宣言方法の変更。下位互換のためにDatabaseのインタフェースを保っていたが、挙動的には変更後のものでも問題ないので少しリファクタリングした

## Why

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] Navigator.of(context).pop() の後にContextを使用したメソッドを実行していない
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した