### PR TITLE
Fix timeline

### DIFF
--- a/ios/Widget/Entry.swift
+++ b/ios/Widget/Entry.swift
@@ -84,10 +84,12 @@ extension Entry {
       todayPillNumberBase = recordedPillSheetGroupTodayPillNumber
     }
 
-    guard let diff = calendar.dateComponents([.day], from: date, to: pillSheetValueLastUpdateDateTime).day else {
+    guard let dateDay = calendar.dateComponents([.day], from: date).day,
+          let pillSheetValueLastUpdateDateTimeDay = calendar.dateComponents([.day], from: pillSheetValueLastUpdateDateTime).day else {
       return todayPillNumberBase
     }
-    let todayPillNumber = todayPillNumberBase + diff
+    let diff = dateDay - pillSheetValueLastUpdateDateTimeDay
+    let todayPillNumber = todayPillNumberBase + max(0, diff)
 
     if let pillSheetEndDisplayPillNumber = pillSheetEndDisplayPillNumber, todayPillNumber > pillSheetEndDisplayPillNumber {
       // 更新されるまで常に1で良い

--- a/ios/Widget/Provider.swift
+++ b/ios/Widget/Provider.swift
@@ -15,7 +15,7 @@ struct Provider: TimelineProvider {
   func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
     let intervalMinute = 15
     let nextTimelineSchedule = Calendar.current.date(byAdding: .minute, value: intervalMinute, to: .now)
-    let timeline = Timeline(entries: [Entry(date: .now.addingTimeInterval(TimeInterval(intervalMinute * 60)))], policy: .after(nextTimelineSchedule ?? .now))
+    let timeline = Timeline(entries: [Entry(date: .now)], policy: .after(nextTimelineSchedule ?? .now))
     completion(timeline)
   }
 }

--- a/ios/Widget/Provider.swift
+++ b/ios/Widget/Provider.swift
@@ -14,10 +14,8 @@ struct Provider: TimelineProvider {
 
   func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
     let intervalMinute = 15
-    let oneDayLoopCount = 24 * (4 * intervalMinute)
-    let entries: [Entry] = .init(repeating: .init(date: .now.addingTimeInterval(TimeInterval(intervalMinute * 60))), count: oneDayLoopCount)
-    let nextTimelineSchedule = Calendar.current.date(byAdding: .minute, value: intervalMinute, to: .now)!
-    let timeline = Timeline(entries: entries, policy: .after(nextTimelineSchedule))
+    let nextTimelineSchedule = Calendar.current.date(byAdding: .minute, value: intervalMinute, to: .now)
+    let timeline = Timeline(entries: [Entry(date: .now.addingTimeInterval(TimeInterval(intervalMinute * 60)))], policy: .after(nextTimelineSchedule ?? .now))
     completion(timeline)
   }
 }


### PR DESCRIPTION
## Abstract
WidgetKitのtimeline providerの修正。.after(interval)をしておけばintervalごとにtimelineの更新が走りそうなのでそれだけにした

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] Navigator.of(context).pop() の後にContextを使用したメソッドを実行していない
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [ ] リリースノートを追加した