### PR TITLE
初期設定からメインストリームの画面に遷移する間での色々を修正

### DIFF
--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -87,8 +87,8 @@ class App extends StatelessWidget {
           ),
         ),
       ),
-      home: const ProviderScope(
-        child: RootPage(),
+      home: ProviderScope(
+        child: RootPage(builder: (_, userID) => InitialSettingOrAppPage(userID: userID)),
       ),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,

--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -5,6 +5,7 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:pilll/features/root/user_setup_page.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
@@ -88,7 +89,7 @@ class App extends StatelessWidget {
         ),
       ),
       home: ProviderScope(
-        child: RootPage(builder: (_, userID) => InitialSettingOrAppPage(userID: userID)),
+        child: RootPage(builder: (_, userID) => UserSetupPage(userID: userID)),
       ),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,

--- a/lib/entrypoint.dart
+++ b/lib/entrypoint.dart
@@ -88,7 +88,7 @@ class App extends StatelessWidget {
         ),
       ),
       home: const ProviderScope(
-        child: Root(),
+        child: RootPage(),
       ),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,

--- a/lib/features/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
+++ b/lib/features/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
@@ -19,7 +19,6 @@ import 'package:pilll/components/atoms/text_color.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/entity/pill_sheet_type.dart';
-import 'package:pilll/provider/auth.dart';
 import 'package:pilll/entity/link_account_type.dart';
 import 'package:pilll/features/sign_in/sign_in_sheet.dart';
 import 'package:pilll/utils/router.dart';

--- a/lib/features/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
+++ b/lib/features/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:pilll/provider/shared_preferences.dart';
+import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/utils/auth/apple.dart';
 import 'package:pilll/utils/auth/google.dart';
@@ -19,6 +21,8 @@ import 'package:pilll/entity/pill_sheet_type.dart';
 import 'package:pilll/provider/auth.dart';
 import 'package:pilll/entity/link_account_type.dart';
 import 'package:pilll/features/sign_in/sign_in_sheet.dart';
+import 'package:pilll/utils/router.dart';
+import 'package:pilll/utils/shared_preference/keys.dart';
 
 class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
   const InitialSettingPillSheetGroupPage({Key? key}) : super(key: key);
@@ -28,9 +32,12 @@ class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
     final store = ref.watch(initialSettingStateNotifierProvider.notifier);
     final state = ref.watch(initialSettingStateNotifierProvider);
     final authStream = ref.watch(firebaseUserStateProvider.stream);
+    final userStream = ref.watch(userProvider.stream);
     final isAppleLinked = ref.watch(isAppleLinkedProvider);
     final isGoogleLinked = ref.watch(isGoogleLinkedProvider);
+    final didEndInitialSettingNotifier = ref.watch(boolSharedPreferencesProvider(BoolKey.didEndInitialSetting).notifier);
 
+    // For linked user
     useEffect(() {
       final subscription = authStream.listen((user) {
         if (user != null) {
@@ -57,6 +64,17 @@ class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
               });
             }
           }
+        }
+      });
+
+      return subscription.cancel;
+    }, [true]);
+
+    // Skip initial setting when user already set setting.
+    useEffect(() {
+      final subscription = userStream.listen((user) async {
+        if (user.setting != null) {
+          await AppRouter.endInitialSetting(context, didEndInitialSettingNotifier);
         }
       });
 

--- a/lib/features/root/initial_setting_or_app_page.dart
+++ b/lib/features/root/initial_setting_or_app_page.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/features/root/launch_exception.dart';
+import 'package:pilll/provider/shared_preferences.dart';
+import 'package:pilll/utils/analytics.dart';
+import 'package:pilll/features/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart';
+import 'package:pilll/entity/user.codegen.dart';
+import 'package:pilll/provider/root.dart';
+import 'package:pilll/features/home/home_page.dart';
+import 'package:pilll/components/molecules/indicator.dart';
+import 'package:pilll/features/error/universal_error_page.dart';
+import 'package:pilll/provider/user.dart';
+import 'package:pilll/utils/shared_preference/keys.dart';
+import 'package:flutter/material.dart';
+
+// FIXME: test 時にboolSharedPreferencesProviderをそのまま使うとフリーズする
+final didEndInitialSettingProvider = Provider((ref) => ref.watch(boolSharedPreferencesProvider(BoolKey.didEndInitialSetting)));
+
+enum InitialSettingOrAppPageScreenType { loading, initialSetting, app }
+
+// InitialSettingかAppのメインストリームのWidgetに分岐する
+// 主にdidEndInitialSettingの値によって分岐するが、下位互換や何らかの理由でuser.settingがnullになってしまったユーザーのためにuserの値を見てinitialSettingに分岐するかも決定する
+class InitialSettingOrAppPage extends HookConsumerWidget {
+  final User user;
+  const InitialSettingOrAppPage({Key? key, required this.user}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final markAsMigratedToFlutter = ref.watch(markAsMigratedToFlutterProvider);
+    final didEndInitialSettingAsyncValue = ref.watch(didEndInitialSettingProvider);
+
+    final error = useState<LaunchException?>(null);
+    final screenType = calcScreenType(user: user, didEndInitialSettingAsyncValue: didEndInitialSettingAsyncValue);
+
+    useEffect(() {
+      if (!user.migratedFlutter) {
+        markAsMigratedToFlutter();
+        analytics.logEvent(name: "user_is_not_migrated_flutter", parameters: {"uid": user.id});
+      } else if (user.setting == null) {
+        analytics.logEvent(name: "uset_setting_is_null", parameters: {"uid": user.id});
+      }
+      return null;
+    }, []);
+
+    return UniversalErrorPage(
+      error: error.value,
+      reload: () => ref.refresh(refreshAppProvider),
+      child: () {
+        switch (screenType) {
+          case InitialSettingOrAppPageScreenType.loading:
+            return const ScaffoldIndicator();
+          case InitialSettingOrAppPageScreenType.initialSetting:
+            return InitialSettingPillSheetGroupPageRoute.screen();
+          case InitialSettingOrAppPageScreenType.app:
+            return const HomePage();
+        }
+      }(),
+    );
+  }
+}
+
+InitialSettingOrAppPageScreenType calcScreenType({
+  required User user,
+  required AsyncValue<bool?> didEndInitialSettingAsyncValue,
+}) {
+  if (didEndInitialSettingAsyncValue is! AsyncData) {
+    return InitialSettingOrAppPageScreenType.loading;
+  }
+  if (!user.migratedFlutter) {
+    return InitialSettingOrAppPageScreenType.initialSetting;
+  } else if (user.setting == null) {
+    return InitialSettingOrAppPageScreenType.initialSetting;
+  }
+
+  final didEndInitialSetting = didEndInitialSettingAsyncValue.value;
+  if (didEndInitialSetting == null) {
+    analytics.logEvent(name: "did_end_i_s_is_null");
+    return InitialSettingOrAppPageScreenType.initialSetting;
+  }
+  if (!didEndInitialSetting) {
+    analytics.logEvent(name: "did_end_i_s_is_false");
+    return InitialSettingOrAppPageScreenType.initialSetting;
+  }
+
+  analytics.logEvent(name: "screen_type_is_home");
+  return InitialSettingOrAppPageScreenType.app;
+}

--- a/lib/features/root/initial_setting_or_app_page.dart
+++ b/lib/features/root/initial_setting_or_app_page.dart
@@ -21,13 +21,14 @@ enum InitialSettingOrAppPageScreenType { loading, initialSetting, app }
 // InitialSettingかAppのメインストリームのWidgetに分岐する
 // 主にdidEndInitialSettingの値によって分岐するが、下位互換や何らかの理由でuser.settingがnullになってしまったユーザーのためにuserの値を見てinitialSettingに分岐するかも決定する
 class InitialSettingOrAppPage extends HookConsumerWidget {
-  final User user;
-  const InitialSettingOrAppPage({Key? key, required this.user}) : super(key: key);
+  const InitialSettingOrAppPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final markAsMigratedToFlutter = ref.watch(markAsMigratedToFlutterProvider);
     final didEndInitialSettingAsyncValue = ref.watch(didEndInitialSettingProvider);
+    // UserSetupPageでUserはできている。ここでwatchしないとInitialSetting -> Appへの遷移が成立しない
+    final user = ref.watch(userProvider).requireValue;
 
     final error = useState<LaunchException?>(null);
     final screenType = calcScreenType(user: user, didEndInitialSettingAsyncValue: didEndInitialSettingAsyncValue);

--- a/lib/features/root/launch_exception.dart
+++ b/lib/features/root/launch_exception.dart
@@ -1,0 +1,12 @@
+class LaunchException {
+  final String message;
+  final Object underlyingException;
+
+  LaunchException(
+    this.message,
+    this.underlyingException,
+  );
+
+  @override
+  String toString() => message + underlyingException.toString();
+}

--- a/lib/features/root/root_page.dart
+++ b/lib/features/root/root_page.dart
@@ -2,24 +2,18 @@ import 'dart:async';
 
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/features/root/launch_exception.dart';
 import 'package:pilll/provider/force_update.dart';
 import 'package:pilll/provider/set_user_id.dart';
-import 'package:pilll/provider/shared_preferences.dart';
-import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/components/page/ok_dialog.dart';
-import 'package:pilll/features/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart';
-import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/provider/root.dart';
 import 'package:pilll/provider/auth.dart';
-import 'package:pilll/features/home/home_page.dart';
 import 'package:pilll/components/molecules/indicator.dart';
 import 'package:pilll/features/error/template.dart';
 import 'package:pilll/features/error/universal_error_page.dart';
 import 'package:pilll/utils/environment.dart';
 import 'package:pilll/utils/error_log.dart';
-import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/platform/platform.dart';
-import 'package:pilll/utils/shared_preference/keys.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -123,117 +117,4 @@ class RootPage extends HookConsumerWidget {
       }(),
     );
   }
-}
-
-class LaunchException {
-  final String message;
-  final Object underlyingException;
-
-  LaunchException(
-    this.message,
-    this.underlyingException,
-  );
-
-  @override
-  String toString() => message + underlyingException.toString();
-}
-
-// FIXME: test 時にboolSharedPreferencesProviderをそのまま使うとフリーズする
-final didEndInitialSettingProvider = Provider((ref) => ref.watch(boolSharedPreferencesProvider(BoolKey.didEndInitialSetting)));
-
-enum InitialSettingOrAppPageScreenType { loading, initialSetting, app }
-
-class InitialSettingOrAppPage extends HookConsumerWidget {
-  final String userID;
-  const InitialSettingOrAppPage({Key? key, required this.userID}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final fetchOrCreateUser = ref.watch(fetchOrCreateUserProvider);
-    final saveUserLaunchInfo = ref.watch(saveUserLaunchInfoProvider);
-    final markAsMigratedToFlutter = ref.watch(markAsMigratedToFlutterProvider);
-    final didEndInitialSettingAsyncValue = ref.watch(didEndInitialSettingProvider);
-
-    final appUser = useState<User?>(null);
-    final error = useState<LaunchException?>(null);
-    final screenType = calcScreenType(user: appUser.value, didEndInitialSettingAsyncValue: didEndInitialSettingAsyncValue);
-
-    // Setup user
-    useEffect(() {
-      f() async {
-        // **** BEGIN: Do not break the sequence. ****
-        try {
-          // Decide screen type. Keep in mind that this method is called when user is logged in.
-          final appUserValue = appUser.value;
-          if (appUserValue == null) {
-            // Retrieve user from app DB.
-            final user = await fetchOrCreateUser(userID);
-            appUser.value = user;
-          }
-        } catch (e, st) {
-          errorLogger.recordError(e, st);
-          error.value = LaunchException("起動時にエラーが発生しました\n${ErrorMessages.connection}\n詳細:", e);
-        }
-        // **** END: Do not break the sequence. ****
-      }
-
-      f();
-      return null;
-    }, []);
-
-    useEffect(() {
-      final appUserValue = appUser.value;
-      if (appUserValue != null) {
-        saveUserLaunchInfo(appUserValue);
-
-        // MUST initial setting user
-        if (!appUserValue.migratedFlutter) {
-          markAsMigratedToFlutter();
-          analytics.logEvent(name: "user_is_not_migrated_flutter", parameters: {"uid": userID});
-        } else if (appUserValue.setting == null) {
-          analytics.logEvent(name: "uset_setting_is_null", parameters: {"uid": userID});
-        }
-      }
-      return null;
-    }, [appUser.value]);
-
-    return UniversalErrorPage(
-      error: error.value,
-      reload: () => ref.refresh(refreshAppProvider),
-      child: () {
-        switch (screenType) {
-          case InitialSettingOrAppPageScreenType.loading:
-            return const ScaffoldIndicator();
-          case InitialSettingOrAppPageScreenType.initialSetting:
-            return InitialSettingPillSheetGroupPageRoute.screen();
-          case InitialSettingOrAppPageScreenType.app:
-            return const HomePage();
-        }
-      }(),
-    );
-  }
-}
-
-InitialSettingOrAppPageScreenType calcScreenType({required User? user, required AsyncValue<bool?> didEndInitialSettingAsyncValue}) {
-  if (user == null || didEndInitialSettingAsyncValue is! AsyncData) {
-    return InitialSettingOrAppPageScreenType.loading;
-  }
-  if (!user.migratedFlutter) {
-    return InitialSettingOrAppPageScreenType.initialSetting;
-  } else if (user.setting == null) {
-    return InitialSettingOrAppPageScreenType.initialSetting;
-  }
-
-  final didEndInitialSetting = didEndInitialSettingAsyncValue.value;
-  if (didEndInitialSetting == null) {
-    analytics.logEvent(name: "did_end_i_s_is_null");
-    return InitialSettingOrAppPageScreenType.initialSetting;
-  }
-  if (!didEndInitialSetting) {
-    analytics.logEvent(name: "did_end_i_s_is_false");
-    return InitialSettingOrAppPageScreenType.initialSetting;
-  }
-
-  analytics.logEvent(name: "screen_type_is_home");
-  return InitialSettingOrAppPageScreenType.app;
 }

--- a/lib/features/root/root_page.dart
+++ b/lib/features/root/root_page.dart
@@ -35,7 +35,7 @@ class RootPage extends HookConsumerWidget {
     final checkForceUpdate = ref.watch(checkForceUpdateProvider);
     final setUserID = ref.watch(setUserIDProvider);
 
-    final userID = useState<String?>(null);
+    final firebaseUserID = useState<String?>(null);
     final shouldForceUpdate = useState(false);
     final error = useState<LaunchException?>(null);
 
@@ -73,7 +73,7 @@ class RootPage extends HookConsumerWidget {
         // SignIn first. Keep in mind that this method is called first.
         try {
           final firebaseUser = await signInFirebaseUser;
-          userID.value = firebaseUser.uid;
+          firebaseUserID.value = firebaseUser.uid;
         } catch (e, st) {
           errorLogger.recordError(e, st);
           error.value = LaunchException("認証時にエラーが発生しました\n${ErrorMessages.connection}\n詳細:", e);
@@ -85,13 +85,13 @@ class RootPage extends HookConsumerWidget {
     }, []);
 
     useEffect(() {
-      final userIDValue = userID.value;
+      final userIDValue = firebaseUserID.value;
       if (userIDValue != null) {
         setUserID(userID: userIDValue);
       }
 
       return null;
-    }, [userID.value]);
+    }, [firebaseUserID.value]);
 
     // For force update
     if (shouldForceUpdate.value) {
@@ -115,7 +115,7 @@ class RootPage extends HookConsumerWidget {
         ref.invalidate(refreshAppProvider);
       },
       child: () {
-        final uid = userID.value;
+        final uid = firebaseUserID.value;
         if (uid == null) {
           return const ScaffoldIndicator();
         } else {

--- a/lib/features/root/root_page.dart
+++ b/lib/features/root/root_page.dart
@@ -35,7 +35,7 @@ class RootPage extends HookConsumerWidget {
     final checkForceUpdate = ref.watch(checkForceUpdateProvider);
     final setUserID = ref.watch(setUserIDProvider);
 
-    final firebaseUserID = useState<String?>(null);
+    final userID = useState<String?>(null);
     final shouldForceUpdate = useState(false);
     final error = useState<LaunchException?>(null);
 
@@ -73,7 +73,7 @@ class RootPage extends HookConsumerWidget {
         // SignIn first. Keep in mind that this method is called first.
         try {
           final firebaseUser = await signInFirebaseUser;
-          firebaseUserID.value = firebaseUser.uid;
+          userID.value = firebaseUser.uid;
         } catch (e, st) {
           errorLogger.recordError(e, st);
           error.value = LaunchException("認証時にエラーが発生しました\n${ErrorMessages.connection}\n詳細:", e);
@@ -85,13 +85,13 @@ class RootPage extends HookConsumerWidget {
     }, []);
 
     useEffect(() {
-      final userIDValue = firebaseUserID.value;
+      final userIDValue = userID.value;
       if (userIDValue != null) {
         setUserID(userID: userIDValue);
       }
 
       return null;
-    }, [firebaseUserID.value]);
+    }, [userID.value]);
 
     // For force update
     if (shouldForceUpdate.value) {
@@ -115,7 +115,7 @@ class RootPage extends HookConsumerWidget {
         ref.invalidate(refreshAppProvider);
       },
       child: () {
-        final uid = firebaseUserID.value;
+        final uid = userID.value;
         if (uid == null) {
           return const ScaffoldIndicator();
         } else {

--- a/lib/features/root/root_page.dart
+++ b/lib/features/root/root_page.dart
@@ -18,7 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class RootPage extends HookConsumerWidget {
-  // NOTE: RootPageより下のWidgetのProviderを用意するのは現実的では無いので、builderからメインストリームのWidgetを決定する
+  // NOTE: テスト時にRootPageより下のWidgetのProviderを用意するのは現実的では無いので、builderからメインストリームのWidgetを決定する。
   final Widget Function(BuildContext, String) builder;
   const RootPage({Key? key, required this.builder}) : super(key: key);
 
@@ -47,6 +47,8 @@ class RootPage extends HookConsumerWidget {
 
       f() async {
         try {
+          // 計測してみたらこの処理が結構長かった。通常の起動時間に影響があるので、この処理を非同期にする。
+          // 多少データが変更される可能性があるが、それは飲み込むことにする。ほとんど問題はないはず
           if (await checkForceUpdate()) {
             shouldForceUpdate.value = true;
           }

--- a/lib/features/root/root_page.dart
+++ b/lib/features/root/root_page.dart
@@ -23,9 +23,6 @@ import 'package:pilll/utils/shared_preference/keys.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-// FIXME: test 時にboolSharedPreferencesProviderをそのまま使うとフリーズする
-final didEndInitialSettingProvider = Provider((ref) => ref.watch(boolSharedPreferencesProvider(BoolKey.didEndInitialSetting)));
-
 class RootPage extends HookConsumerWidget {
   const RootPage({Key? key}) : super(key: key);
 
@@ -138,6 +135,9 @@ class LaunchException {
   @override
   String toString() => message + underlyingException.toString();
 }
+
+// FIXME: test 時にboolSharedPreferencesProviderをそのまま使うとフリーズする
+final didEndInitialSettingProvider = Provider((ref) => ref.watch(boolSharedPreferencesProvider(BoolKey.didEndInitialSetting)));
 
 enum _InitialSettingOrAppPageScreenType { loading, initialSetting, app }
 

--- a/lib/features/root/root_page.dart
+++ b/lib/features/root/root_page.dart
@@ -26,8 +26,8 @@ import 'package:url_launcher/url_launcher.dart';
 // FIXME: test 時にboolSharedPreferencesProviderをそのまま使うとフリーズする
 final didEndInitialSettingProvider = Provider((ref) => ref.watch(boolSharedPreferencesProvider(BoolKey.didEndInitialSetting)));
 
-class Root extends HookConsumerWidget {
-  const Root({Key? key}) : super(key: key);
+class RootPage extends HookConsumerWidget {
+  const RootPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/features/root/root_page.dart
+++ b/lib/features/root/root_page.dart
@@ -115,11 +115,11 @@ class RootPage extends HookConsumerWidget {
         ref.invalidate(refreshAppProvider);
       },
       child: () {
-        final uid = userID.value;
-        if (uid == null) {
+        final userIDValue = userID.value;
+        if (userIDValue == null) {
           return const ScaffoldIndicator();
         } else {
-          return InitialSettingOrAppPage(firebaseUserID: uid);
+          return InitialSettingOrAppPage(userID: userIDValue);
         }
       }(),
     );
@@ -142,8 +142,8 @@ class LaunchException {
 enum _InitialSettingOrAppPageScreenType { loading, initialSetting, app }
 
 class InitialSettingOrAppPage extends HookConsumerWidget {
-  final String firebaseUserID;
-  const InitialSettingOrAppPage({Key? key, required this.firebaseUserID}) : super(key: key);
+  final String userID;
+  const InitialSettingOrAppPage({Key? key, required this.userID}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -168,17 +168,17 @@ class InitialSettingOrAppPage extends HookConsumerWidget {
             final appUserValue = appUser.value;
             if (appUserValue == null) {
               // Retrieve user from app DB.
-              final user = await fetchOrCreateUser(firebaseUserID);
+              final user = await fetchOrCreateUser(userID);
               saveUserLaunchInfo(user);
               appUser.value = user;
 
               // Rescue for old users
               if (!user.migratedFlutter) {
                 markAsMigratedToFlutter();
-                analytics.logEvent(name: "user_is_not_migrated_flutter", parameters: {"uid": firebaseUserID});
+                analytics.logEvent(name: "user_is_not_migrated_flutter", parameters: {"uid": userID});
                 screenType.value = _InitialSettingOrAppPageScreenType.initialSetting;
               } else if (user.setting == null) {
-                analytics.logEvent(name: "uset_setting_is_null", parameters: {"uid": firebaseUserID});
+                analytics.logEvent(name: "uset_setting_is_null", parameters: {"uid": userID});
                 screenType.value = _InitialSettingOrAppPageScreenType.initialSetting;
               }
             }

--- a/lib/features/root/root_page.dart
+++ b/lib/features/root/root_page.dart
@@ -24,7 +24,9 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class RootPage extends HookConsumerWidget {
-  const RootPage({Key? key}) : super(key: key);
+  // NOTE: RootPageより下のWidgetのProviderを用意するのは現実的では無いので、builderからメインストリームのWidgetを決定する
+  final Widget Function(BuildContext, String) builder;
+  const RootPage({Key? key, required this.builder}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -116,7 +118,7 @@ class RootPage extends HookConsumerWidget {
         if (userIDValue == null) {
           return const ScaffoldIndicator();
         } else {
-          return InitialSettingOrAppPage(userID: userIDValue);
+          return builder(context, userIDValue);
         }
       }(),
     );

--- a/lib/features/root/user_setup_page.dart
+++ b/lib/features/root/user_setup_page.dart
@@ -64,9 +64,7 @@ class UserSetupPage extends HookConsumerWidget {
         if (appUserValue == null) {
           return const ScaffoldIndicator();
         } else {
-          return InitialSettingOrAppPage(
-            user: appUserValue,
-          );
+          return const InitialSettingOrAppPage();
         }
       }(),
     );

--- a/lib/features/root/user_setup_page.dart
+++ b/lib/features/root/user_setup_page.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/features/root/initial_setting_or_app_page.dart';
+import 'package:pilll/features/root/launch_exception.dart';
+import 'package:pilll/utils/analytics.dart';
+import 'package:pilll/entity/user.codegen.dart';
+import 'package:pilll/provider/root.dart';
+import 'package:pilll/components/molecules/indicator.dart';
+import 'package:pilll/features/error/template.dart';
+import 'package:pilll/features/error/universal_error_page.dart';
+import 'package:pilll/utils/error_log.dart';
+import 'package:pilll/provider/user.dart';
+import 'package:flutter/material.dart';
+
+// Userの作成・もしくは取得を行い次のWidgetに渡す
+class UserSetupPage extends HookConsumerWidget {
+  final String userID;
+  const UserSetupPage({Key? key, required this.userID}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final fetchOrCreateUser = ref.watch(fetchOrCreateUserProvider);
+    final saveUserLaunchInfo = ref.watch(saveUserLaunchInfoProvider);
+
+    final appUser = useState<User?>(null);
+    final error = useState<LaunchException?>(null);
+
+    // Setup user
+    useEffect(() {
+      f() async {
+        // **** BEGIN: Do not break the sequence. ****
+        try {
+          // Decide screen type. Keep in mind that this method is called when user is logged in.
+          final appUserValue = appUser.value;
+          if (appUserValue == null) {
+            // Retrieve user from app DB.
+            final user = await fetchOrCreateUser(userID);
+            appUser.value = user;
+          }
+        } catch (e, st) {
+          errorLogger.recordError(e, st);
+          error.value = LaunchException("起動時にエラーが発生しました\n${ErrorMessages.connection}\n詳細:", e);
+        }
+        // **** END: Do not break the sequence. ****
+      }
+
+      f();
+      return null;
+    }, []);
+
+    useEffect(() {
+      final appUserValue = appUser.value;
+      if (appUserValue != null) {
+        saveUserLaunchInfo(appUserValue);
+      }
+      return null;
+    }, [appUser.value]);
+
+    return UniversalErrorPage(
+      error: error.value,
+      reload: () => ref.refresh(refreshAppProvider),
+      child: () {
+        final appUserValue = appUser.value;
+        if (appUserValue == null) {
+          return const ScaffoldIndicator();
+        } else {
+          return InitialSettingOrAppPage(
+            user: appUserValue,
+          );
+        }
+      }(),
+    );
+  }
+}
+
+InitialSettingOrAppPageScreenType calcScreenType({
+  required User? user,
+  required AsyncValue<bool> userDocumentIsExist,
+  required AsyncValue<bool?> didEndInitialSettingAsyncValue,
+}) {
+  if (userDocumentIsExist is! AsyncData || userDocumentIsExist.requireValue == false) {
+    return InitialSettingOrAppPageScreenType.loading;
+  }
+  if (user == null || didEndInitialSettingAsyncValue is! AsyncData) {
+    return InitialSettingOrAppPageScreenType.loading;
+  }
+  if (!user.migratedFlutter) {
+    return InitialSettingOrAppPageScreenType.initialSetting;
+  } else if (user.setting == null) {
+    return InitialSettingOrAppPageScreenType.initialSetting;
+  }
+
+  final didEndInitialSetting = didEndInitialSettingAsyncValue.value;
+  if (didEndInitialSetting == null) {
+    analytics.logEvent(name: "did_end_i_s_is_null");
+    return InitialSettingOrAppPageScreenType.initialSetting;
+  }
+  if (!didEndInitialSetting) {
+    analytics.logEvent(name: "did_end_i_s_is_false");
+    return InitialSettingOrAppPageScreenType.initialSetting;
+  }
+
+  analytics.logEvent(name: "screen_type_is_home");
+  return InitialSettingOrAppPageScreenType.app;
+}

--- a/lib/provider/auth.dart
+++ b/lib/provider/auth.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/utils/auth/apple.dart';

--- a/lib/provider/database.dart
+++ b/lib/provider/database.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: prefer_function_declarations_over_variables
 
+import 'package:firebase_auth/firebase_auth.dart' as firebase;
 import 'package:flutter/foundation.dart';
 import 'package:pilll/entity/diary.codegen.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -15,7 +16,8 @@ import 'package:pilll/provider/auth.dart';
 
 final databaseProvider = Provider<DatabaseConnection>((ref) {
   final stream = ref.watch(firebaseUserStateProvider);
-  final uid = stream.asData?.value?.uid;
+  // 初回起動の時には.userChanges()のstreamは流れてこないので、currentUserのidを使う
+  final uid = stream.asData?.value?.uid ?? firebase.FirebaseAuth.instance.currentUser?.uid;
   debugPrint("[DEBUG] database uid is $uid");
   return DatabaseConnection(uid);
 });

--- a/lib/provider/database.dart
+++ b/lib/provider/database.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: prefer_function_declarations_over_variables
 
-import 'package:firebase_auth/firebase_auth.dart' as firebase;
 import 'package:flutter/foundation.dart';
 import 'package:pilll/entity/diary.codegen.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -16,7 +15,7 @@ import 'package:pilll/provider/auth.dart';
 
 final databaseProvider = Provider<DatabaseConnection>((ref) {
   final stream = ref.watch(firebaseUserStateProvider);
-  final uid = stream.asData?.value?.uid ?? firebase.FirebaseAuth.instance.currentUser?.uid;
+  final uid = stream.asData?.value?.uid;
   debugPrint("[DEBUG] database uid is $uid");
   return DatabaseConnection(uid);
 });

--- a/lib/provider/shared_preferences.dart
+++ b/lib/provider/shared_preferences.dart
@@ -3,7 +3,6 @@ import 'package:pilll/provider/shared_preference.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-final mustSharedPreferenceProvider = Provider((ref) => ref.watch(sharedPreferenceProvider).value!);
 final boolSharedPreferencesProvider = AsyncNotifierProvider.family<BoolSharedPreferences, bool?, String>(() => BoolSharedPreferences());
 
 class BoolSharedPreferences extends FamilyAsyncNotifier<bool?, String> {
@@ -19,7 +18,7 @@ class BoolSharedPreferences extends FamilyAsyncNotifier<bool?, String> {
   @override
   FutureOr<bool?> build(String arg) async {
     key = arg;
-    sharedPreferences = ref.watch(mustSharedPreferenceProvider);
+    sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
     return sharedPreferences.getBool(key);
   }
 }
@@ -39,7 +38,7 @@ class IntSharedPreferences extends FamilyAsyncNotifier<int?, String> {
   @override
   FutureOr<int?> build(String arg) async {
     key = arg;
-    sharedPreferences = ref.watch(mustSharedPreferenceProvider);
+    sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
     return sharedPreferences.getInt(key);
   }
 }
@@ -61,7 +60,8 @@ class StringSharedPreferences extends FamilyAsyncNotifier<String?, String> {
   @override
   FutureOr<String?> build(String arg) async {
     key = arg;
-    sharedPreferences = ref.watch(mustSharedPreferenceProvider);
+    sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
+
     return sharedPreferences.getString(key);
   }
 }

--- a/lib/provider/shared_preferences.dart
+++ b/lib/provider/shared_preferences.dart
@@ -61,7 +61,6 @@ class StringSharedPreferences extends FamilyAsyncNotifier<String?, String> {
   FutureOr<String?> build(String arg) async {
     key = arg;
     sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
-
     return sharedPreferences.getString(key);
   }
 }

--- a/lib/provider/shared_preferences.dart
+++ b/lib/provider/shared_preferences.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
-import 'package:pilll/provider/shared_preference.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+final sharedPrefenreceProvider = FutureProvider((ref) => SharedPreferences.getInstance());
+final mustSharedPreferencesProvider = Provider((ref) => ref.watch(sharedPrefenreceProvider).value!);
 
 final boolSharedPreferencesProvider = AsyncNotifierProvider.family<BoolSharedPreferences, bool?, String>(() => BoolSharedPreferences());
 
@@ -18,7 +20,7 @@ class BoolSharedPreferences extends FamilyAsyncNotifier<bool?, String> {
   @override
   FutureOr<bool?> build(String arg) async {
     key = arg;
-    sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
+    sharedPreferences = ref.watch(mustSharedPreferencesProvider);
     return sharedPreferences.getBool(key);
   }
 }
@@ -38,7 +40,7 @@ class IntSharedPreferences extends FamilyAsyncNotifier<int?, String> {
   @override
   FutureOr<int?> build(String arg) async {
     key = arg;
-    sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
+    sharedPreferences = ref.watch(mustSharedPreferencesProvider);
     return sharedPreferences.getInt(key);
   }
 }
@@ -60,7 +62,7 @@ class StringSharedPreferences extends FamilyAsyncNotifier<String?, String> {
   @override
   FutureOr<String?> build(String arg) async {
     key = arg;
-    sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
+    sharedPreferences = ref.watch(mustSharedPreferencesProvider);
     return sharedPreferences.getString(key);
   }
 }

--- a/lib/provider/shared_preferences.dart
+++ b/lib/provider/shared_preferences.dart
@@ -3,6 +3,7 @@ import 'package:pilll/provider/shared_preference.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+final mustSharedPreferenceProvider = Provider((ref) => ref.watch(sharedPreferenceProvider).value!);
 final boolSharedPreferencesProvider = AsyncNotifierProvider.family<BoolSharedPreferences, bool?, String>(() => BoolSharedPreferences());
 
 class BoolSharedPreferences extends FamilyAsyncNotifier<bool?, String> {
@@ -18,7 +19,7 @@ class BoolSharedPreferences extends FamilyAsyncNotifier<bool?, String> {
   @override
   FutureOr<bool?> build(String arg) async {
     key = arg;
-    sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
+    sharedPreferences = ref.watch(mustSharedPreferenceProvider);
     return sharedPreferences.getBool(key);
   }
 }
@@ -38,7 +39,7 @@ class IntSharedPreferences extends FamilyAsyncNotifier<int?, String> {
   @override
   FutureOr<int?> build(String arg) async {
     key = arg;
-    sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
+    sharedPreferences = ref.watch(mustSharedPreferenceProvider);
     return sharedPreferences.getInt(key);
   }
 }
@@ -60,7 +61,7 @@ class StringSharedPreferences extends FamilyAsyncNotifier<String?, String> {
   @override
   FutureOr<String?> build(String arg) async {
     key = arg;
-    sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
+    sharedPreferences = ref.watch(mustSharedPreferenceProvider);
     return sharedPreferences.getString(key);
   }
 }

--- a/lib/provider/shared_preferences.dart
+++ b/lib/provider/shared_preferences.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
+import 'package:pilll/provider/shared_preference.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-
-final sharedPrefenreceProvider = FutureProvider((ref) => SharedPreferences.getInstance());
-final mustSharedPreferencesProvider = Provider((ref) => ref.watch(sharedPrefenreceProvider).value!);
 
 final boolSharedPreferencesProvider = AsyncNotifierProvider.family<BoolSharedPreferences, bool?, String>(() => BoolSharedPreferences());
 
@@ -20,7 +18,7 @@ class BoolSharedPreferences extends FamilyAsyncNotifier<bool?, String> {
   @override
   FutureOr<bool?> build(String arg) async {
     key = arg;
-    sharedPreferences = ref.watch(mustSharedPreferencesProvider);
+    sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
     return sharedPreferences.getBool(key);
   }
 }
@@ -40,7 +38,7 @@ class IntSharedPreferences extends FamilyAsyncNotifier<int?, String> {
   @override
   FutureOr<int?> build(String arg) async {
     key = arg;
-    sharedPreferences = ref.watch(mustSharedPreferencesProvider);
+    sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
     return sharedPreferences.getInt(key);
   }
 }
@@ -62,7 +60,7 @@ class StringSharedPreferences extends FamilyAsyncNotifier<String?, String> {
   @override
   FutureOr<String?> build(String arg) async {
     key = arg;
-    sharedPreferences = ref.watch(mustSharedPreferencesProvider);
+    sharedPreferences = await ref.watch(sharedPreferenceProvider.future);
     return sharedPreferences.getString(key);
   }
 }

--- a/lib/provider/user.dart
+++ b/lib/provider/user.dart
@@ -71,7 +71,7 @@ class FetchOrCreateUser {
       if (error is UserNotFound) {
         return _create(uid).then((_) => _fetch(uid));
       }
-      throw FormatException("cause exception when failed fetch and create user. error: $error, stackTrace: ${StackTrace.current.toString()}");
+      throw FormatException("Create user error: $error, stackTrace: ${StackTrace.current.toString()}");
     });
     return user;
   }

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -10,6 +10,7 @@ import 'package:pilll/provider/database.dart';
 import 'package:pilll/provider/force_update.dart';
 import 'package:pilll/provider/set_user_id.dart';
 import 'package:pilll/provider/shared_preference.dart';
+import 'package:pilll/provider/shared_preferences.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/utils/auth/apple.dart';
@@ -97,7 +98,7 @@ void main() {
             isGoogleLinkedProvider.overrideWith((ref) => false),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
-            sharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
+            mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: const MaterialApp(
             home: Material(
@@ -151,7 +152,7 @@ void main() {
             isGoogleLinkedProvider.overrideWith((ref) => false),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
-            sharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
+            mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: const MaterialApp(
             home: Material(
@@ -201,7 +202,7 @@ void main() {
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(null)),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
-            sharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
+            mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: MaterialApp(
             home: Material(
@@ -245,7 +246,7 @@ void main() {
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
-            sharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
+            mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: MaterialApp(
             home: Material(
@@ -289,7 +290,7 @@ void main() {
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
-            sharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
+            mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: MaterialApp(
             home: Material(
@@ -333,7 +334,7 @@ void main() {
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
-            sharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
+            mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: MaterialApp(
             home: Material(

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -88,11 +88,11 @@ void main() {
             saveUserLaunchInfoProvider.overrideWith((ref) => saveUserLaunchInfo),
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             firebaseSignInProvider.overrideWith((ref) => Future.value(fakeFirebaseUser)),
-            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(null)),
             // For InitialSettingPillSheetGroupPage
             isAppleLinkedProvider.overrideWith((ref) => false),
             isGoogleLinkedProvider.overrideWith((ref) => false),
+            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
           ],
           child: const MaterialApp(
             home: Material(
@@ -138,11 +138,11 @@ void main() {
             saveUserLaunchInfoProvider.overrideWith((ref) => saveUserLaunchInfo),
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             firebaseSignInProvider.overrideWith((ref) => Future.value(fakeFirebaseUser)),
-            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(null)),
             // For InitialSettingPillSheetGroupPage
             isAppleLinkedProvider.overrideWith((ref) => false),
             isGoogleLinkedProvider.overrideWith((ref) => false),
+            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
           ],
           child: const MaterialApp(
             home: Material(

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -81,7 +81,6 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            firebaseSignInProvider.overrideWith((ref) => Future.value(fakeFirebaseUser)),
             checkForceUpdateProvider.overrideWith((_) => checkForceUpdate),
             setUserIDProvider.overrideWith((ref) => setUserID),
             databaseProvider.overrideWith((ref) => MockDatabaseConnection()),
@@ -131,7 +130,6 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            firebaseSignInProvider.overrideWith((ref) => Future.value(fakeFirebaseUser)),
             checkForceUpdateProvider.overrideWith((_) => checkForceUpdate),
             setUserIDProvider.overrideWith((ref) => setUserID),
             databaseProvider.overrideWith((ref) => MockDatabaseConnection()),

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -88,6 +88,7 @@ void main() {
             saveUserLaunchInfoProvider.overrideWith((ref) => saveUserLaunchInfo),
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             firebaseSignInProvider.overrideWith((ref) => Future.value(fakeFirebaseUser)),
+            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(null)),
             // For InitialSettingPillSheetGroupPage
             isAppleLinkedProvider.overrideWith((ref) => false),
@@ -137,6 +138,7 @@ void main() {
             saveUserLaunchInfoProvider.overrideWith((ref) => saveUserLaunchInfo),
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             firebaseSignInProvider.overrideWith((ref) => Future.value(fakeFirebaseUser)),
+            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(null)),
             // For InitialSettingPillSheetGroupPage
             isAppleLinkedProvider.overrideWith((ref) => false),
@@ -186,6 +188,7 @@ void main() {
             saveUserLaunchInfoProvider.overrideWith((ref) => saveUserLaunchInfo),
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(null)),
+            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
           ],
           child: MaterialApp(
             home: Material(
@@ -225,6 +228,7 @@ void main() {
             saveUserLaunchInfoProvider.overrideWith((ref) => saveUserLaunchInfo),
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
+            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
           ],
           child: MaterialApp(
             home: Material(
@@ -264,6 +268,7 @@ void main() {
             saveUserLaunchInfoProvider.overrideWith((ref) => saveUserLaunchInfo),
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
+            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
           ],
           child: MaterialApp(
             home: Material(
@@ -303,6 +308,7 @@ void main() {
             saveUserLaunchInfoProvider.overrideWith((ref) => saveUserLaunchInfo),
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
+            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
           ],
           child: MaterialApp(
             home: Material(

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -78,8 +78,9 @@ void main() {
       final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
-      final sharedPreferences = await SharedPreferences.getInstance();
       SharedPreferences.setMockInitialValues({});
+      final sharedPreferences = await SharedPreferences.getInstance();
+
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -131,8 +132,9 @@ void main() {
       final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
-      final sharedPreferences = await SharedPreferences.getInstance();
       SharedPreferences.setMockInitialValues({});
+      final sharedPreferences = await SharedPreferences.getInstance();
+
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -186,8 +188,9 @@ void main() {
       final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
-      final sharedPreferences = await SharedPreferences.getInstance();
       SharedPreferences.setMockInitialValues({});
+      final sharedPreferences = await SharedPreferences.getInstance();
+
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -227,10 +230,11 @@ void main() {
       final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
-      final sharedPreferences = await SharedPreferences.getInstance();
       SharedPreferences.setMockInitialValues({
         BoolKey.didEndInitialSetting: true,
       });
+      final sharedPreferences = await SharedPreferences.getInstance();
+
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -270,10 +274,11 @@ void main() {
       final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
-      final sharedPreferences = await SharedPreferences.getInstance();
       SharedPreferences.setMockInitialValues({
         BoolKey.didEndInitialSetting: true,
       });
+      final sharedPreferences = await SharedPreferences.getInstance();
+
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -313,10 +318,11 @@ void main() {
       final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
-      final sharedPreferences = await SharedPreferences.getInstance();
       SharedPreferences.setMockInitialValues({
         BoolKey.didEndInitialSetting: true,
       });
+      final sharedPreferences = await SharedPreferences.getInstance();
+
       await tester.pumpWidget(
         ProviderScope(
           overrides: [

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -9,7 +9,6 @@ import 'package:pilll/provider/auth.dart';
 import 'package:pilll/provider/database.dart';
 import 'package:pilll/provider/force_update.dart';
 import 'package:pilll/provider/set_user_id.dart';
-import 'package:pilll/provider/shared_preference.dart';
 import 'package:pilll/provider/shared_preferences.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -93,6 +93,7 @@ void main() {
             isAppleLinkedProvider.overrideWith((ref) => false),
             isGoogleLinkedProvider.overrideWith((ref) => false),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
+            userIsNotAnonymousProvider.overrideWith((ref) => false),
           ],
           child: const MaterialApp(
             home: Material(
@@ -143,6 +144,7 @@ void main() {
             isAppleLinkedProvider.overrideWith((ref) => false),
             isGoogleLinkedProvider.overrideWith((ref) => false),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
+            userIsNotAnonymousProvider.overrideWith((ref) => false),
           ],
           child: const MaterialApp(
             home: Material(
@@ -189,6 +191,7 @@ void main() {
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(null)),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
+            userIsNotAnonymousProvider.overrideWith((ref) => false),
           ],
           child: MaterialApp(
             home: Material(
@@ -229,6 +232,7 @@ void main() {
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
+            userIsNotAnonymousProvider.overrideWith((ref) => false),
           ],
           child: MaterialApp(
             home: Material(
@@ -269,6 +273,7 @@ void main() {
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
+            userIsNotAnonymousProvider.overrideWith((ref) => false),
           ],
           child: MaterialApp(
             home: Material(
@@ -309,6 +314,7 @@ void main() {
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
+            userIsNotAnonymousProvider.overrideWith((ref) => false),
           ],
           child: MaterialApp(
             home: Material(

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -32,6 +32,13 @@ class _FakeFirebaseUser extends Fake implements firebase_auth.User {
   String get uid => "abcdefg";
 }
 
+class _FakeWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}
+
 class _FakeUser extends Fake implements User {
   final bool fakeMigratedFlutter;
   final Setting? fakeSetting;
@@ -99,9 +106,9 @@ void main() {
             userIsNotAnonymousProvider.overrideWith((ref) => false),
             mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
-          child: const MaterialApp(
+          child: MaterialApp(
             home: Material(
-              child: RootPage(),
+              child: RootPage(builder: (_, __) => _FakeWidget()),
             ),
           ),
         ),
@@ -109,7 +116,7 @@ void main() {
       await tester.pump();
 
       expect(
-        find.byWidgetPredicate((widget) => widget is InitialSettingOrAppPage),
+        find.byWidgetPredicate((widget) => widget is _FakeWidget),
         findsOneWidget,
       );
     });
@@ -153,9 +160,9 @@ void main() {
             userIsNotAnonymousProvider.overrideWith((ref) => false),
             mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
-          child: const MaterialApp(
+          child: MaterialApp(
             home: Material(
-              child: RootPage(),
+              child: RootPage(builder: (_, __) => _FakeWidget()),
             ),
           ),
         ),
@@ -165,6 +172,10 @@ void main() {
       expect(
         find.byWidgetPredicate((widget) => widget is ScaffoldIndicator),
         findsOneWidget,
+      );
+      expect(
+        find.byWidgetPredicate((widget) => widget is _FakeWidget),
+        findsNothing,
       );
 // FIXME: Cann't check of did showDialog Widget
 //      expect(

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -103,7 +103,6 @@ void main() {
             isGoogleLinkedProvider.overrideWith((ref) => false),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
-            mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: MaterialApp(
             home: Material(
@@ -139,7 +138,6 @@ void main() {
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
       SharedPreferences.setMockInitialValues({});
-      final sharedPreferences = await SharedPreferences.getInstance();
 
       await tester.pumpWidget(
         ProviderScope(
@@ -157,7 +155,6 @@ void main() {
             isGoogleLinkedProvider.overrideWith((ref) => false),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
-            mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: MaterialApp(
             home: Material(

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -2,18 +2,14 @@ import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 import 'package:pilll/components/molecules/indicator.dart';
 import 'package:pilll/entity/setting.codegen.dart';
 import 'package:pilll/entity/user.codegen.dart';
-import 'package:pilll/features/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart';
 import 'package:pilll/features/root/initial_setting_or_app_page.dart';
 import 'package:pilll/features/root/root_page.dart';
 import 'package:pilll/provider/auth.dart';
 import 'package:pilll/provider/database.dart';
 import 'package:pilll/provider/force_update.dart';
 import 'package:pilll/provider/set_user_id.dart';
-import 'package:pilll/provider/shared_preferences.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
-import 'package:pilll/utils/auth/apple.dart';
-import 'package:pilll/utils/auth/google.dart';
 import 'package:pilll/utils/environment.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -85,7 +81,6 @@ void main() {
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
       SharedPreferences.setMockInitialValues({});
-      final sharedPreferences = await SharedPreferences.getInstance();
 
       await tester.pumpWidget(
         ProviderScope(
@@ -98,11 +93,6 @@ void main() {
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             firebaseSignInProvider.overrideWith((ref) => Future.value(fakeFirebaseUser)),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(null)),
-            // For InitialSettingPillSheetGroupPage
-            isAppleLinkedProvider.overrideWith((ref) => false),
-            isGoogleLinkedProvider.overrideWith((ref) => false),
-            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
-            userIsNotAnonymousProvider.overrideWith((ref) => false),
           ],
           child: MaterialApp(
             home: Material(
@@ -150,11 +140,6 @@ void main() {
             markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
             firebaseSignInProvider.overrideWith((ref) => Future.value(fakeFirebaseUser)),
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(null)),
-            // For InitialSettingPillSheetGroupPage
-            isAppleLinkedProvider.overrideWith((ref) => false),
-            isGoogleLinkedProvider.overrideWith((ref) => false),
-            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
-            userIsNotAnonymousProvider.overrideWith((ref) => false),
           ],
           child: MaterialApp(
             home: Material(

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -9,6 +9,7 @@ import 'package:pilll/provider/auth.dart';
 import 'package:pilll/provider/database.dart';
 import 'package:pilll/provider/force_update.dart';
 import 'package:pilll/provider/set_user_id.dart';
+import 'package:pilll/provider/shared_preference.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/utils/auth/apple.dart';
@@ -77,6 +78,7 @@ void main() {
       final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
+      final sharedPreferences = await SharedPreferences.getInstance();
       SharedPreferences.setMockInitialValues({});
       await tester.pumpWidget(
         ProviderScope(
@@ -94,6 +96,7 @@ void main() {
             isGoogleLinkedProvider.overrideWith((ref) => false),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
+            sharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: const MaterialApp(
             home: Material(
@@ -128,6 +131,7 @@ void main() {
       final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
+      final sharedPreferences = await SharedPreferences.getInstance();
       SharedPreferences.setMockInitialValues({});
       await tester.pumpWidget(
         ProviderScope(
@@ -145,6 +149,7 @@ void main() {
             isGoogleLinkedProvider.overrideWith((ref) => false),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
+            sharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: const MaterialApp(
             home: Material(
@@ -181,6 +186,7 @@ void main() {
       final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
+      final sharedPreferences = await SharedPreferences.getInstance();
       SharedPreferences.setMockInitialValues({});
       await tester.pumpWidget(
         ProviderScope(
@@ -192,6 +198,7 @@ void main() {
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(null)),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
+            sharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: MaterialApp(
             home: Material(
@@ -220,6 +227,7 @@ void main() {
       final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
+      final sharedPreferences = await SharedPreferences.getInstance();
       SharedPreferences.setMockInitialValues({
         BoolKey.didEndInitialSetting: true,
       });
@@ -233,6 +241,7 @@ void main() {
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
+            sharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: MaterialApp(
             home: Material(
@@ -261,6 +270,7 @@ void main() {
       final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
+      final sharedPreferences = await SharedPreferences.getInstance();
       SharedPreferences.setMockInitialValues({
         BoolKey.didEndInitialSetting: true,
       });
@@ -274,6 +284,7 @@ void main() {
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
+            sharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: MaterialApp(
             home: Material(
@@ -302,6 +313,7 @@ void main() {
       final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
       when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
 
+      final sharedPreferences = await SharedPreferences.getInstance();
       SharedPreferences.setMockInitialValues({
         BoolKey.didEndInitialSetting: true,
       });
@@ -315,6 +327,7 @@ void main() {
             didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
             userProvider.overrideWith((ref) => Stream.value(fakeUser)),
             userIsNotAnonymousProvider.overrideWith((ref) => false),
+            sharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
           ],
           child: MaterialApp(
             home: Material(

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -2,8 +2,8 @@ import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 import 'package:pilll/components/molecules/indicator.dart';
 import 'package:pilll/entity/setting.codegen.dart';
 import 'package:pilll/entity/user.codegen.dart';
-import 'package:pilll/features/home/home_page.dart';
 import 'package:pilll/features/initial_setting/pill_sheet_group/initial_setting_pill_sheet_group_page.dart';
+import 'package:pilll/features/root/initial_setting_or_app_page.dart';
 import 'package:pilll/features/root/root_page.dart';
 import 'package:pilll/provider/auth.dart';
 import 'package:pilll/provider/database.dart';
@@ -21,7 +21,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mockito/mockito.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:pilll/utils/error_log.dart';
-import 'package:pilll/utils/shared_preference/keys.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../helper/fake.dart';
@@ -186,10 +185,6 @@ void main() {
   });
 
   group('#calcScreenType', () {
-    testWidgets('user or didEndInitialSetting is not fetched', (WidgetTester tester) async {
-      final screenType = calcScreenType(user: null, didEndInitialSettingAsyncValue: const AsyncLoading());
-      expect(screenType, InitialSettingOrAppPageScreenType.loading);
-    });
     testWidgets('didEndInitialSetting is not exist', (WidgetTester tester) async {
       final fakeUser = _FakeUser(true, _FakeSetting());
       final screenType = calcScreenType(user: fakeUser, didEndInitialSettingAsyncValue: const AsyncData(null));

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -101,7 +101,7 @@ void main() {
           ],
           child: const MaterialApp(
             home: Material(
-              child: Root(),
+              child: RootPage(),
             ),
           ),
         ),
@@ -155,7 +155,7 @@ void main() {
           ],
           child: const MaterialApp(
             home: Material(
-              child: Root(),
+              child: RootPage(),
             ),
           ),
         ),

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -205,7 +205,7 @@ void main() {
           ],
           child: MaterialApp(
             home: Material(
-              child: InitialSettingOrAppPage(firebaseUserID: fakeFirebaseUser.uid),
+              child: InitialSettingOrAppPage(userID: fakeFirebaseUser.uid),
             ),
           ),
         ),
@@ -249,7 +249,7 @@ void main() {
           ],
           child: MaterialApp(
             home: Material(
-              child: InitialSettingOrAppPage(firebaseUserID: fakeFirebaseUser.uid),
+              child: InitialSettingOrAppPage(userID: fakeFirebaseUser.uid),
             ),
           ),
         ),
@@ -293,7 +293,7 @@ void main() {
           ],
           child: MaterialApp(
             home: Material(
-              child: InitialSettingOrAppPage(firebaseUserID: fakeFirebaseUser.uid),
+              child: InitialSettingOrAppPage(userID: fakeFirebaseUser.uid),
             ),
           ),
         ),
@@ -337,7 +337,7 @@ void main() {
           ],
           child: MaterialApp(
             home: Material(
-              child: InitialSettingOrAppPage(firebaseUserID: fakeFirebaseUser.uid),
+              child: InitialSettingOrAppPage(userID: fakeFirebaseUser.uid),
             ),
           ),
         ),

--- a/test/features/root/root_page_test.dart
+++ b/test/features/root/root_page_test.dart
@@ -185,180 +185,35 @@ void main() {
     });
   });
 
-  group('#InitialSettingOrAppPage', () {
+  group('#calcScreenType', () {
+    testWidgets('user or didEndInitialSetting is not fetched', (WidgetTester tester) async {
+      final screenType = calcScreenType(user: null, didEndInitialSettingAsyncValue: const AsyncLoading());
+      expect(screenType, InitialSettingOrAppPageScreenType.loading);
+    });
     testWidgets('didEndInitialSetting is not exist', (WidgetTester tester) async {
-      final fakeFirebaseUser = _FakeFirebaseUser();
       final fakeUser = _FakeUser(true, _FakeSetting());
-
-      final fetchOrCreateUser = MockFetchOrCreateUser();
-      when(fetchOrCreateUser(fakeFirebaseUser.uid)).thenAnswer((realInvocation) => Future.value(fakeUser));
-
-      final saveUserLaunchInfo = MockSaveUserLaunchInfo();
-      when(saveUserLaunchInfo(fakeUser)).thenReturn(null);
-
-      final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
-      when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
-
-      SharedPreferences.setMockInitialValues({});
-      final sharedPreferences = await SharedPreferences.getInstance();
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            fetchOrCreateUserProvider.overrideWith((_) => fetchOrCreateUser),
-            databaseProvider.overrideWith((ref) => MockDatabaseConnection()),
-            saveUserLaunchInfoProvider.overrideWith((ref) => saveUserLaunchInfo),
-            markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
-            didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(null)),
-            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
-            userIsNotAnonymousProvider.overrideWith((ref) => false),
-            mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
-          ],
-          child: MaterialApp(
-            home: Material(
-              child: InitialSettingOrAppPage(userID: fakeFirebaseUser.uid),
-            ),
-          ),
-        ),
-      );
-      await tester.pump();
-
-      expect(
-        find.byWidgetPredicate((widget) => widget is InitialSettingPillSheetGroupPage),
-        findsOneWidget,
-      );
+      final screenType = calcScreenType(user: fakeUser, didEndInitialSettingAsyncValue: const AsyncData(null));
+      expect(screenType, InitialSettingOrAppPageScreenType.initialSetting);
+    });
+    testWidgets('didEndInitialSetting is false', (WidgetTester tester) async {
+      final fakeUser = _FakeUser(true, _FakeSetting());
+      final screenType = calcScreenType(user: fakeUser, didEndInitialSettingAsyncValue: const AsyncData(false));
+      expect(screenType, InitialSettingOrAppPageScreenType.initialSetting);
     });
     testWidgets('didEndInitialSetting is true', (WidgetTester tester) async {
-      final fakeFirebaseUser = _FakeFirebaseUser();
       final fakeUser = _FakeUser(true, _FakeSetting());
-
-      final fetchOrCreateUser = MockFetchOrCreateUser();
-      when(fetchOrCreateUser(fakeFirebaseUser.uid)).thenAnswer((realInvocation) => Future.value(fakeUser));
-
-      final saveUserLaunchInfo = MockSaveUserLaunchInfo();
-      when(saveUserLaunchInfo(fakeUser)).thenReturn(null);
-
-      final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
-      when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
-
-      SharedPreferences.setMockInitialValues({
-        BoolKey.didEndInitialSetting: true,
-      });
-      final sharedPreferences = await SharedPreferences.getInstance();
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            fetchOrCreateUserProvider.overrideWith((_) => fetchOrCreateUser),
-            databaseProvider.overrideWith((ref) => MockDatabaseConnection()),
-            saveUserLaunchInfoProvider.overrideWith((ref) => saveUserLaunchInfo),
-            markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
-            didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
-            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
-            userIsNotAnonymousProvider.overrideWith((ref) => false),
-            mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
-          ],
-          child: MaterialApp(
-            home: Material(
-              child: InitialSettingOrAppPage(userID: fakeFirebaseUser.uid),
-            ),
-          ),
-        ),
-      );
-      await tester.pump();
-
-      expect(
-        find.byWidgetPredicate((widget) => widget is HomePage),
-        findsOneWidget,
-      );
+      final screenType = calcScreenType(user: fakeUser, didEndInitialSettingAsyncValue: const AsyncData(true));
+      expect(screenType, InitialSettingOrAppPageScreenType.app);
     });
     testWidgets('didEndInitialSetting is true and user.migratedFlutter is false', (WidgetTester tester) async {
-      final fakeFirebaseUser = _FakeFirebaseUser();
       final fakeUser = _FakeUser(false, _FakeSetting());
-
-      final fetchOrCreateUser = MockFetchOrCreateUser();
-      when(fetchOrCreateUser(fakeFirebaseUser.uid)).thenAnswer((realInvocation) => Future.value(fakeUser));
-
-      final saveUserLaunchInfo = MockSaveUserLaunchInfo();
-      when(saveUserLaunchInfo(fakeUser)).thenReturn(null);
-
-      final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
-      when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
-
-      SharedPreferences.setMockInitialValues({
-        BoolKey.didEndInitialSetting: true,
-      });
-      final sharedPreferences = await SharedPreferences.getInstance();
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            fetchOrCreateUserProvider.overrideWith((_) => fetchOrCreateUser),
-            databaseProvider.overrideWith((ref) => MockDatabaseConnection()),
-            saveUserLaunchInfoProvider.overrideWith((ref) => saveUserLaunchInfo),
-            markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
-            didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
-            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
-            userIsNotAnonymousProvider.overrideWith((ref) => false),
-            mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
-          ],
-          child: MaterialApp(
-            home: Material(
-              child: InitialSettingOrAppPage(userID: fakeFirebaseUser.uid),
-            ),
-          ),
-        ),
-      );
-      await tester.pump();
-
-      expect(
-        find.byWidgetPredicate((widget) => widget is InitialSettingPillSheetGroupPage),
-        findsOneWidget,
-      );
+      final screenType = calcScreenType(user: fakeUser, didEndInitialSettingAsyncValue: const AsyncData(true));
+      expect(screenType, InitialSettingOrAppPageScreenType.initialSetting);
     });
     testWidgets('didEndInitialSetting is true and user.migratedFlutter is true but setting is null', (WidgetTester tester) async {
-      final fakeFirebaseUser = _FakeFirebaseUser();
       final fakeUser = _FakeUser(true, null);
-
-      final fetchOrCreateUser = MockFetchOrCreateUser();
-      when(fetchOrCreateUser(fakeFirebaseUser.uid)).thenAnswer((realInvocation) => Future.value(fakeUser));
-
-      final saveUserLaunchInfo = MockSaveUserLaunchInfo();
-      when(saveUserLaunchInfo(fakeUser)).thenReturn(null);
-
-      final markAsMigratedToFlutter = MockMarkAsMigratedToFlutter();
-      when(markAsMigratedToFlutter()).thenAnswer((realInvocation) => Future.value());
-
-      SharedPreferences.setMockInitialValues({
-        BoolKey.didEndInitialSetting: true,
-      });
-      final sharedPreferences = await SharedPreferences.getInstance();
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            fetchOrCreateUserProvider.overrideWith((_) => fetchOrCreateUser),
-            databaseProvider.overrideWith((ref) => MockDatabaseConnection()),
-            saveUserLaunchInfoProvider.overrideWith((ref) => saveUserLaunchInfo),
-            markAsMigratedToFlutterProvider.overrideWith((ref) => markAsMigratedToFlutter),
-            didEndInitialSettingProvider.overrideWithValue(const AsyncValue.data(true)),
-            userProvider.overrideWith((ref) => Stream.value(fakeUser)),
-            userIsNotAnonymousProvider.overrideWith((ref) => false),
-            mustSharedPreferenceProvider.overrideWith((ref) => sharedPreferences),
-          ],
-          child: MaterialApp(
-            home: Material(
-              child: InitialSettingOrAppPage(userID: fakeFirebaseUser.uid),
-            ),
-          ),
-        ),
-      );
-      await tester.pump();
-
-      expect(
-        find.byWidgetPredicate((widget) => widget is InitialSettingPillSheetGroupPage),
-        findsOneWidget,
-      );
+      final screenType = calcScreenType(user: fakeUser, didEndInitialSettingAsyncValue: const AsyncData(true));
+      expect(screenType, InitialSettingOrAppPageScreenType.initialSetting);
     });
   });
 }


### PR DESCRIPTION
## Abstract
- サインイン後にメインの画面に遷移しなかったので修正
- ↑の修正をしている時にテストがこけてしまうので根本的に組み直した
- InitialSettingOrAppPageType はfunctionに切り出して単体テストできるように
  - それ以上下位のWidgetがProviderを使うと、その分のMockまで用意する必要がある
- RootPage -> UserSetupPage -> InitialSettingOrApp と初期セットアップの処理ごとにWidgetを分離。ツリーの下に行くことで前提を増やして考え事を少なくする

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた