### PR TITLE
RemoteDBが書き換わるまでピルシートグループが更新されてもUIを更新しない

### DIFF
--- a/lib/provider/take_pill.dart
+++ b/lib/provider/take_pill.dart
@@ -62,7 +62,6 @@ class TakePill {
 
       return pillSheet.copyWith(lastTakenDate: takenDate);
     }).toList();
-    debugPrint("$updatedPillSheets");
 
     final updatedPillSheetGroup = pillSheetGroup.copyWith(pillSheets: updatedPillSheets);
     final updatedIndexses = pillSheetGroup.pillSheets.asMap().keys.where((index) {
@@ -74,10 +73,7 @@ class TakePill {
       return true;
     }).toList();
 
-    debugPrint("updatedIndexses: $updatedIndexses");
     if (updatedIndexses.isEmpty) {
-      debugPrint("unexpected updatedIndexes is empty");
-
       // NOTE: avoid error for unit test
       if (Firebase.apps.isNotEmpty) {
         errorLogger.recordError(const FormatException("unexpected updatedIndexes is empty"), StackTrace.current);

--- a/lib/provider/take_pill.dart
+++ b/lib/provider/take_pill.dart
@@ -90,7 +90,6 @@ class TakePill {
 
     final before = pillSheetGroup.pillSheets[updatedIndexses.first];
     final after = updatedPillSheetGroup.pillSheets[updatedIndexses.last];
-    debugPrint("before: $before, after: $after");
     final history = PillSheetModifiedHistoryServiceActionFactory.createTakenPillAction(
       pillSheetGroupID: pillSheetGroup.id,
       before: before,

--- a/lib/provider/take_pill.dart
+++ b/lib/provider/take_pill.dart
@@ -99,6 +99,8 @@ class TakePill {
     );
     batchSetPillSheetModifiedHistory(batch, history);
 
+    // 服用記録はBackendの通知等によく使われるので、DBに書き込まれたあとにStreamを通じてUIを更新する
+    awaitsPillSheetGroupRemoteDBDataChanged = true;
     await batch.commit();
 
     return updatedPillSheetGroup;


### PR DESCRIPTION
## Abstract
特定のパターン(服用)の処理に関してはDBが書き換わるまではUIを更新しない

## Why
- ローカルDBだけが書き換わってBackendに変更が届いてないため、服用記録が手元に来る問い合わせが発生している
- この修正ですべてのパターンを解消できるわけでは無いが、一つのパターンを解消した
- ただ、アプリの操作感的にはリモートDBの変更を待つので少し重たくなった

## Links


## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた