### PR TITLE
日記の保存と予定の保存の調整

### DIFF
--- a/lib/components/atoms/buttons.dart
+++ b/lib/components/atoms/buttons.dart
@@ -26,7 +26,7 @@ class PrimaryButton extends HookWidget {
       children: [
         ElevatedButton(
           child: ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 44, minHeight: 44, minWidth: 180, maxWidth: 180),
+            constraints: const BoxConstraints(maxHeight: 44, minHeight: 44, minWidth: 180),
             child: Center(child: Text(text, style: ButtonTextStyle.main)),
           ),
           style: ButtonStyle(backgroundColor: MaterialStateProperty.resolveWith((statuses) {

--- a/lib/components/organisms/calendar/week/week_calendar.dart
+++ b/lib/components/organisms/calendar/week/week_calendar.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/analytics.dart';
 import 'package:pilll/components/organisms/calendar/band/calendar_band.dart';
@@ -140,24 +141,37 @@ void transitionWhenCalendarDayTapped(
     return;
   }
 
+  final diary = diaries.lastWhereOrNull((element) => isSameDay(element.date, date));
   if (isExistsSchedule(schedules, date)) {
-    showModalBottomSheet(
-      context: context,
-      builder: (context) => DiaryOrScheduleSheet(
-          showDiary: () => Navigator.of(context).push(DiaryPostPageRoute.route(date, null)),
-          showSchedule: () => Navigator.of(context).push(SchedulePostPageRoute.route(date))),
-    );
+    if (diary == null) {
+      showModalBottomSheet(
+        context: context,
+        builder: (context) => DiaryOrScheduleSheet(
+            showDiary: () => Navigator.of(context).push(DiaryPostPageRoute.route(date, null)),
+            showSchedule: () => Navigator.of(context).push(SchedulePostPageRoute.route(date))),
+      );
+    } else {
+      showModalBottomSheet(
+        context: context,
+        builder: (context) => DiaryOrScheduleSheet(
+            showDiary: () => _showConfirmDiarySheet(context, diary),
+            showSchedule: () => Navigator.of(context).push(SchedulePostPageRoute.route(date))),
+      );
+    }
     return;
   }
 
-  if (!isExistsPostedDiary(diaries, date)) {
+  if (diary == null) {
     Navigator.of(context).push(DiaryPostPageRoute.route(date, null));
   } else {
-    final diary = diaries.lastWhere((element) => isSameDay(element.date, date));
-    showModalBottomSheet(
-      context: context,
-      builder: (context) => ConfirmDiarySheet(diary),
-      backgroundColor: Colors.transparent,
-    );
+    _showConfirmDiarySheet(context, diary);
   }
+}
+
+void _showConfirmDiarySheet(BuildContext context, Diary diary) {
+  showModalBottomSheet(
+    context: context,
+    builder: (context) => ConfirmDiarySheet(diary),
+    backgroundColor: Colors.transparent,
+  );
 }

--- a/lib/domain/diary_post/diary_post_page.dart
+++ b/lib/domain/diary_post/diary_post_page.dart
@@ -36,6 +36,10 @@ class DiaryPostPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final stateNotifier = ref.watch(diaryPostStateNotifierProvider(_family()).notifier);
     final asyncState = ref.watch(diaryPostStateNotifierProvider(_family()));
+    final textEditingController = useTextEditingController(text: "");
+    final focusNode = useFocusNode();
+    final scrollController = useScrollController();
+    final offset = MediaQuery.of(context).viewInsets.bottom + keyboardToolbarHeight + 60;
 
     if (asyncState is AsyncLoading) {
       return const ScaffoldIndicator();
@@ -48,10 +52,9 @@ class DiaryPostPage extends HookConsumerWidget {
       return UniversalErrorPage(error: error, child: null, reload: () => ref.refresh(diaryPostAsyncStateProvider(_family())));
     }
 
-    final textEditingController = useTextEditingController(text: state.diary.memo);
-    final focusNode = useFocusNode();
-    final scrollController = useScrollController();
-    final offset = MediaQuery.of(context).viewInsets.bottom + keyboardToolbarHeight + 60;
+    useEffect(() {
+      textEditingController.text = state.diary.memo;
+    }, [state.diary.memo]);
 
     return Scaffold(
       backgroundColor: PilllColors.white,

--- a/lib/domain/diary_post/diary_post_page.dart
+++ b/lib/domain/diary_post/diary_post_page.dart
@@ -36,10 +36,6 @@ class DiaryPostPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final stateNotifier = ref.watch(diaryPostStateNotifierProvider(_family()).notifier);
     final asyncState = ref.watch(diaryPostStateNotifierProvider(_family()));
-    final textEditingController = useTextEditingController(text: "");
-    final focusNode = useFocusNode();
-    final scrollController = useScrollController();
-    final offset = MediaQuery.of(context).viewInsets.bottom + keyboardToolbarHeight + 60;
 
     if (asyncState is AsyncLoading) {
       return const ScaffoldIndicator();
@@ -52,9 +48,10 @@ class DiaryPostPage extends HookConsumerWidget {
       return UniversalErrorPage(error: error, child: null, reload: () => ref.refresh(diaryPostAsyncStateProvider(_family())));
     }
 
-    useEffect(() {
-      textEditingController.text = state.diary.memo;
-    }, [state.diary.memo]);
+    final textEditingController = useTextEditingController(text: state.diary.memo);
+    final focusNode = useFocusNode();
+    final scrollController = useScrollController();
+    final offset = MediaQuery.of(context).viewInsets.bottom + keyboardToolbarHeight + 60;
 
     return Scaffold(
       backgroundColor: PilllColors.white,

--- a/lib/domain/diary_post/diary_post_page.dart
+++ b/lib/domain/diary_post/diary_post_page.dart
@@ -51,20 +51,8 @@ class DiaryPostPage extends HookConsumerWidget {
     final TextEditingController? textEditingController = useTextEditingController(text: state.diary.memo);
     final focusNode = useFocusNode();
     final scrollController = useScrollController();
+    final offset = MediaQuery.of(context).viewInsets.bottom + keyboardToolbarHeight + 60;
 
-    focusNode.addListener(() {
-      if (focusNode.hasFocus) {
-        // NOTE: The final keyboard height cannot be got at the moment of focus via MediaQuery.of(context).viewInsets.bottom. so it is delayed.
-        Future.delayed(const Duration(milliseconds: 100)).then((_) {
-          final overwrapHeight = focusNode.rect.bottom - (MediaQuery.of(context).viewInsets.bottom + keyboardToolbarHeight);
-          if (overwrapHeight > 0) {
-            scrollController.animateTo(overwrapHeight, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
-          }
-        });
-      } else {
-        scrollController.animateTo(scrollController.position.minScrollExtent, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
-      }
-    });
     return Scaffold(
       backgroundColor: PilllColors.white,
       resizeToAvoidBottomInset: false,
@@ -87,26 +75,19 @@ class DiaryPostPage extends HookConsumerWidget {
       body: SafeArea(
         child: Stack(
           children: [
-            SizedBox(
-              height: MediaQuery.of(context).size.height,
-              width: MediaQuery.of(context).size.width,
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: ListView(
-                  controller: scrollController,
-                  children: [
-                    Text(DateTimeFormatter.yearAndMonthAndDay(date), style: FontType.sBigTitle.merge(TextColorStyle.main)),
-                    ...[
-                      _physicalConditions(stateNotifier, state),
-                      _physicalConditionDetails(context, stateNotifier, state),
-                      _sex(stateNotifier, state),
-                      _memo(context, textEditingController, focusNode, stateNotifier, state),
-                    ].map((e) => _withContentSpacer(e)),
-                    SizedBox(
-                      height: MediaQuery.of(context).viewInsets.bottom + keyboardToolbarHeight + 60,
-                    ),
-                  ],
-                ),
+            Padding(
+              padding: EdgeInsets.fromLTRB(16, 16, 16, offset),
+              child: ListView(
+                controller: scrollController,
+                children: [
+                  Text(DateTimeFormatter.yearAndMonthAndDay(date), style: FontType.sBigTitle.merge(TextColorStyle.main)),
+                  ...[
+                    _physicalConditions(stateNotifier, state),
+                    _physicalConditionDetails(context, stateNotifier, state),
+                    _sex(stateNotifier, state),
+                    _memo(context, textEditingController, focusNode, stateNotifier, state),
+                  ].map((e) => _withContentSpacer(e)),
+                ],
               ),
             ),
             if (focusNode.hasFocus) _keyboardToolbar(context, focusNode),

--- a/lib/domain/diary_post/diary_post_page.dart
+++ b/lib/domain/diary_post/diary_post_page.dart
@@ -48,7 +48,7 @@ class DiaryPostPage extends HookConsumerWidget {
       return UniversalErrorPage(error: error, child: null, reload: () => ref.refresh(diaryPostAsyncStateProvider(_family())));
     }
 
-    final TextEditingController? textEditingController = useTextEditingController(text: state.diary.memo);
+    final textEditingController = useTextEditingController(text: state.diary.memo);
     final focusNode = useFocusNode();
     final scrollController = useScrollController();
     final offset = MediaQuery.of(context).viewInsets.bottom + keyboardToolbarHeight + 60;
@@ -263,7 +263,7 @@ class DiaryPostPage extends HookConsumerWidget {
 
   Widget _memo(
     BuildContext context,
-    TextEditingController? textEditingController,
+    TextEditingController textEditingController,
     FocusNode focusNode,
     DiaryPostStateNotifier store,
     DiaryPostState state,

--- a/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
+++ b/lib/domain/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
@@ -81,8 +81,7 @@ class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
                         style: FontType.sBigTitle.merge(TextColorStyle.main),
                         textAlign: TextAlign.center,
                       ),
-                      InitialSettingPillSheetGroupPageBody(
-                          state: state, store: store),
+                      InitialSettingPillSheetGroupPageBody(state: state, store: store),
                       const SizedBox(height: 100),
                     ],
                   ),
@@ -96,23 +95,22 @@ class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         if (state.pillSheetTypes.isNotEmpty)
-                          PrimaryButton(
-                            text: "次へ",
-                            onPressed: () async {
-                              analytics.logEvent(
-                                  name: "next_to_today_pill_number");
-                              Navigator.of(context).push(
-                                  InitialSettingSelectTodayPillNumberPageRoute
-                                      .route());
-                            },
+                          SizedBox(
+                            width: 180,
+                            child: PrimaryButton(
+                              text: "次へ",
+                              onPressed: () async {
+                                analytics.logEvent(name: "next_to_today_pill_number");
+                                Navigator.of(context).push(InitialSettingSelectTodayPillNumberPageRoute.route());
+                              },
+                            ),
                           ),
                         if (!state.userIsNotAnonymous) ...[
                           const SizedBox(height: 20),
                           AlertButton(
                             text: "すでにアカウントをお持ちの方はこちら",
                             onPressed: () async {
-                              analytics.logEvent(
-                                  name: "pressed_initial_setting_signin");
+                              analytics.logEvent(name: "pressed_initial_setting_signin");
                               showSignInSheet(
                                 context,
                                 SignInSheetStateContext.initialSetting,
@@ -156,18 +154,21 @@ class InitialSettingPillSheetGroupPageBody extends StatelessWidget {
             const SizedBox(height: 80),
             SvgPicture.asset("images/empty_pill_sheet_type.svg"),
             const SizedBox(height: 24),
-            PrimaryButton(
-                onPressed: () async {
-                  analytics.logEvent(name: "empty_pill_sheet_type");
-                  showSettingPillSheetGroupSelectPillSheetTypePage(
-                    context: context,
-                    pillSheetType: null,
-                    onSelect: (pillSheetType) {
-                      store.selectedFirstPillSheetType(pillSheetType);
-                    },
-                  );
-                },
-                text: "ピルの種類を選ぶ"),
+            SizedBox(
+              width: 180,
+              child: PrimaryButton(
+                  onPressed: () async {
+                    analytics.logEvent(name: "empty_pill_sheet_type");
+                    showSettingPillSheetGroupSelectPillSheetTypePage(
+                      context: context,
+                      pillSheetType: null,
+                      onSelect: (pillSheetType) {
+                        store.selectedFirstPillSheetType(pillSheetType);
+                      },
+                    );
+                  },
+                  text: "ピルの種類を選ぶ"),
+            ),
           ],
         ),
       );
@@ -178,24 +179,16 @@ class InitialSettingPillSheetGroupPageBody extends StatelessWidget {
           SettingPillSheetGroup(
               pillSheetTypes: state.pillSheetTypes,
               onAdd: (pillSheetType) {
-                analytics.logEvent(
-                    name: "initial_setting_add_pill_sheet_group",
-                    parameters: {"pill_sheet_type": pillSheetType.fullName});
+                analytics.logEvent(name: "initial_setting_add_pill_sheet_group", parameters: {"pill_sheet_type": pillSheetType.fullName});
                 store.addPillSheetType(pillSheetType);
               },
               onChange: (index, pillSheetType) {
                 analytics.logEvent(
-                    name: "initial_setting_change_pill_sheet_group",
-                    parameters: {
-                      "index": index,
-                      "pill_sheet_type": pillSheetType.fullName
-                    });
+                    name: "initial_setting_change_pill_sheet_group", parameters: {"index": index, "pill_sheet_type": pillSheetType.fullName});
                 store.changePillSheetType(index, pillSheetType);
               },
               onDelete: (index) {
-                analytics.logEvent(
-                    name: "initial_setting_delete_pill_sheet_group",
-                    parameters: {"index": index});
+                analytics.logEvent(name: "initial_setting_delete_pill_sheet_group", parameters: {"index": index});
                 store.removePillSheetType(index);
               }),
         ],
@@ -204,8 +197,7 @@ class InitialSettingPillSheetGroupPageBody extends StatelessWidget {
   }
 }
 
-extension InitialSettingPillSheetGroupPageRoute
-    on InitialSettingPillSheetGroupPage {
+extension InitialSettingPillSheetGroupPageRoute on InitialSettingPillSheetGroupPage {
   static InitialSettingPillSheetGroupPage screen() {
     analytics.setCurrentScreen(screenName: "InitialSettingPillSheetGroupPage");
     return const InitialSettingPillSheetGroupPage();

--- a/lib/domain/initial_setting/reminder_times/initial_setting_reminder_times_page.dart
+++ b/lib/domain/initial_setting/reminder_times/initial_setting_reminder_times_page.dart
@@ -56,8 +56,7 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
                           return _form(context, store, state, index);
                         })),
                   ),
-                  Text("複数設定しておく事で飲み忘れを防げます",
-                      style: FontType.assisting.merge(TextColorStyle.main)),
+                  Text("複数設定しておく事で飲み忘れを防げます", style: FontType.assisting.merge(TextColorStyle.main)),
                 ],
               ),
               const Spacer(),
@@ -69,50 +68,41 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
                       children: [
                         TextSpan(
                           text: "プライバシーポリシー",
-                          style: FontType.sSmallSentence
-                              .merge(TextColorStyle.link),
+                          style: FontType.sSmallSentence.merge(TextColorStyle.link),
                           recognizer: TapGestureRecognizer()
                             ..onTap = () {
-                              launchUrl(
-                                  Uri.parse(
-                                      "https://bannzai.github.io/Pilll/PrivacyPolicy"),
-                                  mode: LaunchMode.inAppWebView);
+                              launchUrl(Uri.parse("https://bannzai.github.io/Pilll/PrivacyPolicy"), mode: LaunchMode.inAppWebView);
                             },
                         ),
                         TextSpan(
                           text: "と",
-                          style: FontType.sSmallSentence
-                              .merge(TextColorStyle.gray),
+                          style: FontType.sSmallSentence.merge(TextColorStyle.gray),
                         ),
                         TextSpan(
                           text: "利用規約",
-                          style: FontType.sSmallSentence
-                              .merge(TextColorStyle.link),
+                          style: FontType.sSmallSentence.merge(TextColorStyle.link),
                           recognizer: TapGestureRecognizer()
                             ..onTap = () {
-                              launchUrl(
-                                  Uri.parse(
-                                      "https://bannzai.github.io/Pilll/Terms"),
-                                  mode: LaunchMode.inAppWebView);
+                              launchUrl(Uri.parse("https://bannzai.github.io/Pilll/Terms"), mode: LaunchMode.inAppWebView);
                             },
                         ),
                         TextSpan(
                           text: "を読んで\n利用をはじめてください",
-                          style: FontType.sSmallSentence
-                              .merge(TextColorStyle.gray),
+                          style: FontType.sSmallSentence.merge(TextColorStyle.gray),
                         ),
                       ],
                     ),
                   ),
                   const SizedBox(height: 24),
-                  PrimaryButton(
-                    text: "次へ",
-                    onPressed: () async {
-                      analytics.logEvent(
-                          name: "next_initial_setting_reminder_times");
-                      Navigator.of(context).push(
-                          IntiialSettingPremiumTrialStartPageRoute.route());
-                    },
+                  SizedBox(
+                    width: 180,
+                    child: PrimaryButton(
+                      text: "次へ",
+                      onPressed: () async {
+                        analytics.logEvent(name: "next_initial_setting_reminder_times");
+                        Navigator.of(context).push(IntiialSettingPremiumTrialStartPageRoute.route());
+                      },
+                    ),
                   ),
                 ],
               ),
@@ -133,19 +123,15 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
     analytics.logEvent(name: "show_initial_setting_reminder_picker");
     final reminderDateTime = state.reminderTimeOrNull(index);
     final n = now();
-    DateTime initialDateTime =
-        reminderDateTime ?? DateTime(n.year, n.month, n.day, n.hour, 0, 0);
+    DateTime initialDateTime = reminderDateTime ?? DateTime(n.year, n.month, n.day, n.hour, 0, 0);
     showModalBottomSheet(
       context: context,
       builder: (BuildContext context) {
         return TimePicker(
           initialDateTime: initialDateTime,
           done: (dateTime) {
-            analytics.logEvent(
-                name: "selected_times_initial_setting",
-                parameters: {"hour": dateTime.hour, "minute": dateTime.minute});
-            store.setReminderTime(
-                index: index, hour: dateTime.hour, minute: dateTime.minute);
+            analytics.logEvent(name: "selected_times_initial_setting", parameters: {"hour": dateTime.hour, "minute": dateTime.minute});
+            store.setReminderTime(index: index, hour: dateTime.hour, minute: dateTime.minute);
             Navigator.pop(context);
           },
         );
@@ -160,20 +146,14 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
     int index,
   ) {
     final reminderTime = state.reminderTimeOrNull(index);
-    final formValue = reminderTime == null
-        ? "--:--"
-        : DateTimeFormatter.militaryTime(reminderTime);
+    final formValue = reminderTime == null ? "--:--" : DateTimeFormatter.militaryTime(reminderTime);
     return Padding(
       padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
       child: Column(
         children: [
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              SvgPicture.asset("images/alerm.svg"),
-              Text("通知${index + 1}",
-                  style: FontType.assisting.merge(TextColorStyle.main))
-            ],
+            children: [SvgPicture.asset("images/alerm.svg"), Text("通知${index + 1}", style: FontType.assisting.merge(TextColorStyle.main))],
           ),
           const SizedBox(height: 8),
           GestureDetector(
@@ -189,8 +169,7 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
                 ),
               ),
               child: Center(
-                child: Text(formValue,
-                    style: FontType.inputNumber.merge(TextColorStyle.gray)),
+                child: Text(formValue, style: FontType.inputNumber.merge(TextColorStyle.gray)),
               ),
             ),
           )
@@ -200,8 +179,7 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
   }
 }
 
-extension InitialSettingReminderTimesPageRoute
-    on InitialSettingReminderTimesPage {
+extension InitialSettingReminderTimesPageRoute on InitialSettingReminderTimesPage {
   static Route<dynamic> route() {
     return MaterialPageRoute(
       settings: const RouteSettings(name: "InitialSettingReminderTimesPage"),

--- a/lib/domain/initial_setting/today_pill_number/initial_setting_select_today_pill_number_page.dart
+++ b/lib/domain/initial_setting/today_pill_number/initial_setting_select_today_pill_number_page.dart
@@ -62,10 +62,8 @@ class InitialSettingSelectTodayPillNumberPage extends HookConsumerWidget {
                     InconspicuousButton(
                       onPressed: () async {
                         store.unsetTodayPillNumber();
-                        analytics.logEvent(
-                            name: "unknown_number_initial_setting");
-                        Navigator.of(context)
-                            .push(InitialSettingReminderTimesPageRoute.route());
+                        analytics.logEvent(name: "unknown_number_initial_setting");
+                        Navigator.of(context).push(InitialSettingReminderTimesPageRoute.route());
                       },
                       text: "まだ分からない",
                     ),
@@ -76,16 +74,17 @@ class InitialSettingSelectTodayPillNumberPage extends HookConsumerWidget {
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
                   const SizedBox(height: 30),
-                  PrimaryButton(
-                    text: "次へ",
-                    onPressed: state.todayPillNumber == null
-                        ? null
-                        : () async {
-                            analytics.logEvent(
-                                name: "done_today_number_initial_setting");
-                            Navigator.of(context).push(
-                                InitialSettingReminderTimesPageRoute.route());
-                          },
+                  SizedBox(
+                    width: 180,
+                    child: PrimaryButton(
+                      text: "次へ",
+                      onPressed: state.todayPillNumber == null
+                          ? null
+                          : () async {
+                              analytics.logEvent(name: "done_today_number_initial_setting");
+                              Navigator.of(context).push(InitialSettingReminderTimesPageRoute.route());
+                            },
+                    ),
                   ),
                   const SizedBox(height: 35),
                 ],
@@ -98,12 +97,10 @@ class InitialSettingSelectTodayPillNumberPage extends HookConsumerWidget {
   }
 }
 
-extension InitialSettingSelectTodayPillNumberPageRoute
-    on InitialSettingSelectTodayPillNumberPage {
+extension InitialSettingSelectTodayPillNumberPageRoute on InitialSettingSelectTodayPillNumberPage {
   static Route<dynamic> route() {
     return MaterialPageRoute(
-      settings:
-          const RouteSettings(name: "InitialSettingSelectTodayPillNumberPage"),
+      settings: const RouteSettings(name: "InitialSettingSelectTodayPillNumberPage"),
       builder: (_) => const InitialSettingSelectTodayPillNumberPage(),
     );
   }

--- a/lib/domain/menstruation/components/menstruation_record_button.dart
+++ b/lib/domain/menstruation/components/menstruation_record_button.dart
@@ -22,50 +22,48 @@ class MenstruationRecordButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PrimaryButton(
-      onPressed: () async {
-        analytics.logEvent(name: "pressed_menstruation_record");
-        final latestMenstruation = state.latestMenstruation;
-        if (latestMenstruation != null &&
-            latestMenstruation.dateRange.inRange(today())) {
-          showMenstruationEditPage(context, menstruation: latestMenstruation);
-          return;
-        }
+    return SizedBox(
+      width: 180,
+      child: PrimaryButton(
+        onPressed: () async {
+          analytics.logEvent(name: "pressed_menstruation_record");
+          final latestMenstruation = state.latestMenstruation;
+          if (latestMenstruation != null && latestMenstruation.dateRange.inRange(today())) {
+            showMenstruationEditPage(context, menstruation: latestMenstruation);
+            return;
+          }
 
-        final setting = state.setting;
+          final setting = state.setting;
 
-        if (setting.durationMenstruation == 0) {
-          return showMenstruationEditPage(context, menstruation: null);
-        }
-        showModalBottomSheet(
-          context: context,
-          builder: (_) =>
-              MenstruationSelectModifyTypeSheet(onTap: (type) async {
-            switch (type) {
-              case MenstruationSelectModifyType.today:
-                analytics.logEvent(name: "tapped_menstruation_record_today");
-                final created =
-                    await store.asyncAction.recordFromToday(setting: setting);
-                onRecord(created);
-                Navigator.of(context).pop();
-                return;
-              case MenstruationSelectModifyType.yesterday:
-                analytics.logEvent(
-                    name: "tapped_menstruation_record_yesterday");
-                final created = await store.asyncAction
-                    .recordFromYesterday(setting: setting);
-                onRecord(created);
-                Navigator.of(context).pop();
-                return;
-              case MenstruationSelectModifyType.begin:
-                analytics.logEvent(name: "tapped_menstruation_record_begin");
-                Navigator.of(context).pop();
-                return showMenstruationEditPage(context, menstruation: null);
-            }
-          }),
-        );
-      },
-      text: state.buttonString,
+          if (setting.durationMenstruation == 0) {
+            return showMenstruationEditPage(context, menstruation: null);
+          }
+          showModalBottomSheet(
+            context: context,
+            builder: (_) => MenstruationSelectModifyTypeSheet(onTap: (type) async {
+              switch (type) {
+                case MenstruationSelectModifyType.today:
+                  analytics.logEvent(name: "tapped_menstruation_record_today");
+                  final created = await store.asyncAction.recordFromToday(setting: setting);
+                  onRecord(created);
+                  Navigator.of(context).pop();
+                  return;
+                case MenstruationSelectModifyType.yesterday:
+                  analytics.logEvent(name: "tapped_menstruation_record_yesterday");
+                  final created = await store.asyncAction.recordFromYesterday(setting: setting);
+                  onRecord(created);
+                  Navigator.of(context).pop();
+                  return;
+                case MenstruationSelectModifyType.begin:
+                  analytics.logEvent(name: "tapped_menstruation_record_begin");
+                  Navigator.of(context).pop();
+                  return showMenstruationEditPage(context, menstruation: null);
+              }
+            }),
+          );
+        },
+        text: state.buttonString,
+      ),
     );
   }
 }

--- a/lib/domain/premium_introduction/premium_complete_dialog.dart
+++ b/lib/domain/premium_introduction/premium_complete_dialog.dart
@@ -4,12 +4,10 @@ import 'package:pilll/components/atoms/buttons.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 
-
 class PremiumCompleteDialog extends StatelessWidget {
   final VoidCallback onClose;
 
-  const PremiumCompleteDialog({Key? key, required this.onClose})
-      : super(key: key);
+  const PremiumCompleteDialog({Key? key, required this.onClose}) : super(key: key);
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
@@ -42,12 +40,15 @@ class PremiumCompleteDialog extends StatelessWidget {
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 24),
-          PrimaryButton(
-            onPressed: () async {
-              Navigator.of(context).pop();
-              onClose();
-            },
-            text: "OK",
+          SizedBox(
+            width: 180,
+            child: PrimaryButton(
+              onPressed: () async {
+                Navigator.of(context).pop();
+                onClose();
+              },
+              text: "OK",
+            ),
           ),
         ],
       ),

--- a/lib/domain/record/components/add_pill_sheet_group/add_pill_sheet_group_page.dart
+++ b/lib/domain/record/components/add_pill_sheet_group/add_pill_sheet_group_page.dart
@@ -43,24 +43,16 @@ class AddPillSheetGroupPage extends HookConsumerWidget {
               SettingPillSheetGroup(
                 pillSheetTypes: setting.pillSheetEnumTypes,
                 onAdd: (pillSheetType) {
-                  analytics.logEvent(
-                      name: "setting_add_pill_sheet_group",
-                      parameters: {"pill_sheet_type": pillSheetType.fullName});
+                  analytics.logEvent(name: "setting_add_pill_sheet_group", parameters: {"pill_sheet_type": pillSheetType.fullName});
                   store.addPillSheetType(pillSheetType, setting);
                 },
                 onChange: (index, pillSheetType) {
-                  analytics.logEvent(
-                      name: "setting_change_pill_sheet_group",
-                      parameters: {
-                        "index": index,
-                        "pill_sheet_type": pillSheetType.fullName
-                      });
+                  analytics
+                      .logEvent(name: "setting_change_pill_sheet_group", parameters: {"index": index, "pill_sheet_type": pillSheetType.fullName});
                   store.changePillSheetType(index, pillSheetType, setting);
                 },
                 onDelete: (index) {
-                  analytics.logEvent(
-                      name: "setting_delete_pill_sheet_group",
-                      parameters: {"index": index});
+                  analytics.logEvent(name: "setting_delete_pill_sheet_group", parameters: {"index": index});
                   store.removePillSheetType(index, setting);
                 },
               ),
@@ -75,14 +67,16 @@ class AddPillSheetGroupPage extends HookConsumerWidget {
                       children: [
                         DisplayNumberSetting(store: store, state: state),
                         const SizedBox(height: 24),
-                        PrimaryButton(
-                          text: "追加",
-                          onPressed: () async {
-                            analytics.logEvent(
-                                name: "pressed_add_pill_sheet_group");
-                            await store.register(setting);
-                            Navigator.of(context).pop();
-                          },
+                        SizedBox(
+                          width: 180,
+                          child: PrimaryButton(
+                            text: "追加",
+                            onPressed: () async {
+                              analytics.logEvent(name: "pressed_add_pill_sheet_group");
+                              await store.register(setting);
+                              Navigator.of(context).pop();
+                            },
+                          ),
                         ),
                       ],
                     ),

--- a/lib/domain/record/components/button/taken_button.dart
+++ b/lib/domain/record/components/button/taken_button.dart
@@ -29,25 +29,28 @@ class TakenButton extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(recordPageStateNotifierProvider.notifier);
 
-    return PrimaryButton(
-      text: "飲んだ",
-      onPressed: () async {
-        try {
-          analytics.logEvent(name: "taken_button_pressed", parameters: {
-            "last_taken_pill_number": pillSheet.lastTakenPillNumber,
-            "today_pill_number": pillSheet.todayPillNumber,
-          });
-          // NOTE: batch.commit でリモートのDBに書き込む時間がかかるので事前にバッジを0にする
-          FlutterAppBadger.removeBadge();
-          requestInAppReview();
-          showReleaseNotePreDialog(context);
-          final updatedPillSheetGroup = await store.asyncAction.taken(pillSheetGroup: pillSheetGroup);
-          syncActivePillSheetValue(pillSheetGroup: updatedPillSheetGroup);
-        } catch (exception, stack) {
-          errorLogger.recordError(exception, stack);
-          showErrorAlert(context, exception);
-        }
-      },
+    return SizedBox(
+      width: 180,
+      child: PrimaryButton(
+        text: "飲んだ",
+        onPressed: () async {
+          try {
+            analytics.logEvent(name: "taken_button_pressed", parameters: {
+              "last_taken_pill_number": pillSheet.lastTakenPillNumber,
+              "today_pill_number": pillSheet.todayPillNumber,
+            });
+            // NOTE: batch.commit でリモートのDBに書き込む時間がかかるので事前にバッジを0にする
+            FlutterAppBadger.removeBadge();
+            requestInAppReview();
+            showReleaseNotePreDialog(context);
+            final updatedPillSheetGroup = await store.asyncAction.taken(pillSheetGroup: pillSheetGroup);
+            syncActivePillSheetValue(pillSheetGroup: updatedPillSheetGroup);
+          } catch (exception, stack) {
+            errorLogger.recordError(exception, stack);
+            showErrorAlert(context, exception);
+          }
+        },
+      ),
     );
   }
 }

--- a/lib/domain/settings/menstruation/setting_menstruation_page.dart
+++ b/lib/domain/settings/menstruation/setting_menstruation_page.dart
@@ -22,8 +22,7 @@ class SettingMenstruationPage extends HookConsumerWidget {
       pillSheetList: SettingMenstruationPillSheetList(
         pillSheetTypes: setting.pillSheetEnumTypes,
         appearanceMode: PillSheetAppearanceMode.sequential,
-        selectedPillNumber: (pageIndex) =>
-            store.retrieveMenstruationSelectedPillNumber(setting, pageIndex),
+        selectedPillNumber: (pageIndex) => store.retrieveMenstruationSelectedPillNumber(setting, pageIndex),
         markSelected: (pageIndex, number) {
           analytics.logEvent(name: "from_menstruation_setting", parameters: {
             "number": number,
@@ -40,9 +39,7 @@ class SettingMenstruationPage extends HookConsumerWidget {
         pillSheetTypes: setting.pillSheetEnumTypes,
         fromMenstruation: setting.pillNumberForFromMenstruation,
         fromMenstructionDidDecide: (number) {
-          analytics.logEvent(
-              name: "from_menstruation_initial_setting",
-              parameters: {"number": number});
+          analytics.logEvent(name: "from_menstruation_initial_setting", parameters: {"number": number});
           store.modifyFromMenstruationFromPicker(
             setting: setting,
             serializedPillNumberIntoGroup: number,
@@ -50,9 +47,7 @@ class SettingMenstruationPage extends HookConsumerWidget {
         },
         durationMenstruation: setting.durationMenstruation,
         durationMenstructionDidDecide: (number) {
-          analytics.logEvent(
-              name: "duration_menstruation_initial_setting",
-              parameters: {"number": number});
+          analytics.logEvent(name: "duration_menstruation_initial_setting", parameters: {"number": number});
           store.modifyDurationMenstruation(
             setting: setting,
             durationMenstruation: number,

--- a/lib/domain/settings/setting_account_list/components/delete_user_button.dart
+++ b/lib/domain/settings/setting_account_list/components/delete_user_button.dart
@@ -136,12 +136,15 @@ class _CompletedDialog extends StatelessWidget {
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 24),
-          PrimaryButton(
-            onPressed: () async {
-              Navigator.of(context).pop();
-              await onClose();
-            },
-            text: "OK",
+          SizedBox(
+            width: 180,
+            child: PrimaryButton(
+              onPressed: () async {
+                Navigator.of(context).pop();
+                await onClose();
+              },
+              text: "OK",
+            ),
           ),
         ],
       ),

--- a/lib/domain/settings/today_pill_number/setting_today_pill_number_page.dart
+++ b/lib/domain/settings/today_pill_number/setting_today_pill_number_page.dart
@@ -32,8 +32,7 @@ class SettingTodayPillNumberPage extends HookConsumerWidget {
       activedPillSheet: activedPillSheet,
     );
     final state = ref.watch(settingTodayPillNumberStoreProvider(parameter));
-    final store =
-        ref.watch(settingTodayPillNumberStoreProvider(parameter).notifier);
+    final store = ref.watch(settingTodayPillNumberStoreProvider(parameter).notifier);
 
     return Scaffold(
       backgroundColor: PilllColors.background,
@@ -63,16 +62,11 @@ class SettingTodayPillNumberPage extends HookConsumerWidget {
                   const SizedBox(height: 56),
                   Center(
                     child: SettingTodayPillNumberPillSheetList(
-                      pillSheetTypes: pillSheetGroup.pillSheets
-                          .map((e) => e.pillSheetType)
-                          .toList(),
+                      pillSheetTypes: pillSheetGroup.pillSheets.map((e) => e.pillSheetType).toList(),
                       appearanceMode: state.appearanceMode,
-                      selectedTodayPillNumberIntoPillSheet:
-                          state.selectedTodayPillNumberIntoPillSheet,
+                      selectedTodayPillNumberIntoPillSheet: state.selectedTodayPillNumberIntoPillSheet,
                       markSelected: (pageIndex, pillNumberIntoPillSheet) =>
-                          store.markSelected(
-                              pageIndex: pageIndex,
-                              pillNumberIntoPillSheet: pillNumberIntoPillSheet),
+                          store.markSelected(pageIndex: pageIndex, pillNumberIntoPillSheet: pillNumberIntoPillSheet),
                     ),
                   ),
                   const SizedBox(height: 20),
@@ -83,15 +77,18 @@ class SettingTodayPillNumberPage extends HookConsumerWidget {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
-                    PrimaryButton(
-                      onPressed: () async {
-                        unawaited(store.modifiyTodayPillNumber(
-                          pillSheetGroup: pillSheetGroup,
-                          activedPillSheet: activedPillSheet,
-                        ));
-                        Navigator.of(context).pop();
-                      },
-                      text: "変更する",
+                    SizedBox(
+                      width: 180,
+                      child: PrimaryButton(
+                        onPressed: () async {
+                          unawaited(store.modifiyTodayPillNumber(
+                            pillSheetGroup: pillSheetGroup,
+                            activedPillSheet: activedPillSheet,
+                          ));
+                          Navigator.of(context).pop();
+                        },
+                        text: "変更する",
+                      ),
                     ),
                     const SizedBox(height: 35),
                   ],


### PR DESCRIPTION
## Abstract
以下のバグの修正と仕様の追加
- 予定と日記が両方存在する日にちの場合に日記を開いた時に既に保存されている日記の情報を受け継がなかった
- 予定と日記が両方存在する日にちの場合に日記を削除できない
- Simulatorで日記の投稿画面を開くとフリーズする。原因はKeyboard表示時のScroll部分の実装にあった。リリースビルドは動くが不便なので簡易なコードに置き換えた。少し動きが変わったが前も不自然だったのでまあ良いだろう
- 予定の削除機能を追加
- 予定機能の保存が空文字でも保存できたので修正

ついでに変更した
- PrimaryButtonのmaxWidthを削除。widthがほしい場合は都度指定

## Why

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] Navigator.of(context).pop() の後にContextを使用したメソッドを実行していない
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した