### PR TITLE
Fix login

### DIFF
--- a/lib/features/settings/components/inquiry/inquiry.dart
+++ b/lib/features/settings/components/inquiry/inquiry.dart
@@ -7,6 +7,8 @@ import 'package:pilll/entity/setting.codegen.dart';
 import 'package:pilll/provider/pill_sheet_group.dart';
 import 'package:pilll/utils/environment.dart';
 import 'package:package_info/package_info.dart';
+import 'package:pilll/utils/shared_preference/keys.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../entity/user.codegen.dart';
@@ -23,7 +25,8 @@ inquiry() {
 Future<String> debugInfo(String separator) async {
   final userID = auth.FirebaseAuth.instance.currentUser?.uid;
   if (userID == null) {
-    return Future.value("DEBUG INFO user is not found");
+    final sharedPreferences = await SharedPreferences.getInstance();
+    return Future.value("DEBUG INFO user is not found. lastest last login id ${sharedPreferences.getString(StringKey.lastSignInAnonymousUID)}");
   }
 
   DatabaseConnection databaseConnection = DatabaseConnection(userID);

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -81,7 +81,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            firebaseUserStateProvider.overrideWith((ref) => Stream.value(fakeFirebaseUser)),
+            firebaseSignInProvider.overrideWith((ref) => Future.value(fakeFirebaseUser)),
             checkForceUpdateProvider.overrideWith((_) => checkForceUpdate),
             setUserIDProvider.overrideWith((ref) => setUserID),
             databaseProvider.overrideWith((ref) => MockDatabaseConnection()),
@@ -131,7 +131,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            firebaseUserStateProvider.overrideWith((ref) => Stream.value(fakeFirebaseUser)),
+            firebaseSignInProvider.overrideWith((ref) => Future.value(fakeFirebaseUser)),
             checkForceUpdateProvider.overrideWith((_) => checkForceUpdate),
             setUserIDProvider.overrideWith((ref) => setUserID),
             databaseProvider.overrideWith((ref) => MockDatabaseConnection()),


### PR DESCRIPTION
## Abstract
ログインの処理を修正。userStateChangesを最初に監視するとイベントが飛んでこない場合がありそうでずっとローディングになる(可能性がある）
冷静に処理を見返すとsignInの時にcurrentUserのチェックをした後にuserChangesのStreamの確認の流れの関数があり、この処理の流れが本来正しいなと思いそれを直接使用する

## Why

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] Navigator.of(context).pop() の後にContextを使用したメソッドを実行していない
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた
- [x] リリースノートを追加した