### PR TITLE
生理計算部分にバグがあったので修正

### DIFF
--- a/lib/components/organisms/pill_sheet/setting_pill_sheet_view.dart
+++ b/lib/components/organisms/pill_sheet/setting_pill_sheet_view.dart
@@ -56,11 +56,8 @@ class SettingPillSheetView extends StatelessWidget {
         return Container(width: PillSheetViewLayout.componentWidth);
       }
 
-      final pillNumberIntoPillSheet =
-          PillMarkWithNumberLayoutHelper.calcPillNumberIntoPillSheet(
-              index, lineIndex);
-      final offset = summarizedPillCountWithPillSheetTypesToEndIndex(
-          pillSheetTypes: pillSheetTypes, endIndex: pageIndex);
+      final pillNumberIntoPillSheet = PillMarkWithNumberLayoutHelper.calcPillNumberIntoPillSheet(index, lineIndex);
+      final offset = summarizedPillCountWithPillSheetTypesToEndIndex(pillSheetTypes: pillSheetTypes, endIndex: pageIndex);
 
       return SizedBox(
         width: PillSheetViewLayout.componentWidth,
@@ -103,8 +100,7 @@ class SettingPillSheetView extends StatelessWidget {
     }
 
     if (pillSheetType.dosingPeriod < pillNumberIntoPillSheet) {
-      return (pillSheetType == PillSheetType.pillsheet_21 ||
-              pillSheetType == PillSheetType.pillsheet_24_rest_4)
+      return (pillSheetType == PillSheetType.pillsheet_21 || pillSheetType == PillSheetType.pillsheet_24_rest_4)
           ? PillMarkType.rest
           : PillMarkType.fake;
     }

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -57,6 +57,10 @@ class PillSheetGroup with _$PillSheetGroup {
   bool get _isDeleted => deletedAt != null;
   bool get isDeactived => activedPillSheet == null || _isDeleted;
 
+  DateTime get beginDate {
+    return pillSheets[0].beginingDate;
+  }
+
   int get sequentialTodayPillNumber {
     if (pillSheets.isEmpty) {
       return 0;

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -34,8 +34,7 @@ class PillSheetGroup with _$PillSheetGroup {
     DisplayNumberSetting? displayNumberSetting,
   }) = _PillSheetGroup;
 
-  factory PillSheetGroup.fromJson(Map<String, dynamic> json) =>
-      _$PillSheetGroupFromJson(json);
+  factory PillSheetGroup.fromJson(Map<String, dynamic> json) => _$PillSheetGroupFromJson(json);
 
   PillSheet? get activedPillSheet {
     final filtered = pillSheets.where((element) => element.isActive);
@@ -46,8 +45,7 @@ class PillSheetGroup with _$PillSheetGroup {
     if (pillSheet.id == null) {
       throw const FormatException("ピルシートの置き換えによる更新できませんでした");
     }
-    final index =
-        pillSheets.indexWhere((element) => element.id == pillSheet.id);
+    final index = pillSheets.indexWhere((element) => element.id == pillSheet.id);
     if (index == -1) {
       throw FormatException("ピルシートの置き換えによる更新できませんでした。id: ${pillSheet.id}");
     }
@@ -68,13 +66,10 @@ class PillSheetGroup with _$PillSheetGroup {
       return 0;
     }
 
-    final passedPillCountForPillSheetTypes =
-        summarizedPillCountWithPillSheetTypesToEndIndex(
-            pillSheetTypes: pillSheets.map((e) => e.pillSheetType).toList(),
-            endIndex: activedPillSheet.groupIndex);
+    final passedPillCountForPillSheetTypes = summarizedPillCountWithPillSheetTypesToEndIndex(
+        pillSheetTypes: pillSheets.map((e) => e.pillSheetType).toList(), endIndex: activedPillSheet.groupIndex);
 
-    var sequentialTodayPillNumber =
-        passedPillCountForPillSheetTypes + activedPillSheet.todayPillNumber;
+    var sequentialTodayPillNumber = passedPillCountForPillSheetTypes + activedPillSheet.todayPillNumber;
 
     final displayNumberSetting = this.displayNumberSetting;
     if (displayNumberSetting != null) {
@@ -104,13 +99,10 @@ class PillSheetGroup with _$PillSheetGroup {
       return 0;
     }
 
-    final passedPillCountForPillSheetTypes =
-        summarizedPillCountWithPillSheetTypesToEndIndex(
-            pillSheetTypes: pillSheets.map((e) => e.pillSheetType).toList(),
-            endIndex: activedPillSheet.groupIndex);
+    final passedPillCountForPillSheetTypes = summarizedPillCountWithPillSheetTypesToEndIndex(
+        pillSheetTypes: pillSheets.map((e) => e.pillSheetType).toList(), endIndex: activedPillSheet.groupIndex);
 
-    var sequentialLastTakenPillNumber =
-        passedPillCountForPillSheetTypes + activedPillSheet.lastTakenPillNumber;
+    var sequentialLastTakenPillNumber = passedPillCountForPillSheetTypes + activedPillSheet.lastTakenPillNumber;
 
     final displayNumberSetting = this.displayNumberSetting;
     if (displayNumberSetting != null) {
@@ -133,9 +125,7 @@ class PillSheetGroup with _$PillSheetGroup {
 
   int get estimatedEndPillNumber {
     var estimatedEndPillNumber =
-        summarizedPillCountWithPillSheetTypesToEndIndex(
-            pillSheetTypes: pillSheets.map((e) => e.pillSheetType).toList(),
-            endIndex: pillSheets.length);
+        summarizedPillCountWithPillSheetTypesToEndIndex(pillSheetTypes: pillSheets.map((e) => e.pillSheetType).toList(), endIndex: pillSheets.length);
 
     final displayNumberSetting = this.displayNumberSetting;
     if (displayNumberSetting != null) {
@@ -165,6 +155,5 @@ class DisplayNumberSetting with _$DisplayNumberSetting {
     int? endPillNumber,
   }) = _DisplayNumberSetting;
 
-  factory DisplayNumberSetting.fromJson(Map<String, dynamic> json) =>
-      _$DisplayNumberSettingFromJson(json);
+  factory DisplayNumberSetting.fromJson(Map<String, dynamic> json) => _$DisplayNumberSettingFromJson(json);
 }


### PR DESCRIPTION
## Abstract
生理画面の `あと$diff日`の表記の計算式の修正。
21 , 28 , 28 錠のシートの組み合わせで、生理設定を28錠ずつに設定すると、下の計算式が、ピルシート毎に28錠目の番号を探すような計算式になっていた。
これだと21の存在により微妙に計算式がずれるようになっていた。が、単純にピルシートグループの開始日から、設定のピル番号を足していく計算式で良いのでは。と思い直し変更を加える

## Why

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] Navigator.of(context).pop() の後にContextを使用したメソッドを実行していない
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した