### PR TITLE
強制アップデート時のエラーハンドリングをなくす

### DIFF
--- a/lib/features/root/root_page.dart
+++ b/lib/features/root/root_page.dart
@@ -93,7 +93,7 @@ class RootPage extends HookConsumerWidget {
         await showOKDialog(context, title: "アプリをアップデートしてください", message: "お使いのアプリのバージョンのアップデートをお願いしております。$storeNameから最新バージョンにアップデートしてください",
             ok: () async {
           await launchUrl(
-            Uri.parse(storeURL),
+            Uri.parse(forceUpdateStoreURL),
             mode: LaunchMode.externalApplication,
           );
         });

--- a/lib/features/root/root_page.dart
+++ b/lib/features/root/root_page.dart
@@ -54,7 +54,6 @@ class RootPage extends HookConsumerWidget {
           }
         } catch (e, st) {
           errorLogger.recordError(e, st);
-          error.value = LaunchException("起動処理でエラーが発生しました\n${ErrorMessages.connection}\n詳細:", e);
         }
       }
 

--- a/lib/utils/platform/platform.dart
+++ b/lib/utils/platform/platform.dart
@@ -8,8 +8,8 @@ String get accountName {
   return Platform.isIOS ? "Apple ID" : "Google アカウント";
 }
 
-String get storeURL {
+String get forceUpdateStoreURL {
   return Platform.isIOS
-      ? "https://apps.apple.com/jp/app/id1405931017"
-      : "https://play.google.com/store/apps/details?id=com.mizuki.Ohashi.Pilll";
+      ? "https://apps.apple.com/app/apple-store/id1405931017?pt=97327896&ct=force_update&mt=8"
+      : "https://play.google.com/store/apps/details?id=com.mizuki.Ohashi.Pilll&utm_source=force_update&utm_campaign=force_update&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1";
 }


### PR DESCRIPTION
## Abstract

## Why
強制アップデートは今必須というわけでもないので、エラーが起きてもスルーして通常のアプリを開始してもらう

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた