### PR TITLE
Bugfix calc rest duration

### DIFF
--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -161,32 +161,30 @@ class PillSheet with _$PillSheet {
 
   DateTime displayPillTakeDate(int pillNumberIntoPillSheet) {
     final originDate = beginingDate.add(Duration(days: pillNumberIntoPillSheet - 1)).date();
-    print("[DEBUG] 1: originDate: $originDate, pillNumberIntoPillSheet: $pillNumberIntoPillSheet");
+
     if (restDurations.isEmpty) {
       return originDate;
     }
 
-    var displayedDate = originDate;
-    for (final restDuration in restDurations) {
-      final restDurationBeginDate = restDuration.beginDate.date();
-      final restDurationEndDate = restDuration.endDate?.date();
+    final distance = restDurations.fold(0, (int result, restDuration) {
+      final beginDate = restDuration.beginDate.date();
+      final endDate = restDuration.endDate?.date();
 
-      if (restDurationEndDate != null && isSameDay(restDurationBeginDate, restDurationEndDate)) {
-        continue;
+      if (endDate != null && isSameDay(beginDate, endDate)) {
+        return result;
       }
-      if (displayedDate.isBefore(restDurationBeginDate)) {
-        continue;
+      if (originDate.isBefore(beginDate)) {
+        return result;
       }
 
-      if (restDurationEndDate != null) {
-        displayedDate = displayedDate.add(Duration(days: daysBetween(restDurationBeginDate, restDurationEndDate)));
+      if (endDate != null) {
+        return result + daysBetween(beginDate, endDate);
       } else {
-        displayedDate = displayedDate.add(Duration(days: daysBetween(restDurationBeginDate, today())));
+        return result + daysBetween(beginDate, today());
       }
-    }
+    });
 
-    print("[DEBUG] 2: originDate: $originDate, pillNumberIntoPillSheet: $pillNumberIntoPillSheet, displayDate: $displayedDate");
-    return displayedDate;
+    return originDate.add(Duration(days: distance));
   }
 }
 

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -161,30 +161,32 @@ class PillSheet with _$PillSheet {
 
   DateTime displayPillTakeDate(int pillNumberIntoPillSheet) {
     final originDate = beginingDate.add(Duration(days: pillNumberIntoPillSheet - 1)).date();
-
+    print("[DEBUG] 1: originDate: $originDate, pillNumberIntoPillSheet: $pillNumberIntoPillSheet");
     if (restDurations.isEmpty) {
       return originDate;
     }
 
-    final distance = restDurations.fold(0, (int result, restDuration) {
-      final beginDate = restDuration.beginDate.date();
-      final endDate = restDuration.endDate?.date();
+    var displayedDate = originDate;
+    for (final restDuration in restDurations) {
+      final restDurationBeginDate = restDuration.beginDate.date();
+      final restDurationEndDate = restDuration.endDate?.date();
 
-      if (endDate != null && isSameDay(beginDate, endDate)) {
-        return result;
+      if (restDurationEndDate != null && isSameDay(restDurationBeginDate, restDurationEndDate)) {
+        continue;
       }
-      if (originDate.isBefore(beginDate)) {
-        return result;
+      if (displayedDate.isBefore(restDurationBeginDate)) {
+        continue;
       }
 
-      if (endDate != null) {
-        return result + daysBetween(beginDate, endDate);
+      if (restDurationEndDate != null) {
+        displayedDate = displayedDate.add(Duration(days: daysBetween(restDurationBeginDate, restDurationEndDate)));
       } else {
-        return result + daysBetween(beginDate, today());
+        displayedDate = displayedDate.add(Duration(days: daysBetween(restDurationBeginDate, today())));
       }
-    });
+    }
 
-    return originDate.add(Duration(days: distance));
+    print("[DEBUG] 2: originDate: $originDate, pillNumberIntoPillSheet: $pillNumberIntoPillSheet, displayDate: $displayedDate");
+    return displayedDate;
   }
 }
 

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -161,6 +161,7 @@ class PillSheet with _$PillSheet {
 
   DateTime displayPillTakeDate(int pillNumberIntoPillSheet) {
     final originDate = beginingDate.add(Duration(days: pillNumberIntoPillSheet - 1)).date();
+    print("[DEBUG] 1: originDate: $originDate, pillNumberIntoPillSheet: $pillNumberIntoPillSheet");
     if (restDurations.isEmpty) {
       return originDate;
     }
@@ -184,6 +185,7 @@ class PillSheet with _$PillSheet {
       }
     }
 
+    print("[DEBUG] 2: originDate: $originDate, pillNumberIntoPillSheet: $pillNumberIntoPillSheet, displayDate: $displayedDate");
     return displayedDate;
   }
 }

--- a/lib/entity/pill_sheet.codegen.dart
+++ b/lib/entity/pill_sheet.codegen.dart
@@ -161,7 +161,6 @@ class PillSheet with _$PillSheet {
 
   DateTime displayPillTakeDate(int pillNumberIntoPillSheet) {
     final originDate = beginingDate.add(Duration(days: pillNumberIntoPillSheet - 1)).date();
-    print("[DEBUG] 1: originDate: $originDate, pillNumberIntoPillSheet: $pillNumberIntoPillSheet");
     if (restDurations.isEmpty) {
       return originDate;
     }
@@ -185,7 +184,6 @@ class PillSheet with _$PillSheet {
       }
     }
 
-    print("[DEBUG] 2: originDate: $originDate, pillNumberIntoPillSheet: $pillNumberIntoPillSheet, displayDate: $displayedDate");
     return displayedDate;
   }
 }

--- a/test/features/record/components/record_page_pill_sheet_test.dart
+++ b/test/features/record/components/record_page_pill_sheet_test.dart
@@ -669,6 +669,47 @@ void main() {
         });
       });
     });
+    test("Bugfix 2023-02-11 dev:/users/Ka9rvL7WdFfmV7ZJe24XD9QfBAF2/pill_sheet_groups/pPJ3ncti5k3HfvbxU5Xe", () async {
+      final originalTodayRepository = todayRepository;
+      final mockTodayRepository = MockTodayService();
+      todayRepository = mockTodayRepository;
+      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2023-01-14"));
+      when(mockTodayRepository.now()).thenReturn(DateTime.parse("2023-01-14"));
+      addTearDown(() {
+        todayRepository = originalTodayRepository;
+      });
+
+      final PillSheet pillSheet = PillSheet(
+        id: firestoreIDGenerator(),
+        typeInfo: PillSheetType.pillsheet_28_4.typeInfo,
+        beginingDate: DateTime.parse("2023-01-10"),
+        createdAt: now(),
+        restDurations: [
+          RestDuration(
+            beginDate: DateTime.parse("2023-01-17"),
+            createdDate: DateTime.parse("2023-01-17"),
+            endDate: DateTime.parse("2023-01-24"),
+          ),
+          RestDuration(
+            beginDate: DateTime.parse("2023-02-02"),
+            createdDate: DateTime.parse("2023-02-02"),
+            endDate: DateTime.parse("2023-02-08"),
+          ),
+        ],
+      );
+
+      expect(pillSheet.displayPillTakeDate(1), DateTime.parse("2023-01-10"));
+
+      expect(pillSheet.displayPillTakeDate(7), DateTime.parse("2023-01-16"));
+      expect(pillSheet.displayPillTakeDate(8), DateTime.parse("2023-01-24"));
+
+      expect(pillSheet.displayPillTakeDate(15), DateTime.parse("2023-01-31"));
+      expect(pillSheet.displayPillTakeDate(16), DateTime.parse("2023-02-01"));
+      expect(pillSheet.displayPillTakeDate(17), DateTime.parse("2023-02-08"));
+
+      expect(pillSheet.displayPillTakeDate(19), DateTime.parse("2023-02-10"));
+      expect(pillSheet.displayPillTakeDate(20), DateTime.parse("2023-02-11"));
+    });
   });
   group("#RecordPagePillSheet.isContainedMenstruationDuration", () {
     test("group has only one pill sheet", () async {


### PR DESCRIPTION
## TODO:
- [x] UnitTest
- [x] 他の箇所でもロジックの書き換えが必要かを検討する

## Abstract
> ・ピルシートの日付の表示がズレてる（本来は今日飲むピルは2/11と表示されるはずが、2/5になっている）

下記の下記のデータで再現
<img width="522" alt="image" src="https://user-images.githubusercontent.com/10897361/218259256-7746db06-beba-4cca-8fa7-129c3414cbbf.png">

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた