### PR TITLE
Bugfix take pill

### DIFF
--- a/lib/domain/record/util/take.dart
+++ b/lib/domain/record/util/take.dart
@@ -52,7 +52,6 @@ Future<PillSheetGroup?> takePill({
     final updatedPillSheetLastTakenDate = updatedPillSheet.lastTakenDate;
     if (updatedPillSheet.groupIndex == activedPillSheet.groupIndex &&
         updatedPillSheetLastTakenDate != null) {
-      // 同じ日時の時に服用記録されないが、秒数まで同じ場合はレアケースなので無視する
       final begin = updatedPillSheet.beginingDate;
       if (begin.date().isAfter(updatedPillSheetLastTakenDate)) {
         return false;

--- a/lib/domain/record/util/take.dart
+++ b/lib/domain/record/util/take.dart
@@ -4,6 +4,8 @@ import 'package:pilll/entity/pill_sheet_group.codegen.dart';
 import 'package:pilll/database/pill_sheet.dart';
 import 'package:pilll/database/pill_sheet_group.dart';
 import 'package:pilll/database/pill_sheet_modified_history.dart';
+import 'package:pilll/util/datetime/date_compare.dart';
+import 'package:pilll/util/datetime/day.dart';
 
 Future<PillSheetGroup?> takePill({
   required DateTime takenDate,
@@ -50,16 +52,18 @@ Future<PillSheetGroup?> takePill({
     // その場合後続の処理で決定する履歴のafter: PillSheetの値が2枚目のピルシートの値になってしまう。これを避けるための条件式になっている
     final updatedPillSheetLastTakenDate = updatedPillSheet.lastTakenDate;
     if (updatedPillSheet.groupIndex == activedPillSheet.groupIndex &&
-        updatedPillSheetLastTakenDate != null &&
-        updatedPillSheet.beginingDate.isAfter(updatedPillSheetLastTakenDate)) {
-      // index(pillSheet.groupIndex) == 0 の時は上記の条件に該当してしまう。
-      // 同じ結果になり他の書き方をすると
-      // beforeUpdatePillSheet(updatedPillSheetGroup.pillSheets[index - 1]).groupIndex != updatedPillSheet.groupIndex となる
-      if (index > 0) {
-        return false;
-      } else {
-        return true;
+        updatedPillSheetLastTakenDate != null) {
+      // 同じ日時の時に服用記録されないが、秒数まで同じ場合はレアケースなので無視する
+      final begin = updatedPillSheet.beginingDate;
+      if (begin.date().isAfter(updatedPillSheetLastTakenDate)) {
+        // pillSheet.groupIndex == 0 の時は単体のピルシートの状態のみで上記の条件に該当してしまう。
+        // 1つ目のピルシートの一番目のピルの服用記録をつけた後に取り消してもう一度服用した場合に服用できないが該当する
+        if (index > 0) {
+          return false;
+        }
       }
+
+      return true;
     }
 
     return true;

--- a/lib/domain/record/util/take.dart
+++ b/lib/domain/record/util/take.dart
@@ -4,7 +4,6 @@ import 'package:pilll/entity/pill_sheet_group.codegen.dart';
 import 'package:pilll/database/pill_sheet.dart';
 import 'package:pilll/database/pill_sheet_group.dart';
 import 'package:pilll/database/pill_sheet_modified_history.dart';
-import 'package:pilll/util/datetime/date_compare.dart';
 import 'package:pilll/util/datetime/day.dart';
 
 Future<PillSheetGroup?> takePill({
@@ -56,14 +55,8 @@ Future<PillSheetGroup?> takePill({
       // 同じ日時の時に服用記録されないが、秒数まで同じ場合はレアケースなので無視する
       final begin = updatedPillSheet.beginingDate;
       if (begin.date().isAfter(updatedPillSheetLastTakenDate)) {
-        // pillSheet.groupIndex == 0 の時は単体のピルシートの状態のみで上記の条件に該当してしまう。
-        // 1つ目のピルシートの一番目のピルの服用記録をつけた後に取り消してもう一度服用した場合に服用できないが該当する
-        if (index > 0) {
-          return false;
-        }
+        return false;
       }
-
-      return true;
     }
 
     return true;

--- a/lib/domain/record/util/take.dart
+++ b/lib/domain/record/util/take.dart
@@ -56,6 +56,9 @@ Future<PillSheetGroup?> takePill({
           final previousUpdatedPillSheetLastTakenDate = previousUpdatedPillSheet.lastTakenDate;
           final updatedPillSheetLastTakenDate = updatedPillSheet.lastTakenDate;
 
+          // 事前処理でnullではないはず
+          assert(previousUpdatedPillSheetLastTakenDate != null && updatedPillSheetLastTakenDate != null,
+              "previousUpdatedPillSheetLastTakenDate != null && updatedPillSheetLastTakenDate != null");
           if (previousUpdatedPillSheetLastTakenDate != null && updatedPillSheetLastTakenDate != null) {
             if (isSameDay(previousUpdatedPillSheetLastTakenDate, updatedPillSheetLastTakenDate)) {
               return false;

--- a/lib/domain/record/util/take.dart
+++ b/lib/domain/record/util/take.dart
@@ -40,8 +40,7 @@ Future<PillSheetGroup?> takePill({
     }
   }).toList();
 
-  final updatedPillSheetGroup =
-      pillSheetGroup.copyWith(pillSheets: updatedPillSheets);
+  final updatedPillSheetGroup = pillSheetGroup.copyWith(pillSheets: updatedPillSheets);
   final updatedIndexses = pillSheetGroup.pillSheets.asMap().keys.where((index) {
     final updatedPillSheet = updatedPillSheetGroup.pillSheets[index];
     if (pillSheetGroup.pillSheets[index] == updatedPillSheet) {
@@ -52,18 +51,13 @@ Future<PillSheetGroup?> takePill({
     // その場合後続の処理で決定する履歴のafter: PillSheetの値が2枚目のピルシートの値になってしまう。これを避けるための条件式になっている
     if (updatedPillSheet.groupIndex == activedPillSheet.groupIndex) {
       if (index > 0) {
-        final previousUpdatedPillSheet =
-            updatedPillSheetGroup.pillSheets[index - 1];
-        if (isSameDay(
-            previousUpdatedPillSheet.estimatedEndTakenDate, takenDate)) {
-          final previousUpdatedPillSheetLastTakenDate =
-              previousUpdatedPillSheet.lastTakenDate;
+        final previousUpdatedPillSheet = updatedPillSheetGroup.pillSheets[index - 1];
+        if (isSameDay(previousUpdatedPillSheet.estimatedEndTakenDate, takenDate)) {
+          final previousUpdatedPillSheetLastTakenDate = previousUpdatedPillSheet.lastTakenDate;
           final updatedPillSheetLastTakenDate = updatedPillSheet.lastTakenDate;
 
-          if (previousUpdatedPillSheetLastTakenDate != null &&
-              updatedPillSheetLastTakenDate != null) {
-            if (isSameDay(previousUpdatedPillSheetLastTakenDate,
-                updatedPillSheetLastTakenDate)) {
+          if (previousUpdatedPillSheetLastTakenDate != null && updatedPillSheetLastTakenDate != null) {
+            if (isSameDay(previousUpdatedPillSheetLastTakenDate, updatedPillSheetLastTakenDate)) {
               return false;
             }
           }
@@ -86,8 +80,7 @@ Future<PillSheetGroup?> takePill({
 
   final before = pillSheetGroup.pillSheets[updatedIndexses.first];
   final after = updatedPillSheetGroup.pillSheets[updatedIndexses.last];
-  final history =
-      PillSheetModifiedHistoryServiceActionFactory.createTakenPillAction(
+  final history = PillSheetModifiedHistoryServiceActionFactory.createTakenPillAction(
     pillSheetGroupID: pillSheetGroup.id,
     before: before,
     after: after,


### PR DESCRIPTION
## Abstract
ref: https://github.com/bannzai/Pilll/pull/641

beginの方が時間部分が大きい場合があって服用記録ができなかった(差分がないと判断された)ので修正。beginの時間を00:00:00にする。

起きる場合はピルシート作った時間をbeginにしていたので発生していた

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] Navigator.of(context).pop() の後にContextを使用したメソッドを実行していない
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [ ] リリースノートを追加した