### PR TITLE
Use NavigatorKey

### DIFF
--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -47,12 +47,15 @@ void connectToEmulator() {
   FirebaseFirestore.instance.settings = Settings(persistenceEnabled: false, host: '$domain:8080', sslEnabled: false);
 }
 
+final navigatorKey = GlobalKey<NavigatorState>();
+
 class App extends StatelessWidget {
   const App({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      navigatorKey: navigatorKey,
       navigatorObservers: [FirebaseAnalyticsObserver(analytics: firebaseAnalytics)],
       theme: ThemeData(
         appBarTheme: const AppBarTheme(

--- a/lib/features/error/error_alert.dart
+++ b/lib/features/error/error_alert.dart
@@ -50,7 +50,10 @@ class ErrorAlert extends StatelessWidget {
   }
 }
 
-void showErrorAlert(BuildContext context, Object error) {
+void showErrorAlert(BuildContext? context, Object error) {
+  if (context == null) {
+    return;
+  }
   final String title;
   final String message;
   final String? faqLinkURL;

--- a/lib/features/settings/components/rows/pill_sheet_remove.dart
+++ b/lib/features/settings/components/rows/pill_sheet_remove.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/entrypoint.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/components/atoms/button.dart';
 import 'package:pilll/components/atoms/font.dart';
@@ -85,9 +86,15 @@ class PillSheetRemoveRow extends HookConsumerWidget {
                   onPressed: () async {
                     try {
                       await deletePillSheetGroup(latestPillSheetGroup: latestPillSheetGroup, activedPillSheet: activedPillSheet);
-                      Navigator.of(context).pop();
+                      navigatorKey.currentState?.pop();
+                      ScaffoldMessenger.of(navigatorKey.currentContext!).showSnackBar(
+                        const SnackBar(
+                          duration: Duration(seconds: 2),
+                          content: Text("ピルシートを破棄しました"),
+                        ),
+                      );
                     } catch (error) {
-                      showErrorAlert(context, error);
+                      showErrorAlert(navigatorKey.currentContext, error);
                     }
                   },
                 ),

--- a/lib/provider/setting.dart
+++ b/lib/provider/setting.dart
@@ -14,7 +14,7 @@ class SetSetting {
   SetSetting(this.databaseConnection);
 
   Future<void> call(Setting setting) async {
-    await databaseConnection.userRawReference().set({UserFirestoreFieldKeys.settings: setting}, SetOptions(merge: true));
+    await databaseConnection.userRawReference().set({UserFirestoreFieldKeys.settings: setting.toJson()}, SetOptions(merge: true));
   }
 }
 


### PR DESCRIPTION
## Abstract
navigatorKeyをglobalに持っておいて、そこからcontextを取り出すことによりrebuild後でそのWidgetのcontextが存在しない。みたいな問題を回避できることを知ったので使用する
ref: https://stackoverflow.com/questions/56280736/alertdialog-without-context-in-flutter

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] Navigator.of(context).pop() の後にContextを使用したメソッドを実行していない
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [ ] リリースノートを追加した