### PR TITLE
認証プロバイダのリンク方法を変更する

### DIFF
--- a/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/Pilll/BroadCastActionReceiver.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import androidx.core.app.NotificationManagerCompat
-import com.aboutyou.dart_packages.sign_in_with_apple.TAG
 import io.flutter.plugin.common.MethodChannel
 
 
@@ -28,17 +27,14 @@ public class BroadCastActionReceiver: BroadcastReceiver() {
 
     private class RecordPillResult(private val pendingResult: PendingResult): MethodChannel.Result {
         override fun success(result: Any?) {
-            Log.d(TAG, "successfully record pill $result")
             pendingResult.finish();
         }
 
         override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
-            Log.d(TAG, "errorCode: $errorCode, errorMessage: $errorMessage, errorDetails: $errorDetails")
             pendingResult.finish();
         }
 
         override fun notImplemented() {
-            Log.d(TAG, "unexpected not implement method about record pill")
             pendingResult.finish();
         }
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,10 +1,4 @@
 PODS:
-  - AppAuth (1.6.2):
-    - AppAuth/Core (= 1.6.2)
-    - AppAuth/ExternalUserAgent (= 1.6.2)
-  - AppAuth/Core (1.6.2)
-  - AppAuth/ExternalUserAgent (1.6.2):
-    - AppAuth/Core
   - cloud_firestore (4.8.4):
     - Firebase/Firestore (= 10.13.0)
     - firebase_core
@@ -158,9 +152,6 @@ PODS:
     - Flutter
   - flutter_native_timezone (0.0.1):
     - Flutter
-  - google_sign_in_ios (0.0.1):
-    - Flutter
-    - GoogleSignIn (~> 6.2)
   - GoogleAppMeasurement (10.13.0):
     - GoogleAppMeasurement/AdIdSupport (= 10.13.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
@@ -185,10 +176,6 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleSignIn (6.2.4):
-    - AppAuth (~> 1.5)
-    - GTMAppAuth (~> 1.3)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.1)
   - GoogleUtilities/AppDelegateSwizzler (7.11.5):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
@@ -209,9 +196,6 @@ PODS:
     - GoogleUtilities/Logger
   - GoogleUtilities/UserDefaults (7.11.5):
     - GoogleUtilities/Logger
-  - GTMAppAuth (1.3.1):
-    - AppAuth/Core (~> 1.6)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.5)
   - GTMSessionFetcher/Core (2.3.0)
   - in_app_review (0.2.0):
     - Flutter
@@ -235,8 +219,6 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - sign_in_with_apple (0.0.1):
-    - Flutter
   - url_launcher_ios (0.0.1):
     - Flutter
   - webview_flutter_wkwebview (0.0.1):
@@ -256,18 +238,15 @@ DEPENDENCIES:
   - flutter_inappwebview (from `.symlinks/plugins/flutter_inappwebview/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_native_timezone (from `.symlinks/plugins/flutter_native_timezone/ios`)
-  - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/ios`)
   - in_app_review (from `.symlinks/plugins/in_app_review/ios`)
   - package_info (from `.symlinks/plugins/package_info/ios`)
   - purchases_flutter (from `.symlinks/plugins/purchases_flutter/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - sign_in_with_apple (from `.symlinks/plugins/sign_in_with_apple/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
   - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
 
 SPEC REPOS:
   trunk:
-    - AppAuth
     - Firebase
     - FirebaseABTesting
     - FirebaseAnalytics
@@ -284,9 +263,7 @@ SPEC REPOS:
     - FirebaseSessions
     - GoogleAppMeasurement
     - GoogleDataTransport
-    - GoogleSignIn
     - GoogleUtilities
-    - GTMAppAuth
     - GTMSessionFetcher
     - nanopb
     - OrderedSet
@@ -323,8 +300,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_native_timezone:
     :path: ".symlinks/plugins/flutter_native_timezone/ios"
-  google_sign_in_ios:
-    :path: ".symlinks/plugins/google_sign_in_ios/ios"
   in_app_review:
     :path: ".symlinks/plugins/in_app_review/ios"
   package_info:
@@ -333,8 +308,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/purchases_flutter/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
-  sign_in_with_apple:
-    :path: ".symlinks/plugins/sign_in_with_apple/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
   webview_flutter_wkwebview:
@@ -346,7 +319,6 @@ CHECKOUT OPTIONS:
     :tag: 10.13.0
 
 SPEC CHECKSUMS:
-  AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
   cloud_firestore: 83f340ec0776642a2ea8b9616d19f9f2ebdefacf
   Firebase: 343d7539befb614d22b2eae24759f6307b1175e9
   firebase_analytics: 4dacf3ef66e0cd339f5cdead0b429f31c4adbf2c
@@ -374,12 +346,9 @@ SPEC CHECKSUMS:
   flutter_inappwebview: bfd58618f49dc62f2676de690fc6dcda1d6c3721
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   flutter_native_timezone: 5f05b2de06c9776b4cc70e1839f03de178394d22
-  google_sign_in_ios: 1256ff9d941db546373826966720b0c24804bcdd
   GoogleAppMeasurement: 3ae505b44174bcc0775f5c86cecc5826259fbb1e
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
-  GoogleSignIn: 5651ce3a61e56ca864160e79b484cd9ed3f49b7a
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
-  GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
   in_app_review: 318597b3a06c22bb46dc454d56828c85f444f99d
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
@@ -391,7 +360,6 @@ SPEC CHECKSUMS:
   PurchasesHybridCommon: 45fc4487e06787e4b071510f9230e180f49a0a5f
   RevenueCat: 3997b7af3ded18a59346e76f1365cae5a64f4281
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
-  sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
   url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
   webview_flutter_wkwebview: 2e2d318f21a5e036e2c3f26171342e95908bd60a
 

--- a/lib/features/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/features/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -87,13 +87,12 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
                             try {
                               final messenger = ScaffoldMessenger.of(context);
                               final navigator = Navigator.of(context);
-                              final isSuccess = await appleReauthentification();
-                              analytics.logEvent(name: 'a_c_l_apple_long_press_result', parameters: {"success": isSuccess});
+                              analytics.logEvent(name: 'a_c_l_apple_long_press_result');
 
                               messenger.showSnackBar(
-                                SnackBar(
+                                const SnackBar(
                                   duration: const Duration(seconds: 2),
-                                  content: Text(isSuccess ? "認証情報を更新しました" : "認証情報を更新に失敗しました"),
+                                  content: Text("認証情報を更新しました"),
                                 ),
                               );
                               navigator.pop();
@@ -140,13 +139,12 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
                             try {
                               final messenger = ScaffoldMessenger.of(context);
                               final navigator = Navigator.of(context);
-                              final isSuccess = await googleReauthentification();
-                              analytics.logEvent(name: 'a_c_l_google_long_press_result', parameters: {"success": isSuccess});
+                              analytics.logEvent(name: 'a_c_l_google_long_press_result');
 
                               messenger.showSnackBar(
-                                SnackBar(
+                                const SnackBar(
                                   duration: const Duration(seconds: 2),
-                                  content: Text(isSuccess ? "認証情報を更新しました" : "認証情報を更新に失敗しました"),
+                                  content: Text("認証情報を更新しました"),
                                 ),
                               );
                               navigator.pop();

--- a/lib/features/settings/setting_account_list/setting_account_cooperation_list_page.dart
+++ b/lib/features/settings/setting_account_list/setting_account_cooperation_list_page.dart
@@ -91,7 +91,7 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
 
                               messenger.showSnackBar(
                                 const SnackBar(
-                                  duration: const Duration(seconds: 2),
+                                  duration: Duration(seconds: 2),
                                   content: Text("認証情報を更新しました"),
                                 ),
                               );
@@ -143,7 +143,7 @@ class SettingAccountCooperationListPage extends HookConsumerWidget {
 
                               messenger.showSnackBar(
                                 const SnackBar(
-                                  duration: const Duration(seconds: 2),
+                                  duration: Duration(seconds: 2),
                                   content: Text("認証情報を更新しました"),
                                 ),
                               );

--- a/lib/provider/auth.dart
+++ b/lib/provider/auth.dart
@@ -52,6 +52,6 @@ Map<String, dynamic> _logginParameters(User? currentUser) {
     "uid": currentUser.uid,
     "isAnonymous": currentUser.isAnonymous,
     "hasGoogleProviderData": currentUser.providerData.where((element) => element.providerId == googleProviderID).isNotEmpty,
-    "hasAppleProviderData": currentUser.providerData.where((element) => element.providerId == appleProviderID).isNotEmpty,
+    "hasAppleProviderData": currentUser.providerData.where((element) => element.providerId == AppleAuthProvider.PROVIDER_ID).isNotEmpty,
   };
 }

--- a/lib/provider/user.dart
+++ b/lib/provider/user.dart
@@ -124,13 +124,12 @@ class LinkApple {
   final DatabaseConnection databaseConnection;
   LinkApple(this.databaseConnection);
 
-  Future<void> call(String? email) async {
+  Future<void> call() async {
     await databaseConnection.userRawReference().set({
       UserFirestoreFieldKeys.isAnonymous: false,
     }, SetOptions(merge: true));
 
     await databaseConnection.userPrivateRawReference().set({
-      if (email != null) UserPrivateFirestoreFieldKeys.appleEmail: email,
       UserPrivateFirestoreFieldKeys.isLinkedApple: true,
     }, SetOptions(merge: true));
   }
@@ -142,13 +141,12 @@ class LinkGoogle {
   final DatabaseConnection databaseConnection;
   LinkGoogle(this.databaseConnection);
 
-  Future<void> call(String? email) async {
+  Future<void> call() async {
     await databaseConnection.userRawReference().set({
       UserFirestoreFieldKeys.isAnonymous: false,
     }, SetOptions(merge: true));
 
     await databaseConnection.userPrivateRawReference().set({
-      if (email != null) UserPrivateFirestoreFieldKeys.googleEmail: email,
       UserPrivateFirestoreFieldKeys.isLinkedGoogle: true,
     }, SetOptions(merge: true));
   }

--- a/lib/utils/auth/apple.dart
+++ b/lib/utils/auth/apple.dart
@@ -1,15 +1,13 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:pilll/utils/auth/link_value_container.dart';
 import 'package:pilll/provider/auth.dart';
 
 enum SignInWithAppleState { determined, cancel }
 
-Future<LinkValueContainer?> linkWithApple(User user) async {
+Future<UserCredential?> linkWithApple(User user) async {
   try {
     final provider = AppleAuthProvider();
-    final linkedCredential = await user.linkWithProvider(provider);
-    return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
+    return await user.linkWithProvider(provider);
   } on FirebaseAuthException catch (e) {
     // canceled という code で返ってくるが、コードを読んでると該当するエラーが多かったので実際にdumpしてみたメッセージでマッチしている
     // Googleのcodeとは違うので注意

--- a/lib/utils/auth/apple.dart
+++ b/lib/utils/auth/apple.dart
@@ -7,7 +7,7 @@ enum SignInWithAppleState { determined, cancel }
 
 Future<LinkValueContainer?> linkWithApple(User user) async {
   try {
-    final provider = AppleAuthProvider().addScope('email');
+    final provider = AppleAuthProvider();
     final linkedCredential = await user.linkWithProvider(provider);
     return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
   } on FirebaseAuthException catch (e) {

--- a/lib/utils/auth/apple.dart
+++ b/lib/utils/auth/apple.dart
@@ -1,45 +1,16 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:pilll/utils/auth/hash.dart';
 import 'package:pilll/utils/auth/link_value_container.dart';
 import 'package:pilll/provider/auth.dart';
-import 'package:pilll/utils/environment.dart';
-import 'package:sign_in_with_apple/sign_in_with_apple.dart';
-
-const appleProviderID = "apple.com";
 
 enum SignInWithAppleState { determined, cancel }
 
 Future<LinkValueContainer?> linkWithApple(User user) async {
   try {
-    final rawNonce = generateNonce();
-    final state = generateNonce();
-    final appleCredential = await SignInWithApple.getAppleIDCredential(
-      scopes: [AppleIDAuthorizationScopes.email],
-      webAuthenticationOptions: WebAuthenticationOptions(
-        clientId: Environment.siwaServiceIdentifier,
-        redirectUri: Uri.parse(Environment.androidSiwaRedirectURL),
-      ),
-      nonce: sha256ofString(rawNonce).toString(),
-      state: state,
-    );
-    debugPrint("appleCredential: $appleCredential");
-    if (state != appleCredential.state) {
-      throw AssertionError('state not matched!');
-    }
-    final email = appleCredential.email;
-    final credential = OAuthProvider(appleProviderID).credential(
-      idToken: appleCredential.identityToken,
-      accessToken: appleCredential.authorizationCode,
-      rawNonce: rawNonce,
-    );
-    final linkedCredential = await user.linkWithCredential(credential);
-    return Future.value(LinkValueContainer(linkedCredential, email));
-  } on SignInWithAppleAuthorizationException catch (e) {
-    if (e.code == AuthorizationErrorCode.canceled) {
-      return Future.value(null);
-    }
+    final provider = AppleAuthProvider()..addScope('email');
+    final linkedCredential = await user.linkWithProvider(provider);
+    return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
+  } on FirebaseAuthException catch (e) {
     rethrow;
   }
 }
@@ -49,35 +20,8 @@ Future<UserCredential?> signInWithApple() async {
   if (user == null) {
     throw const FormatException("Anonymous User not found");
   }
-  try {
-    final rawNonce = generateNonce();
-    final state = generateNonce();
-    final appleCredential = await SignInWithApple.getAppleIDCredential(
-      scopes: [AppleIDAuthorizationScopes.email],
-      webAuthenticationOptions: WebAuthenticationOptions(
-        clientId: Environment.siwaServiceIdentifier,
-        redirectUri: Uri.parse(Environment.androidSiwaRedirectURL),
-      ),
-      nonce: sha256ofString(rawNonce).toString(),
-      state: state,
-    );
-    debugPrint("appleCredential: $appleCredential");
-    if (state != appleCredential.state) {
-      throw AssertionError('state not matched!');
-    }
-    final credential = OAuthProvider(appleProviderID).credential(
-      idToken: appleCredential.identityToken,
-      accessToken: appleCredential.authorizationCode,
-      rawNonce: rawNonce,
-    );
-
-    return await FirebaseAuth.instance.signInWithCredential(credential);
-  } on SignInWithAppleAuthorizationException catch (e) {
-    if (e.code == AuthorizationErrorCode.canceled) {
-      return Future.value(null);
-    }
-    rethrow;
-  }
+  final provider = AppleAuthProvider()..addScope('email');
+  return await FirebaseAuth.instance.signInWithProvider(provider);
 }
 
 final isAppleLinkedProvider = Provider((ref) {
@@ -88,40 +32,13 @@ final isAppleLinkedProvider = Provider((ref) {
   }
   return isLinkedAppleFor(userValue);
 });
-// bool isLinkedApple() {
-//   final user = FirebaseAuth.instance.currentUser;
-//   if (user == null) {
-//     return false;
-//   }
-//   return isLinkedAppleFor(user);
-// }
 
 bool isLinkedAppleFor(User user) {
-  return user.providerData.where((element) => element.providerId == appleProviderID).isNotEmpty;
+  return user.providerData.where((element) => element.providerId == AppleAuthProvider.PROVIDER_ID).isNotEmpty;
 }
 
 Future<bool> appleReauthentification() async {
-  final rawNonce = generateNonce();
-  final state = generateNonce();
-  final appleCredential = await SignInWithApple.getAppleIDCredential(
-    scopes: [AppleIDAuthorizationScopes.email],
-    webAuthenticationOptions: WebAuthenticationOptions(
-      clientId: Environment.siwaServiceIdentifier,
-      redirectUri: Uri.parse(Environment.androidSiwaRedirectURL),
-    ),
-    nonce: sha256ofString(rawNonce).toString(),
-    state: state,
-  );
-  debugPrint("appleCredential: $appleCredential");
-  if (state != appleCredential.state) {
-    throw AssertionError('state not matched!');
-  }
-  final credential = OAuthProvider(appleProviderID).credential(
-    idToken: appleCredential.identityToken,
-    accessToken: appleCredential.authorizationCode,
-    rawNonce: rawNonce,
-  );
-
-  await FirebaseAuth.instance.currentUser?.reauthenticateWithCredential(credential);
+  final provider = AppleAuthProvider();
+  await FirebaseAuth.instance.currentUser?.reauthenticateWithProvider(provider);
   return true;
 }

--- a/lib/utils/auth/apple.dart
+++ b/lib/utils/auth/apple.dart
@@ -33,8 +33,7 @@ bool isLinkedAppleFor(User user) {
   return user.providerData.where((element) => element.providerId == AppleAuthProvider.PROVIDER_ID).isNotEmpty;
 }
 
-Future<bool> appleReauthentification() async {
+Future<void> appleReauthentification() async {
   final provider = AppleAuthProvider();
   await FirebaseAuth.instance.currentUser?.reauthenticateWithProvider(provider);
-  return true;
 }

--- a/lib/utils/auth/apple.dart
+++ b/lib/utils/auth/apple.dart
@@ -6,13 +6,9 @@ import 'package:pilll/provider/auth.dart';
 enum SignInWithAppleState { determined, cancel }
 
 Future<LinkValueContainer?> linkWithApple(User user) async {
-  try {
-    final provider = AppleAuthProvider()..addScope('email');
-    final linkedCredential = await user.linkWithProvider(provider);
-    return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
-  } on FirebaseAuthException catch (e) {
-    rethrow;
-  }
+  final provider = AppleAuthProvider()..addScope('email');
+  final linkedCredential = await user.linkWithProvider(provider);
+  return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
 }
 
 Future<UserCredential?> signInWithApple() async {

--- a/lib/utils/auth/apple.dart
+++ b/lib/utils/auth/apple.dart
@@ -6,7 +6,7 @@ import 'package:pilll/provider/auth.dart';
 enum SignInWithAppleState { determined, cancel }
 
 Future<LinkValueContainer?> linkWithApple(User user) async {
-  final provider = AppleAuthProvider()..addScope('email');
+  final provider = AppleAuthProvider().addScope('email');
   final linkedCredential = await user.linkWithProvider(provider);
   return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
 }
@@ -16,7 +16,7 @@ Future<UserCredential?> signInWithApple() async {
   if (user == null) {
     throw const FormatException("Anonymous User not found");
   }
-  final provider = AppleAuthProvider()..addScope('email');
+  final provider = AppleAuthProvider().addScope('email');
   return await FirebaseAuth.instance.signInWithProvider(provider);
 }
 

--- a/lib/utils/auth/apple.dart
+++ b/lib/utils/auth/apple.dart
@@ -9,9 +9,8 @@ Future<UserCredential?> linkWithApple(User user) async {
     final provider = AppleAuthProvider();
     return await user.linkWithProvider(provider);
   } on FirebaseAuthException catch (e) {
-    // canceled という code で返ってくるが、コードを読んでると該当するエラーが多かったので実際にdumpしてみたメッセージでマッチしている
     // Googleのcodeとは違うので注意
-    if (e.toString().contains('The user canceled the authorization attempt')) {
+    if (e.code == "canceled") {
       return Future.value(null);
     }
     rethrow;
@@ -27,9 +26,8 @@ Future<UserCredential?> signInWithApple() async {
     final provider = AppleAuthProvider().addScope('email');
     return await FirebaseAuth.instance.signInWithProvider(provider);
   } on FirebaseAuthException catch (e) {
-    // canceled という code で返ってくるが、コードを読んでると該当するエラーが多かったので実際にdumpしてみたメッセージでマッチしている
     // Googleのcodeとは違うので注意
-    if (e.toString().contains('The user canceled the authorization attempt')) {
+    if (e.code == "canceled") {
       return Future.value(null);
     }
     rethrow;
@@ -54,9 +52,8 @@ Future<void> appleReauthentification() async {
     final provider = AppleAuthProvider();
     await FirebaseAuth.instance.currentUser?.reauthenticateWithProvider(provider);
   } on FirebaseAuthException catch (e) {
-    // canceled という code で返ってくるが、コードを読んでると該当するエラーが多かったので実際にdumpしてみたメッセージでマッチしている
     // Googleのcodeとは違うので注意
-    if (e.toString().contains('The user canceled the authorization attempt')) {
+    if (e.code == "canceled") {
       return Future.value();
     }
     rethrow;

--- a/lib/utils/auth/boilerplate.dart
+++ b/lib/utils/auth/boilerplate.dart
@@ -17,9 +17,7 @@ Future<SignInWithAppleState> callLinkWithApple(LinkApple linkApple) async {
     if (credential == null) {
       return Future.value(SignInWithAppleState.cancel);
     }
-    final email = credential.email;
-    assert(email != null);
-    await linkApple(email);
+    await linkApple();
 
     return Future.value(SignInWithAppleState.determined);
   } on FirebaseAuthException catch (error, stackTrace) {
@@ -48,9 +46,7 @@ Future<SignInWithGoogleState> callLinkWithGoogle(LinkGoogle linkGoogle) async {
       return Future.value(SignInWithGoogleState.cancel);
     }
 
-    final email = credential.email;
-    assert(email != null);
-    await linkGoogle(email);
+    await linkGoogle();
 
     return Future.value(SignInWithGoogleState.determined);
   } on FirebaseAuthException catch (error, stackTrace) {

--- a/lib/utils/auth/google.dart
+++ b/lib/utils/auth/google.dart
@@ -9,7 +9,7 @@ enum SignInWithGoogleState { determined, cancel }
 
 Future<LinkValueContainer?> linkWithGoogle(User user) async {
   try {
-    final provider = GoogleAuthProvider().addScope('email');
+    final provider = GoogleAuthProvider();
     final linkedCredential = await user.linkWithProvider(provider);
     return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
   } on FirebaseAuthException catch (e) {

--- a/lib/utils/auth/google.dart
+++ b/lib/utils/auth/google.dart
@@ -13,15 +13,26 @@ Future<LinkValueContainer?> linkWithGoogle(User user) async {
     final provider = GoogleAuthProvider().addScope('email');
     final linkedCredential = await user.linkWithProvider(provider);
     return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
-  } catch (e) {
-    debugPrint(e.toString());
+  } on FirebaseAuthException catch (e) {
+    // sign-in-failed という code で返ってくるが、コードを読んでると該当するエラーが多かったので実際にdumpしてみたメッセージでマッチしている
+    if (e.toString().contains('The interaction was cancelled by the user')) {
+      return Future.value(null);
+    }
     rethrow;
   }
 }
 
 Future<UserCredential?> signInWithGoogle() async {
-  final provider = GoogleAuthProvider().addScope('email');
-  return await FirebaseAuth.instance.signInWithProvider(provider);
+  try {
+    final provider = GoogleAuthProvider().addScope('email');
+    return await FirebaseAuth.instance.signInWithProvider(provider);
+  } on FirebaseAuthException catch (e) {
+    // sign-in-failed という code で返ってくるが、コードを読んでると該当するエラーが多かったので実際にdumpしてみたメッセージでマッチしている
+    if (e.toString().contains('The interaction was cancelled by the user')) {
+      return Future.value(null);
+    }
+    rethrow;
+  }
 }
 
 final isGoogleLinkedProvider = Provider((ref) {
@@ -38,6 +49,14 @@ bool isLinkedGoogleFor(User user) {
 }
 
 Future<void> googleReauthentification() async {
-  final provider = GoogleAuthProvider();
-  await FirebaseAuth.instance.currentUser?.reauthenticateWithProvider(provider);
+  try {
+    final provider = GoogleAuthProvider();
+    await FirebaseAuth.instance.currentUser?.reauthenticateWithProvider(provider);
+  } on FirebaseAuthException catch (e) {
+    // sign-in-failed という code で返ってくるが、コードを読んでると該当するエラーが多かったので実際にdumpしてみたメッセージでマッチしている
+    if (e.toString().contains('The interaction was cancelled by the user')) {
+      return;
+    }
+    rethrow;
+  }
 }

--- a/lib/utils/auth/google.dart
+++ b/lib/utils/auth/google.dart
@@ -10,7 +10,7 @@ enum SignInWithGoogleState { determined, cancel }
 
 Future<LinkValueContainer?> linkWithGoogle(User user) async {
   try {
-    final provider = GoogleAuthProvider()..addScope('email');
+    final provider = GoogleAuthProvider().addScope('email');
     final linkedCredential = await user.linkWithProvider(provider);
     return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
   } catch (e) {
@@ -20,7 +20,7 @@ Future<LinkValueContainer?> linkWithGoogle(User user) async {
 }
 
 Future<UserCredential?> signInWithGoogle() async {
-  final provider = GoogleAuthProvider()..addScope('email');
+  final provider = GoogleAuthProvider().addScope('email');
   return await FirebaseAuth.instance.signInWithProvider(provider);
 }
 

--- a/lib/utils/auth/google.dart
+++ b/lib/utils/auth/google.dart
@@ -1,5 +1,4 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/utils/auth/link_value_container.dart';
 import 'package:pilll/provider/auth.dart';
@@ -15,6 +14,7 @@ Future<LinkValueContainer?> linkWithGoogle(User user) async {
     return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
   } on FirebaseAuthException catch (e) {
     // sign-in-failed という code で返ってくるが、コードを読んでると該当するエラーが多かったので実際にdumpしてみたメッセージでマッチしている
+    // Appleのcodeとは違うので注意
     if (e.toString().contains('The interaction was cancelled by the user')) {
       return Future.value(null);
     }
@@ -24,10 +24,15 @@ Future<LinkValueContainer?> linkWithGoogle(User user) async {
 
 Future<UserCredential?> signInWithGoogle() async {
   try {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      throw const FormatException("Anonymous User not found");
+    }
     final provider = GoogleAuthProvider().addScope('email');
     return await FirebaseAuth.instance.signInWithProvider(provider);
   } on FirebaseAuthException catch (e) {
     // sign-in-failed という code で返ってくるが、コードを読んでると該当するエラーが多かったので実際にdumpしてみたメッセージでマッチしている
+    // Appleのcodeとは違うので注意
     if (e.toString().contains('The interaction was cancelled by the user')) {
       return Future.value(null);
     }
@@ -54,6 +59,7 @@ Future<void> googleReauthentification() async {
     await FirebaseAuth.instance.currentUser?.reauthenticateWithProvider(provider);
   } on FirebaseAuthException catch (e) {
     // sign-in-failed という code で返ってくるが、コードを読んでると該当するエラーが多かったので実際にdumpしてみたメッセージでマッチしている
+    // Appleのcodeとは違うので注意
     if (e.toString().contains('The interaction was cancelled by the user')) {
       return;
     }

--- a/lib/utils/auth/google.dart
+++ b/lib/utils/auth/google.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/utils/auth/link_value_container.dart';
 import 'package:pilll/provider/auth.dart';
@@ -8,9 +9,14 @@ const googleProviderID = 'google.com';
 enum SignInWithGoogleState { determined, cancel }
 
 Future<LinkValueContainer?> linkWithGoogle(User user) async {
-  final provider = GoogleAuthProvider()..addScope('email');
-  final linkedCredential = await user.linkWithProvider(provider);
-  return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
+  try {
+    final provider = GoogleAuthProvider()..addScope('email');
+    final linkedCredential = await user.linkWithProvider(provider);
+    return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
+  } catch (e) {
+    debugPrint(e.toString());
+    rethrow;
+  }
 }
 
 Future<UserCredential?> signInWithGoogle() async {
@@ -31,8 +37,7 @@ bool isLinkedGoogleFor(User user) {
   return user.providerData.where((element) => element.providerId == GoogleAuthProvider.PROVIDER_ID).isNotEmpty;
 }
 
-Future<bool> googleReauthentification() async {
+Future<void> googleReauthentification() async {
   final provider = GoogleAuthProvider();
   await FirebaseAuth.instance.currentUser?.reauthenticateWithProvider(provider);
-  return true;
 }

--- a/lib/utils/auth/google.dart
+++ b/lib/utils/auth/google.dart
@@ -1,5 +1,4 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:google_sign_in/google_sign_in.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/utils/auth/link_value_container.dart';
 import 'package:pilll/provider/auth.dart';
@@ -9,53 +8,14 @@ const googleProviderID = 'google.com';
 enum SignInWithGoogleState { determined, cancel }
 
 Future<LinkValueContainer?> linkWithGoogle(User user) async {
-  // NOTE: workaround https://github.com/flutter/flutter/issues/44564#issuecomment-655884103
-  final googleUser = await GoogleSignIn(
-    scopes: [
-      'email',
-    ],
-    hostedDomain: "",
-  ).signIn();
-
-  // NOTE: aborted
-  if (googleUser == null) {
-    return Future.value(null);
-  }
-  final email = googleUser.email;
-  final GoogleSignInAuthentication googleAuth = await googleUser.authentication;
-  final credential = GoogleAuthProvider.credential(
-    accessToken: googleAuth.accessToken,
-    idToken: googleAuth.idToken,
-  );
-
-  final linkedCredential = await user.linkWithCredential(credential);
-  return Future.value(LinkValueContainer(linkedCredential, email));
+  final provider = GoogleAuthProvider()..addScope('email');
+  final linkedCredential = await user.linkWithProvider(provider);
+  return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
 }
 
 Future<UserCredential?> signInWithGoogle() async {
-  final user = FirebaseAuth.instance.currentUser;
-  if (user == null) {
-    throw const FormatException("Anonymous User not found");
-  }
-  // NOTE: workaround https://github.com/flutter/flutter/issues/44564#issuecomment-655884103
-  final googleUser = await GoogleSignIn(
-    scopes: [
-      'email',
-    ],
-    hostedDomain: "",
-  ).signIn();
-
-  // NOTE: aborted
-  if (googleUser == null) {
-    return Future.value(null);
-  }
-  final GoogleSignInAuthentication googleAuth = await googleUser.authentication;
-  final credential = GoogleAuthProvider.credential(
-    accessToken: googleAuth.accessToken,
-    idToken: googleAuth.idToken,
-  );
-
-  return await FirebaseAuth.instance.signInWithCredential(credential);
+  final provider = GoogleAuthProvider()..addScope('email');
+  return await FirebaseAuth.instance.signInWithProvider(provider);
 }
 
 final isGoogleLinkedProvider = Provider((ref) {
@@ -66,37 +26,13 @@ final isGoogleLinkedProvider = Provider((ref) {
   }
   return isLinkedGoogleFor(userValue);
 });
-// bool isLinkedGoogle() {
-//   final user = FirebaseAuth.instance.currentUser;
-//   if (user == null) {
-//     return false;
-//   }
-//   return isLinkedGoogleFor(user);
-// }
 
 bool isLinkedGoogleFor(User user) {
-  return user.providerData.where((element) => element.providerId == googleProviderID).isNotEmpty;
+  return user.providerData.where((element) => element.providerId == GoogleAuthProvider.PROVIDER_ID).isNotEmpty;
 }
 
 Future<bool> googleReauthentification() async {
-  // NOTE: workaround https://github.com/flutter/flutter/issues/44564#issuecomment-655884103
-  final googleUser = await GoogleSignIn(
-    scopes: [
-      'email',
-    ],
-    hostedDomain: "",
-  ).signIn();
-  // NOTE: aborted
-  if (googleUser == null) {
-    return false;
-  }
-
-  final GoogleSignInAuthentication googleAuth = await googleUser.authentication;
-  final credential = GoogleAuthProvider.credential(
-    accessToken: googleAuth.accessToken,
-    idToken: googleAuth.idToken,
-  );
-
-  await FirebaseAuth.instance.currentUser?.reauthenticateWithCredential(credential);
+  final provider = GoogleAuthProvider();
+  await FirebaseAuth.instance.currentUser?.reauthenticateWithProvider(provider);
   return true;
 }

--- a/lib/utils/auth/google.dart
+++ b/lib/utils/auth/google.dart
@@ -1,17 +1,15 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:pilll/utils/auth/link_value_container.dart';
 import 'package:pilll/provider/auth.dart';
 
 const googleProviderID = 'google.com';
 
 enum SignInWithGoogleState { determined, cancel }
 
-Future<LinkValueContainer?> linkWithGoogle(User user) async {
+Future<UserCredential?> linkWithGoogle(User user) async {
   try {
     final provider = GoogleAuthProvider();
-    final linkedCredential = await user.linkWithProvider(provider);
-    return Future.value(LinkValueContainer(linkedCredential, linkedCredential.user?.email));
+    return await user.linkWithProvider(provider);
   } on FirebaseAuthException catch (e) {
     // sign-in-failed という code で返ってくるが、コードを読んでると該当するエラーが多かったので実際にdumpしてみたメッセージでマッチしている
     // Appleのcodeとは違うので注意

--- a/lib/utils/auth/link_value_container.dart
+++ b/lib/utils/auth/link_value_container.dart
@@ -1,8 +1,0 @@
-import 'package:firebase_auth/firebase_auth.dart';
-
-class LinkValueContainer {
-  final UserCredential credential;
-  final String? email;
-
-  LinkValueContainer(this.credential, this.email);
-}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1045,30 +1045,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
-  sign_in_with_apple:
-    dependency: "direct main"
-    description:
-      name: sign_in_with_apple
-      sha256: "0975c23b9f8b30a80e27d5659a75993a093d4cb5f4eb7d23a9ccc586fea634e0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.0"
-  sign_in_with_apple_platform_interface:
-    dependency: transitive
-    description:
-      name: sign_in_with_apple_platform_interface
-      sha256: a5883edee09ed6be19de19e7d9f618a617fe41a6fa03f76d082dfb787e9ea18d
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
-  sign_in_with_apple_web:
-    dependency: transitive
-    description:
-      name: sign_in_with_apple_web
-      sha256: "44b66528f576e77847c14999d5e881e17e7223b7b0625a185417829e5306f47a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -589,54 +589,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  google_identity_services_web:
-    dependency: transitive
-    description:
-      name: google_identity_services_web
-      sha256: "7940fdc3b1035db4d65d387c1bdd6f9574deaa6777411569c05ecc25672efacd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.1"
-  google_sign_in:
-    dependency: "direct main"
-    description:
-      name: google_sign_in
-      sha256: aab6fdc41374014494f9e9026b9859e7309639d50a0bf4a2a412467a5ae4abc6
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.4"
-  google_sign_in_android:
-    dependency: transitive
-    description:
-      name: google_sign_in_android
-      sha256: "8d60a787b29cb7d2bcf29230865f4a91f17323c6ac5b6b9027a6418e48d9ffc3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.18"
-  google_sign_in_ios:
-    dependency: transitive
-    description:
-      name: google_sign_in_ios
-      sha256: "6ec0e13a4c5c646471b9f6a25ceb3ae76d339889d4c0f79b729bf0714215a63e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.6.2"
-  google_sign_in_platform_interface:
-    dependency: transitive
-    description:
-      name: google_sign_in_platform_interface
-      sha256: e69553c0fc6a76216e9d06a8c3767e291ad9be42171f879aab7ab708569d4393
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.1"
-  google_sign_in_web:
-    dependency: transitive
-    description:
-      name: google_sign_in_web
-      sha256: "69b9ce0e760945ff52337921a8b5871592b74c92f85e7632293310701eea68cc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.12.0+2"
   graphs:
     dependency: transitive
     description:
@@ -661,14 +613,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -917,14 +861,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.6.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      sha256: b1c1ac5ce6688d77f65f3375a9abb9319b3cb32486bdc7a1e0fdf004d7ba4e47
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.1"
   riverpod:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,7 +61,6 @@ dependencies:
     # Use https://github.com/pichillilorenzo/flutter_inappwebview/pull/1238
   flutter_inappwebview: ^5.7.2+3
   flutter_app_badger: ^1.2.0
-  sign_in_with_apple: ^5.0.0
   google_sign_in: ^6.1.4
   purchases_flutter: ^5.6.0
   firebase_performance: ^0.9.0+11

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,7 +61,6 @@ dependencies:
     # Use https://github.com/pichillilorenzo/flutter_inappwebview/pull/1238
   flutter_inappwebview: ^5.7.2+3
   flutter_app_badger: ^1.2.0
-  google_sign_in: ^6.1.4
   purchases_flutter: ^5.6.0
   firebase_performance: ^0.9.0+11
   flutter_native_timezone: ^2.0.0


### PR DESCRIPTION
## TODO
- [x] devのfirebase console に Apple の秘密鍵等を登録する
- [x] prodのfirebase console に Apple の秘密鍵等を登録する
- [x] 動作確認
  - [x] Apple Link
    - [x] iOS -> Android
    - [x] Android -> iOS
    - [x] iOS -> iOS
    - [x] Android -> Android
  - [x] Google Link
    - [x] iOS -> Android
    - [x] Android -> iOS
    - [x] iOS -> iOS
    - [x] Android -> Android
  - [x] Sign in with Apple
    - [x] iOS
    - [x] Android
  - [x] Sign in with Google
    - [x] iOS
    - [x] Android
- [x] キャンセル次の動作確認
  - [x] Google
  - [x] Apple

## Abstract
apple,googleともにOAuthProviderが専用に生えていたのでそれを使用する

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた