### PR TITLE
Bugfix for take pill

### DIFF
--- a/lib/domain/record/util/take_pill.dart
+++ b/lib/domain/record/util/take_pill.dart
@@ -7,7 +7,7 @@ import 'package:pilll/database/pill_sheet.dart';
 import 'package:pilll/database/pill_sheet_group.dart';
 import 'package:pilll/database/pill_sheet_modified_history.dart';
 import 'package:pilll/error_log.dart';
-import 'package:pilll/util/datetime/date_compare.dart';
+import 'package:pilll/util/datetime/day.dart';
 
 class TakePill {
   final BatchFactory batchFactory;
@@ -47,7 +47,7 @@ class TakePill {
 
       // takenDateがピルシートの開始日に満たない場合は、記録の対象になっていないので早期リターン
       // 一つ前のピルシートのピルをタップした時など
-      if (takenDate.isBefore(pillSheet.beginingDate)) {
+      if (takenDate.date().isBefore(pillSheet.beginingDate.date())) {
         return pillSheet;
       }
 
@@ -67,6 +67,8 @@ class TakePill {
 
     debugPrint("updatedIndexses: $updatedIndexses");
     if (updatedIndexses.isEmpty) {
+      debugPrint("unexpected updatedIndexes is empty");
+
       // NOTE: avoid error for unit test
       if (Firebase.apps.isNotEmpty) {
         errorLogger.recordError(const FormatException("unexpected updatedIndexes is empty"), StackTrace.current);

--- a/test/util/take_pill_test.dart
+++ b/test/util/take_pill_test.dart
@@ -13,7 +13,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../helper/mock.mocks.dart';
 
 void main() {
-  final _today = DateTime.parse("2022-07-20");
+  final _today = DateTime.parse("2022-07-24");
   late DateTime activePillSheetBeginDate;
   late DateTime? activePillSheetLastTakenDate;
   late PillSheet previousPillSheet;


### PR DESCRIPTION
## Abstract
ユーザーの問い合わせで服用記録ができないということ。
調べてみるとtakenDate.isBefore(beginDate)の条件で早期リターンとなっていたが、これはbeginDateが時刻を含んで保存されているので、takenDateの時刻によっては意図せぬ条件が合致してしまうことに。なのでどちらも日付に変換して比較することにした

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] Navigator.of(context).pop() の後にContextを使用したメソッドを実行していない
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [ ] リリースノートを追加した