### PR TITLE
Migrate to shared keychain

### DIFF
--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -40,7 +40,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Debug-Development"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -274,9 +274,11 @@ extension AppDelegate {
                 // application(_:didFinishLaunchingWithOptions:)が終了してからFlutterのmainの開始は非同期的でFlutterのmainの完了までラグがある
                 // 特にアプリのプロセスがKillされている状態では、先にuserNotificationCenter(_:didReceive:withCompletionHandler:)の処理が走り
                 // Flutter側でのMethodChannelが確立される前にQuickRecordの呼び出しをおこなってしまう。この場合次にChanelが確立するまでFlutter側の処理の実行は遅延される。これは次のアプリの起動時まで遅延されるとほぼ同義になる
-                // よって対処療法的ではあるが、5秒待つことでほぼ間違いなくmain(の中でもMethodChanelの確立までは)の処理はすべて終えているとしてここではdelayを設けている。
+                // よって対処療法的ではあるが、~5~ -> 10秒待つことでほぼ間違いなくmain(の中でもMethodChanelの確立までは)の処理はすべて終えているとしてここではdelayを設けている。
                 // ちなみに通常は1秒前後あれば十分であるが念のためくらいの間を持たせている
-                DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [self] in
+                // 10秒に伸ばしたのはKeychain移行の処理がクイックレコード後にも走ってしまうので伸ばした
+                // TODO: Keychain移行が終わったら5秒に戻す
+                DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [self] in
                     channel?.invokeMethod("recordPill", arguments: nil, result: { result in
                         end()
                     })

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -158,7 +158,7 @@ private extension AppDelegate {
         let appGroupUser = try? Auth.auth().getStoredUser(forAccessGroup: keychainAccessGroup)
         analytics(name: "migration_users", parameters: ["currentUserID": currentUser?.uid ?? "", "appGroupUserID": appGroupUser?.uid ?? ""])
 
-        // NOTE: このタイミングで Auth.auth().useUserAccessGroup(keychainAccessGroup) を呼ぶのもアリだが、try catch をしなきゃいけないので呼ばなくて良いなら呼ばないようにしている
+        // NOTE: switch前のこの場所でAuth.auth().useUserAccessGroup(keychainAccessGroup) を呼ぶのもアリだが、try catch をしなきゃいけないので呼ばなくて良いなら呼ばないようにしている
         switch (currentUser, appGroupUser) {
         case (_?, _?):
             analytics(name: "migration_already_end")

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -116,7 +116,8 @@ import FirebaseAuth
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
 
-    private func analytics(name: String, parameters: [String: Any]? = nil) {
+    private func analytics(name: String, parameters: [String: Any]? = nil, function: StaticString = #function) {
+        print(function, name, parameters ?? [:])
         channel?.invokeMethod("analytics", arguments: ["name": name, "parameters": parameters ?? [:]])
     }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -150,10 +150,10 @@ private extension AppDelegate {
 
         // NOTE: このタイミングで Auth.auth().useUserAccessGroup(keychainAccessGroup) を呼ぶのもアリだが、try catch をしなきゃいけないので呼ばなくて良いなら呼ばないようにしている
         switch (currentUser, appGroupUser) {
-        case (let _?, let _?):
+        case (_?, _?):
             // すでに移行済み
             completionHandler(true)
-        case (nil, let _?):
+        case (nil, _?):
             // 移行済みではあるが、何かしらの理由でcurrentUserが取得できない状態。Flutterの方でログイン状態の監視を行なっているので成功にして処理を進める
             completionHandler(true)
         case (nil, nil):
@@ -174,7 +174,7 @@ private extension AppDelegate {
             }
 
             Auth.auth().updateCurrentUser(currentUser) { error in
-                if let error = errro {
+                if let error = error {
                     // ここではfatalErrorにしない。 再起動後にcase (nil, nil) の状態になり新しいユーザーでFlutter側でログインされてしまうため
                     UserDefaults.standard.set(currentUser.uid, forKey: Const.errorUpdateCurrentUserID)
                     UserDefaults.standard.set(error.localizedDescription, forKey: Const.errorUpdateCurrentUserError)

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -117,7 +117,7 @@ import FirebaseAuth
     }
 
     private func analytics(name: String, parameters: [String: Any]? = nil) {
-        channel?.invokeMethod("analytics", arguments: ["name": name, "parameters": parameters])
+        channel?.invokeMethod("analytics", arguments: ["name": name, "parameters": parameters ?? [:]])
     }
 }
 
@@ -155,7 +155,7 @@ private extension AppDelegate {
 
         // まだ移行してない時に try catchをした場合に返ってくるエラーが code:0, domain: `Foundation._GenericObjCError.nilError`, userInfo: [] という具合でcatchする意味もなさそうだった。エラーの場合は未移行として処理をしてしまう
         let appGroupUser = try? Auth.auth().getStoredUser(forAccessGroup: keychainAccessGroup)
-        analytics(name: "migration_users", parameters: ["currentUserID": currentUser?.uid, "appGroupUserID": appGroupUser?.uid])
+        analytics(name: "migration_users", parameters: ["currentUserID": currentUser?.uid ?? "", "appGroupUserID": appGroupUser?.uid ?? ""])
 
         // NOTE: このタイミングで Auth.auth().useUserAccessGroup(keychainAccessGroup) を呼ぶのもアリだが、try catch をしなきゃいけないので呼ばなくて良いなら呼ばないようにしている
         switch (currentUser, appGroupUser) {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -147,11 +147,11 @@ private extension AppDelegate {
         if UserDefaults.standard.string(forKey: Const.startMigrateionCurrentUserID) == nil {
             UserDefaults.standard.set(currentUser?.uid, forKey: Const.startMigrateionCurrentUserID)
         }
-        print(#function, "currentUser fetched")
+        print(#function, "currentUser fetched", currentUser?.uid)
 
         // まだ移行してない時に try catchをした場合に返ってくるエラーが code:0, domain: `Foundation._GenericObjCError.nilError`, userInfo: [] という具合でcatchする意味もなさそうだった。エラーの場合は未移行として処理をしてしまう
         let appGroupUser = try? Auth.auth().getStoredUser(forAccessGroup: keychainAccessGroup)
-        print(#function, "appGroupUser fetched")
+        print(#function, "appGroupUser fetched", appGroupUser?.uid)
 
         // NOTE: このタイミングで Auth.auth().useUserAccessGroup(keychainAccessGroup) を呼ぶのもアリだが、try catch をしなきゃいけないので呼ばなくて良いなら呼ばないようにしている
         switch (currentUser, appGroupUser) {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -193,11 +193,11 @@ private extension AppDelegate {
                     // ここではfatalErrorにしない。 再起動後にcase (nil, nil) の状態になり新しいユーザーでFlutter側でログインされてしまうため
                     UserDefaults.standard.set(currentUser.uid, forKey: Const.errorUpdateCurrentUserID)
                     UserDefaults.standard.set(error.localizedDescription, forKey: Const.errorUpdateCurrentUserError)
-                    completionHandler(false)
                     self.analytics(name: "update_current_user_is_fail", parameters: ["code": error._code, "domain": error._domain, "error": error.localizedDescription])
+                    completionHandler(false)
                 } else {
-                    completionHandler(true)
                     self.analytics(name: "update_current_user_is_success")
+                    completionHandler(true)
                 }
             }
         }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -9,7 +9,7 @@ import FirebaseAuth
     var channel: FlutterMethodChannel?
 
     private let teamID = "TQPN82UBBY"
-    private var keychainAccessGroup: String { "\(teamID).\(Bundle.main.bundleIdentifier!)" }
+    private var keychainAccessGroup: String { "\(teamID).\(Bundle.main.bundleIdentifier!).keychain" }
     private let isMigratedToSharedKeychainUserDefaultsKey = "isMigratedToSharedKeychainUserDefaultsKey"
 
     override func application(

--- a/lib/analytics.dart
+++ b/lib/analytics.dart
@@ -20,12 +20,12 @@ class Analytics {
         }
       }
     }
-    return firebaseAnalytics.logEvent(name: name, parameters: parameters);
+    firebaseAnalytics.logEvent(name: name, parameters: parameters);
   }
 
   void setCurrentScreen({required String screenName, String screenClassOverride = 'Flutter'}) async {
     unawaited(firebaseAnalytics.logEvent(name: "screen_$screenName"));
-    return firebaseAnalytics.setCurrentScreen(screenName: screenName, screenClassOverride: screenClassOverride);
+    firebaseAnalytics.setCurrentScreen(screenName: screenName, screenClassOverride: screenClassOverride);
   }
 
   /// Up to 25 user property names are supported.

--- a/lib/analytics.dart
+++ b/lib/analytics.dart
@@ -7,8 +7,7 @@ final firebaseAnalytics = FirebaseAnalytics.instance;
 
 class Analytics {
   logEvent({required String name, Map<String, dynamic>? parameters}) async {
-    assert(name.length <= 40,
-        "firebase analytics log event name limit length up to 40");
+    assert(name.length <= 40, "firebase analytics log event name limit length up to 40");
     if (kDebugMode) {
       print("[INFO] logEvent name: $name, parameters: $parameters");
     }
@@ -24,12 +23,9 @@ class Analytics {
     return firebaseAnalytics.logEvent(name: name, parameters: parameters);
   }
 
-  setCurrentScreen(
-      {required String screenName,
-      String screenClassOverride = 'Flutter'}) async {
+  setCurrentScreen({required String screenName, String screenClassOverride = 'Flutter'}) async {
     unawaited(firebaseAnalytics.logEvent(name: "screen_$screenName"));
-    return firebaseAnalytics.setCurrentScreen(
-        screenName: screenName, screenClassOverride: screenClassOverride);
+    return firebaseAnalytics.setCurrentScreen(screenName: screenName, screenClassOverride: screenClassOverride);
   }
 
   /// Up to 25 user property names are supported.
@@ -39,8 +35,7 @@ class Analytics {
     assert(name.toLowerCase() != "age");
     assert(name.toLowerCase() != "gender");
     assert(name.toLowerCase() != "interest");
-    assert(name.length < 25,
-        "firebase setUserProperties name limit length up to 25");
+    assert(name.length < 25, "firebase setUserProperties name limit length up to 25");
     assert(!name.startsWith("firebase_"));
 
     if (kDebugMode) {

--- a/lib/analytics.dart
+++ b/lib/analytics.dart
@@ -6,7 +6,7 @@ import 'package:flutter/foundation.dart';
 final firebaseAnalytics = FirebaseAnalytics.instance;
 
 class Analytics {
-  logEvent({required String name, Map<String, dynamic>? parameters}) async {
+  void logEvent({required String name, Map<String, dynamic>? parameters}) async {
     assert(name.length <= 40, "firebase analytics log event name limit length up to 40");
     if (kDebugMode) {
       print("[INFO] logEvent name: $name, parameters: $parameters");
@@ -23,7 +23,7 @@ class Analytics {
     return firebaseAnalytics.logEvent(name: name, parameters: parameters);
   }
 
-  setCurrentScreen({required String screenName, String screenClassOverride = 'Flutter'}) async {
+  void setCurrentScreen({required String screenName, String screenClassOverride = 'Flutter'}) async {
     unawaited(firebaseAnalytics.logEvent(name: "screen_$screenName"));
     return firebaseAnalytics.setCurrentScreen(screenName: screenName, screenClassOverride: screenClassOverride);
   }
@@ -31,7 +31,7 @@ class Analytics {
   /// Up to 25 user property names are supported.
   // The "firebase_" prefix is reserved and should not be used for
   /// user property names.
-  setUserProperties(String name, value) {
+  void setUserProperties(String name, value) {
     assert(name.toLowerCase() != "age");
     assert(name.toLowerCase() != "gender");
     assert(name.toLowerCase() != "interest");

--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -11,6 +11,7 @@ import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/domain/root/root.dart';
 import 'package:pilll/error/universal_error_page.dart';
 import 'package:pilll/native/channel.dart';
+import 'package:pilll/native/ios_keychain_migration.dart';
 import 'package:pilll/util/datetime/debug_print.dart';
 import 'package:pilll/util/environment.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -25,6 +26,11 @@ Future<void> entrypoint() async {
     WidgetsFlutterBinding.ensureInitialized();
 
     await Firebase.initializeApp();
+    if (Platform.isIOS) {
+      if (!(await isMigratedSharedKeychain())) {
+        await iOSKeychainMigrateToSharedKeychain();
+      }
+    }
 
     // QuickRecordの処理などFirebaseを使用するのでFirebase.initializeApp()の後に時刻する
     // また、同じくQuickRecordの処理開始までにMethodChannelが確立されていてほしいのでこの処理はなるべく早く実行する

--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -29,7 +29,7 @@ Future<void> entrypoint() async {
     await Firebase.initializeApp();
     // QuickRecordの処理などFirebaseを使用するのでFirebase.initializeApp()の後に時刻する
     // また、同じくQuickRecordの処理開始までにMethodChannelが確立されていてほしいのでこの処理はなるべく早く実行する
-    definedChannel();
+    defineChannel();
     if (Platform.isIOS) {
       if (!(await isMigratedSharedKeychain())) {
         final isSuccess = await iOSKeychainMigrateToSharedKeychain();

--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -28,7 +28,12 @@ Future<void> entrypoint() async {
     await Firebase.initializeApp();
     if (Platform.isIOS) {
       if (!(await isMigratedSharedKeychain())) {
-        await iOSKeychainMigrateToSharedKeychain();
+        final isSuccess = await iOSKeychainMigrateToSharedKeychain();
+        if (!isSuccess) {
+          // おおむねKeychainにアクセスできずに失敗する。
+          // それは異常事態なのでユーザーに起動し直してもらうで良い
+          exit(1);
+        }
       }
     }
 

--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -23,7 +23,9 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 Future<void> entrypoint() async {
   runZonedGuarded(() async {
     WidgetsFlutterBinding.ensureInitialized();
+
     await Firebase.initializeApp();
+
     // QuickRecordの処理などFirebaseを使用するのでFirebase.initializeApp()の後に時刻する
     // また、同じくQuickRecordの処理開始までにMethodChannelが確立されていてほしいのでこの処理はなるべく早く実行する
     definedChannel();
@@ -52,8 +54,7 @@ Future<void> entrypoint() async {
 
 void connectToEmulator() {
   final domain = Platform.isAndroid ? '10.0.2.2' : 'localhost';
-  FirebaseFirestore.instance.settings = Settings(
-      persistenceEnabled: false, host: '$domain:8080', sslEnabled: false);
+  FirebaseFirestore.instance.settings = Settings(persistenceEnabled: false, host: '$domain:8080', sslEnabled: false);
 }
 
 class App extends StatelessWidget {
@@ -62,9 +63,7 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      navigatorObservers: [
-        FirebaseAnalyticsObserver(analytics: firebaseAnalytics)
-      ],
+      navigatorObservers: [FirebaseAnalyticsObserver(analytics: firebaseAnalytics)],
       theme: ThemeData(
         appBarTheme: const AppBarTheme(
           systemOverlayStyle: SystemUiOverlayStyle.dark,
@@ -78,8 +77,7 @@ class App extends StatelessWidget {
         primaryColor: PilllColors.primary,
         visualDensity: VisualDensity.adaptivePlatformDensity,
         toggleableActiveColor: PilllColors.primary,
-        cupertinoOverrideTheme: const NoDefaultCupertinoThemeData(
-            textTheme: CupertinoTextThemeData(textStyle: FontType.xBigTitle)),
+        cupertinoOverrideTheme: const NoDefaultCupertinoThemeData(textTheme: CupertinoTextThemeData(textStyle: FontType.xBigTitle)),
         buttonTheme: const ButtonThemeData(
           buttonColor: PilllColors.secondary,
           disabledColor: PilllColors.disable,

--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -25,7 +25,11 @@ Future<void> entrypoint() async {
   runZonedGuarded(() async {
     WidgetsFlutterBinding.ensureInitialized();
 
+    // `ここから`順番は変えてはいけない
     await Firebase.initializeApp();
+    // QuickRecordの処理などFirebaseを使用するのでFirebase.initializeApp()の後に時刻する
+    // また、同じくQuickRecordの処理開始までにMethodChannelが確立されていてほしいのでこの処理はなるべく早く実行する
+    definedChannel();
     if (Platform.isIOS) {
       if (!(await isMigratedSharedKeychain())) {
         final isSuccess = await iOSKeychainMigrateToSharedKeychain();
@@ -36,10 +40,7 @@ Future<void> entrypoint() async {
         }
       }
     }
-
-    // QuickRecordの処理などFirebaseを使用するのでFirebase.initializeApp()の後に時刻する
-    // また、同じくQuickRecordの処理開始までにMethodChannelが確立されていてほしいのでこの処理はなるべく早く実行する
-    definedChannel();
+    // `ここまで`順番は変えてはいけない
 
     if (kDebugMode) {
       overrideDebugPrint();

--- a/lib/native/channel.dart
+++ b/lib/native/channel.dart
@@ -4,7 +4,7 @@ import 'package:pilll/native/legacy.dart';
 import 'package:pilll/native/pill.dart';
 
 const methodChannel = MethodChannel("method.channel.MizukiOhashi.Pilll");
-void definedChannel() {
+void defineChannel() {
   methodChannel.setMethodCallHandler((MethodCall call) async {
     switch (call.method) {
       case 'recordPill':

--- a/lib/native/channel.dart
+++ b/lib/native/channel.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/services.dart';
+import 'package:pilll/analytics.dart';
 import 'package:pilll/native/legacy.dart';
 import 'package:pilll/native/pill.dart';
 
@@ -10,6 +11,12 @@ void definedChannel() {
         return recordPill();
       case "salvagedOldStartTakenDate":
         return salvagedOldStartTakenDate(call.arguments);
+      case "analytics":
+        final arguments = call.arguments as Map<String, dynamic>;
+        final name = arguments["name"] as String;
+        final parameters = arguments["parameters"] as Map<String, dynamic>?;
+        analytics.logEvent(name: name, parameters: parameters);
+        break;
       default:
         break;
     }

--- a/lib/native/ios_keychain_migration.dart
+++ b/lib/native/ios_keychain_migration.dart
@@ -1,5 +1,10 @@
 import 'package:pilll/native/channel.dart';
 
+Future<bool> isMigratedSharedKeychain() async {
+  final result = await methodChannel.invokeMethod("isMigratedSharedKeychain");
+  return result["isMigratedSharedKeychain"] == true;
+}
+
 Future<bool> iOSKeychainMigrateToSharedKeychain() async {
   final result = await methodChannel.invokeMethod("iOSKeychainMigrateToSharedKeychain");
   return result["iOSKeychainMigrateToSharedKeychain"] == true;

--- a/lib/native/ios_keychain_migration.dart
+++ b/lib/native/ios_keychain_migration.dart
@@ -1,0 +1,6 @@
+import 'package:pilll/native/channel.dart';
+
+Future<bool> iOSKeychainMigrateToSharedKeychain() async {
+  final result = await methodChannel.invokeMethod("iOSKeychainMigrateToSharedKeychain");
+  return result["iOSKeychainMigrateToSharedKeychain"] == true;
+}

--- a/lib/service/auth.dart
+++ b/lib/service/auth.dart
@@ -69,7 +69,7 @@ Future<User> cachedUserOrSignInAnonymously() async {
     analytics.logEvent(name: "cached_current_user_not_exists");
 
     // keep until FirebaseAuth.instance user state updated
-    final obtainLatestChangedOptionalUserState = Future<User?>(() {
+    final waitLatestChangedOptionalUserState = Future<User?>(() {
       final completer = Completer<User?>();
 
       StreamSubscription<User?>? subscription;
@@ -80,7 +80,7 @@ Future<User> cachedUserOrSignInAnonymously() async {
       return completer.future;
     });
 
-    final obtainedUser = await obtainLatestChangedOptionalUserState;
+    final obtainedUser = await waitLatestChangedOptionalUserState;
     if (obtainedUser != null) {
       analytics.logEvent(
         name: "obtained_current_user_exists",
@@ -102,7 +102,7 @@ Future<User> cachedUserOrSignInAnonymously() async {
     }
 
     // keep until FirebaseAuth.instance user state updated
-    final obtainLatestChangedUserState = Future<User>(() {
+    final waitLatestChangedUserState = Future<User>(() {
       final completer = Completer<User>();
       final Stream<User> nonOptionalStream = _userAuthStateChanges().where((event) => event != null).cast();
 
@@ -114,7 +114,7 @@ Future<User> cachedUserOrSignInAnonymously() async {
       return completer.future;
     });
 
-    final User signedUser = await obtainLatestChangedUserState;
+    final User signedUser = await waitLatestChangedUserState;
     assert(anonymousUser.user?.uid == signedUser.uid);
     return signedUser;
   }

--- a/lib/service/auth.dart
+++ b/lib/service/auth.dart
@@ -17,8 +17,7 @@ final authStateStreamProvider = StreamProvider<User>(
   (ref) => _userAuthStateChanges().where((event) => event != null).cast(),
 );
 
-final isLinkedProvider =
-    Provider((ref) => apple.isLinkedApple() || google.isLinkedGoogle());
+final isLinkedProvider = Provider((ref) => apple.isLinkedApple() || google.isLinkedGoogle());
 
 class AuthService {
   // 退会時は一時的にnullになる。なのでOptional型のこのstreamを使う
@@ -57,9 +56,7 @@ Future<User> cachedUserOrSignInAnonymously() async {
   );
 
   if (currentUser != null) {
-    analytics.logEvent(
-        name: "cached_current_user_exists",
-        parameters: _logginParameters(currentUser));
+    analytics.logEvent(name: "cached_current_user_exists", parameters: _logginParameters(currentUser));
 
     final sharedPreferences = await SharedPreferences.getInstance();
     final existsUID = sharedPreferences.getString(StringKey.currentUserUID);
@@ -93,26 +90,21 @@ Future<User> cachedUserOrSignInAnonymously() async {
     }
 
     final anonymousUser = await FirebaseAuth.instance.signInAnonymously();
-    analytics.logEvent(
-        name: "signin_anonymously",
-        parameters: _logginParameters(anonymousUser.user));
+    analytics.logEvent(name: "signin_anonymously", parameters: _logginParameters(anonymousUser.user));
 
     final sharedPreferences = await SharedPreferences.getInstance();
-    final existsUID =
-        sharedPreferences.getString(StringKey.lastSignInAnonymousUID);
+    final existsUID = sharedPreferences.getString(StringKey.lastSignInAnonymousUID);
     if (existsUID == null || existsUID.isEmpty) {
       final user = anonymousUser.user;
       if (user != null) {
-        await sharedPreferences.setString(
-            StringKey.lastSignInAnonymousUID, user.uid);
+        await sharedPreferences.setString(StringKey.lastSignInAnonymousUID, user.uid);
       }
     }
 
     // keep until FirebaseAuth.instance user state updated
     final obtainLatestChangedUserState = Future<User>(() {
       final completer = Completer<User>();
-      final Stream<User> nonOptionalStream =
-          _userAuthStateChanges().where((event) => event != null).cast();
+      final Stream<User> nonOptionalStream = _userAuthStateChanges().where((event) => event != null).cast();
 
       StreamSubscription<User>? subscription;
       subscription = nonOptionalStream.listen((firebaseUser) {
@@ -136,11 +128,7 @@ Map<String, dynamic> _logginParameters(User? currentUser) {
   return {
     "uid": currentUser.uid,
     "isAnonymous": currentUser.isAnonymous,
-    "hasGoogleProviderData": currentUser.providerData
-        .where((element) => element.providerId == googleProviderID)
-        .isNotEmpty,
-    "hasAppleProviderData": currentUser.providerData
-        .where((element) => element.providerId == appleProviderID)
-        .isNotEmpty,
+    "hasGoogleProviderData": currentUser.providerData.where((element) => element.providerId == googleProviderID).isNotEmpty,
+    "hasAppleProviderData": currentUser.providerData.where((element) => element.providerId == appleProviderID).isNotEmpty,
   };
 }

--- a/test/helper/mock.mocks.dart
+++ b/test/helper/mock.mocks.dart
@@ -183,19 +183,24 @@ class MockAnalytics extends _i1.Mock implements _i21.Analytics {
   }
 
   @override
-  dynamic logEvent({String? name, Map<String, dynamic>? parameters}) =>
-      super.noSuchMethod(Invocation.method(
-          #logEvent, [], {#name: name, #parameters: parameters}));
+  void logEvent({String? name, Map<String, dynamic>? parameters}) =>
+      super.noSuchMethod(
+          Invocation.method(
+              #logEvent, [], {#name: name, #parameters: parameters}),
+          returnValueForMissingStub: null);
   @override
-  dynamic setCurrentScreen(
+  void setCurrentScreen(
           {String? screenName, String? screenClassOverride = r'Flutter'}) =>
-      super.noSuchMethod(Invocation.method(#setCurrentScreen, [], {
-        #screenName: screenName,
-        #screenClassOverride: screenClassOverride
-      }));
+      super.noSuchMethod(
+          Invocation.method(#setCurrentScreen, [], {
+            #screenName: screenName,
+            #screenClassOverride: screenClassOverride
+          }),
+          returnValueForMissingStub: null);
   @override
-  dynamic setUserProperties(String? name, dynamic value) =>
-      super.noSuchMethod(Invocation.method(#setUserProperties, [name, value]));
+  void setUserProperties(String? name, dynamic value) =>
+      super.noSuchMethod(Invocation.method(#setUserProperties, [name, value]),
+          returnValueForMissingStub: null);
 }
 
 /// A class which mocks [DiaryDatastore].


### PR DESCRIPTION
## Abstract
Firebase AuthのKeychainでuserAccessGroupを使用する。これによりWidgetExtensionなどのApp ExtensionとKeychainを共有できるメリットが挙げられる。iOSのWidget Extension対応に関連して行う

## Why

## Links

## Checklist
### 正常系
- [x] 既存からの移行
  - [x] 2度目の起動
  - [x] method channelの順番を変更したので確認
- [x] 新規登録
  - [x] 2度目の起動
  - [x] method channelの順番を変更したので確認
- [ ] Androidで起動ができる
  - [ ] 2度目の起動
- [ ] 古いバージョンからのアプデ後にクイックレコードができる

### 異常系
- [x] method channel から移行結果がfalseの場合にクラッシュする

#### 途中から失敗
- [ ] ~updateCurrentUser でエラーが起きた場合に一度アプリがクラッシュする。その後の起動で正常に移行が完了するかを確認~ 意図的にエラーを起こすのが難しいのでパス



## Checked
- [ ] Analyticsのログを入れたか
- [ ] Navigator.of(context).pop() の後にContextを使用したメソッドを実行していない
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [ ] リリースノートを追加した