### PR TITLE
release 3.12.2

### DIFF
--- a/lib/domain/record/components/notification_bar/components/pilll_ads.dart
+++ b/lib/domain/record/components/notification_bar/components/pilll_ads.dart
@@ -19,6 +19,7 @@ class PilllAdsNotificationBar extends HookConsumerWidget {
       padding: const EdgeInsets.symmetric(horizontal: 8),
       child: GestureDetector(
         onTap: () {
+          analytics.logEvent(name: "pilll_ads_tapped");
           launchUrl(Uri.parse("https://mederi.jp/pr/tvcmdoctor01/?utm_source=Pilll_reminder&utm_medium=Pilll_reminder&utm_campaign=202208"));
         },
         child: Stack(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 3.12.1+1671
+version: 3.12.2+1671
 
 environment:
   sdk: ">=2.15.0 <3.0.0"


### PR DESCRIPTION
## Abstract
ログ入れ忘れたので追加

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] Navigator.of(context).pop() の後にContextを使用したメソッドを実行していない
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [ ] リリースノートを追加した