### PR TITLE
GitHub ActionsのSecretを誤って後悔しない様にコメントを追加

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -7,6 +7,8 @@ name: Test
 on:
   push:
     branches: [ main, feature/* ]
+  # pull_request_targetsにはしない。Public repoだからforkされるとsecretが読み込まれる
+  # NOTE: Dependabotでbuild-ios-debug,build-android-debugで毎回失敗するが仕方ないものとする。他のCIが通っていればOK
   pull_request:
     branches: [ main, feature/* ]
 


### PR DESCRIPTION
## Abstract
on: pull_requestを保つ様にコメントを追加。pull_request_targetsにするとfork先でsecretが読み込めてしまうので気をつける必要がある

## Why
dependabotのCIが毎回転んでどうしようかなー。と思っていたが、単純にコメントを書いて転んでしまったのは諦めるでよいか。ときづいたのでこの方針で行く

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた