### PR TITLE
生理予定日を表示するロジックを改修

### DIFF
--- a/lib/components/organisms/calendar/band/calendar_band_function.dart
+++ b/lib/components/organisms/calendar/band/calendar_band_function.dart
@@ -7,10 +7,10 @@ import 'package:pilll/entity/setting.codegen.dart';
 import 'package:pilll/entity/weekday.dart';
 import 'package:pilll/utils/datetime/day.dart';
 
-// 予定されている生理日 or 記録されている生理日の日付の配列を返す
+// 予定されている生理日
 // maxDateRangeCountは主にユニットテストの時に嬉しい引数になっているがプロダクションコードでもそのまま使用している
 // ユースケースとして大体の未来のものを返せれば良いので厳密な計算結果が欲しいわけではないので動作確認とユニットテストをしやすい方式をとっている
-List<DateRange> scheduledOrInTheMiddleMenstruationDateRanges(PillSheetGroup? pillSheetGroup, Setting? setting, List<Menstruation> menstruations,
+List<DateRange> scheduledMenstruationDateRanges(PillSheetGroup? pillSheetGroup, Setting? setting, List<Menstruation> menstruations,
     [int maxDateRangeCount = 15]) {
   if (pillSheetGroup == null || setting == null) {
     return [];
@@ -31,14 +31,13 @@ List<DateRange> scheduledOrInTheMiddleMenstruationDateRanges(PillSheetGroup? pil
             menstruationDateRange.inRange(scheduledMenstruationRange.begin) || menstruationDateRange.inRange(scheduledMenstruationRange.end))
         .isEmpty;
   }).toList();
-  final baseDateRanges = scheduledMenstruationDateRanges..addAll(menstruationDateRanges);
 
-  List<DateRange> dateRanges = baseDateRanges;
+  List<DateRange> dateRanges = scheduledMenstruationDateRanges;
   final pillSheetGroupTotalPillCount = pillSheetGroup.pillSheetTypes.fold(0, (p, e) => p + e.typeInfo.totalCount);
   for (var i = 1; i <= maxDateRangeCount; i++) {
     final offset = pillSheetGroupTotalPillCount * i;
     final dateRangesWithOffset =
-        baseDateRanges.map((e) => DateRange(e.begin.add(Duration(days: offset)), e.end.add(Duration(days: offset)))).toList();
+        scheduledMenstruationDateRanges.map((e) => DateRange(e.begin.add(Duration(days: offset)), e.end.add(Duration(days: offset)))).toList();
     dateRanges = dateRanges..addAll(dateRangesWithOffset);
   }
 

--- a/lib/components/organisms/calendar/band/calendar_band_function.dart
+++ b/lib/components/organisms/calendar/band/calendar_band_function.dart
@@ -38,7 +38,7 @@ List<DateRange> scheduledMenstruationDateRanges(PillSheetGroup? pillSheetGroup, 
     final offset = pillSheetGroupTotalPillCount * i;
     final dateRangesWithOffset =
         scheduledMenstruationDateRanges.map((e) => DateRange(e.begin.add(Duration(days: offset)), e.end.add(Duration(days: offset)))).toList();
-    dateRanges = dateRanges..addAll(dateRangesWithOffset);
+    dateRanges = [...dateRanges, ...dateRangesWithOffset];
   }
 
   if (dateRanges.length > maxDateRangeCount) {

--- a/lib/components/organisms/calendar/band/calendar_band_function.dart
+++ b/lib/components/organisms/calendar/band/calendar_band_function.dart
@@ -26,7 +26,7 @@ List<DateRange> scheduledMenstruationDateRanges(PillSheetGroup? pillSheetGroup, 
   final menstruationDateRanges = menstruations.map((e) => e.dateRange);
   final scheduledMenstruationDateRanges = pillSheetGroup
       .menstruationDateRanges(setting: setting)
-      .where((scheduledMenstruationRange) => scheduledMenstruationRange.begin.isAfter(today()) && scheduledMenstruationRange.end.isAfter(today()))
+      .where((scheduledMenstruationRange) => !scheduledMenstruationRange.end.isBefore(today()))
       .where((scheduledMenstruationRange) {
     // すでに記録されている生理については除外したものを予定されている生理とする
     return menstruationDateRanges

--- a/lib/components/organisms/calendar/band/calendar_band_function.dart
+++ b/lib/components/organisms/calendar/band/calendar_band_function.dart
@@ -24,7 +24,10 @@ List<DateRange> scheduledMenstruationDateRanges(PillSheetGroup? pillSheetGroup, 
   assert(maxDateRangeCount > 0);
 
   final menstruationDateRanges = menstruations.map((e) => e.dateRange);
-  final scheduledMenstruationDateRanges = pillSheetGroup.menstruationDateRanges(setting: setting).where((scheduledMenstruationRange) {
+  final scheduledMenstruationDateRanges = pillSheetGroup
+      .menstruationDateRanges(setting: setting)
+      .where((scheduledMenstruationRange) => scheduledMenstruationRange.begin.isAfter(today()) && scheduledMenstruationRange.end.isAfter(today()))
+      .where((scheduledMenstruationRange) {
     // すでに記録されている生理については除外したものを予定されている生理とする
     return menstruationDateRanges
         .where((menstruationDateRange) =>

--- a/lib/components/organisms/calendar/band/calendar_band_provider.dart
+++ b/lib/components/organisms/calendar/band/calendar_band_provider.dart
@@ -28,7 +28,7 @@ final calendarScheduledMenstruationBandListProvider = Provider<AsyncValue<List<C
     ref.watch(settingProvider),
     ref.watch(allMenstruationProvider),
   ).whenData(
-    (t) => scheduledOrInTheMiddleMenstruationDateRanges(
+    (t) => scheduledMenstruationDateRanges(
       t.t1,
       t.t2,
       t.t3,

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -249,13 +249,13 @@ class PillSheetGroup with _$PillSheetGroup {
       return [];
     }
 
-    // 28番ごとなら28,56,84番目開始の番号とマッチさせるために各始まりの番号を配列にする
     final summarizedPillCount = pillSheets.fold<int>(
       0,
       (previousValue, element) => previousValue + element.typeInfo.totalCount,
     );
     // ピルシートグループの中に何度pillNumberForFromMenstruation が出てくるか算出
     final numberOfMenstruationSettingInPillSheetGroup = summarizedPillCount / setting.pillNumberForFromMenstruation;
+    // 28番ごとなら28,56,84番目開始の番号とマッチさせるために各始まりの番号を配列にする
     List<int> fromMenstruations = [];
     for (var i = 0; i < numberOfMenstruationSettingInPillSheetGroup; i++) {
       fromMenstruations.add(setting.pillNumberForFromMenstruation + (setting.pillNumberForFromMenstruation * i));

--- a/lib/features/menstruation/components/menstruation_card_list.dart
+++ b/lib/features/menstruation/components/menstruation_card_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/organisms/calendar/band/calendar_band_model.dart';
+import 'package:pilll/utils/datetime/date_range.dart';
 import 'package:pilll/features/menstruation/history/menstruation_history_card.dart';
 import 'package:pilll/features/menstruation/history/menstruation_history_card_state.dart';
 import 'package:pilll/features/menstruation/menstruation_card.dart';
@@ -31,13 +32,7 @@ class MenstruationCardList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final card = cardState(
-      latestPillSheetGroup,
-      latestMenstruation,
-      setting,
-      allMenstruation,
-      calendarScheduledMenstruationBandModels,
-    );
+    final card = cardState(latestPillSheetGroup, latestMenstruation, setting, calendarScheduledMenstruationBandModels);
     final historyCard = historyCardState(latestMenstruation, allMenstruation, premiumAndTrial);
     return Expanded(
       child: Container(
@@ -62,7 +57,6 @@ MenstruationCardState? cardState(
   PillSheetGroup? pillSheetGroup,
   Menstruation? menstration,
   Setting setting,
-  List<Menstruation> allMenstruation,
   List<CalendarScheduledMenstruationBandModel> calendarScheduledMenstruationBandModels,
 ) {
   if (menstration != null && menstration.dateRange.inRange(today())) {
@@ -76,13 +70,14 @@ MenstruationCardState? cardState(
     return null;
   }
 
-  final inTheMiddleDateRanges = allMenstruation.map((e) => e.dateRange).where((element) => element.inRange(today()));
+  final menstruationDateRanges = calendarScheduledMenstruationBandModels;
+  final inTheMiddleDateRanges = menstruationDateRanges.map((e) => DateRange(e.begin, e.end)).where((element) => element.inRange(today()));
 
   if (inTheMiddleDateRanges.isNotEmpty) {
     return MenstruationCardState.inTheMiddle(scheduledDate: inTheMiddleDateRanges.first.begin);
   }
 
-  final futureDateRanges = calendarScheduledMenstruationBandModels.where((element) => element.begin.isAfter(today()));
+  final futureDateRanges = menstruationDateRanges.where((element) => element.begin.isAfter(today()));
   if (futureDateRanges.isNotEmpty) {
     return MenstruationCardState.future(nextSchedule: futureDateRanges.first.begin);
   }

--- a/lib/features/menstruation/components/menstruation_card_list.dart
+++ b/lib/features/menstruation/components/menstruation_card_list.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/organisms/calendar/band/calendar_band_model.dart';
-import 'package:pilll/utils/datetime/date_range.dart';
 import 'package:pilll/features/menstruation/history/menstruation_history_card.dart';
 import 'package:pilll/features/menstruation/history/menstruation_history_card_state.dart';
 import 'package:pilll/features/menstruation/menstruation_card.dart';
@@ -32,7 +31,13 @@ class MenstruationCardList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final card = cardState(latestPillSheetGroup, latestMenstruation, setting, calendarScheduledMenstruationBandModels);
+    final card = cardState(
+      latestPillSheetGroup,
+      latestMenstruation,
+      setting,
+      allMenstruation,
+      calendarScheduledMenstruationBandModels,
+    );
     final historyCard = historyCardState(latestMenstruation, allMenstruation, premiumAndTrial);
     return Expanded(
       child: Container(
@@ -57,6 +62,7 @@ MenstruationCardState? cardState(
   PillSheetGroup? pillSheetGroup,
   Menstruation? menstration,
   Setting setting,
+  List<Menstruation> allMenstruation,
   List<CalendarScheduledMenstruationBandModel> calendarScheduledMenstruationBandModels,
 ) {
   if (menstration != null && menstration.dateRange.inRange(today())) {
@@ -70,14 +76,13 @@ MenstruationCardState? cardState(
     return null;
   }
 
-  final menstruationDateRanges = calendarScheduledMenstruationBandModels;
-  final inTheMiddleDateRanges = menstruationDateRanges.map((e) => DateRange(e.begin, e.end)).where((element) => element.inRange(today()));
+  final inTheMiddleDateRanges = allMenstruation.map((e) => e.dateRange).where((element) => element.inRange(today()));
 
   if (inTheMiddleDateRanges.isNotEmpty) {
     return MenstruationCardState.inTheMiddle(scheduledDate: inTheMiddleDateRanges.first.begin);
   }
 
-  final futureDateRanges = menstruationDateRanges.where((element) => element.begin.isAfter(today()));
+  final futureDateRanges = calendarScheduledMenstruationBandModels.where((element) => element.begin.isAfter(today()));
   if (futureDateRanges.isNotEmpty) {
     return MenstruationCardState.future(nextSchedule: futureDateRanges.first.begin);
   }

--- a/test/features/calendar/util_test.dart
+++ b/test/features/calendar/util_test.dart
@@ -61,7 +61,7 @@ void main() {
             timezoneDatabaseName: null,
           );
           expect(
-            scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, [], 2),
+            scheduledMenstruationDateRanges(pillSheetGroup, setting, [], 2),
             [
               DateRange(
                 DateTime.parse("2020-09-23"),
@@ -116,7 +116,7 @@ void main() {
             timezoneDatabaseName: null,
           );
           expect(
-            scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, [], 2),
+            scheduledMenstruationDateRanges(pillSheetGroup, setting, [], 2),
             [
               DateRange(
                 DateTime.parse("2020-09-23"),
@@ -171,7 +171,7 @@ void main() {
             timezoneDatabaseName: null,
           );
           expect(
-            scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, [], 4),
+            scheduledMenstruationDateRanges(pillSheetGroup, setting, [], 4),
             [
               DateRange(
                 DateTime.parse("2020-09-23"),
@@ -246,7 +246,7 @@ void main() {
           assert(pillSheetType.dosingPeriod == 21,
               "scheduledMenstruationDateRange adding value with dosingPeriod when it will create DateRange. pillsheet_28_7 type has 24 dosingPeriod");
           expect(
-            scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, [], 1),
+            scheduledMenstruationDateRanges(pillSheetGroup, setting, [], 1),
             [
               DateRange(
                 DateTime.parse("2020-09-23"),
@@ -292,7 +292,7 @@ void main() {
           assert(pillSheetType.dosingPeriod == 21,
               "scheduledMenstruationDateRange adding value with dosingPeriod when it will create DateRange. pillsheet_28_7 type has 24 dosingPeriod");
           expect(
-            scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, [], 2),
+            scheduledMenstruationDateRanges(pillSheetGroup, setting, [], 2),
             [
               DateRange(
                 DateTime.parse("2020-09-23"),
@@ -341,7 +341,7 @@ void main() {
           assert(pillSheetType.dosingPeriod == 21,
               "scheduledMenstruationDateRange adding value with dosingPeriod when it will create DateRange. pillsheet_28_7 type has 24 dosingPeriod");
           expect(
-            scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, [], 3),
+            scheduledMenstruationDateRanges(pillSheetGroup, setting, [], 3),
             [
               DateRange(
                 DateTime.parse("2020-09-23"),
@@ -394,7 +394,7 @@ void main() {
           assert(pillSheetType.dosingPeriod == 28,
               "scheduledMenstruationDateRange adding value with dosingPeriod when it will create DateRange. pillsheet_28_7 type has 24 dosingPeriod");
           expect(
-            scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, [], 1),
+            scheduledMenstruationDateRanges(pillSheetGroup, setting, [], 1),
             [
               DateRange(
                 DateTime.parse("2021-02-09"),
@@ -435,7 +435,7 @@ void main() {
             timezoneDatabaseName: null,
           );
           expect(
-            scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, [], 3),
+            scheduledMenstruationDateRanges(pillSheetGroup, setting, [], 3),
             [
               DateRange(
                 DateTime.parse("2021-01-23"),
@@ -487,7 +487,7 @@ void main() {
           assert(pillSheetType.dosingPeriod == 28,
               "scheduledMenstruationDateRange adding value with dosingPeriod when it will create DateRange. pillsheet_28_7 type has 24 dosingPeriod");
           expect(
-            scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, [], 1),
+            scheduledMenstruationDateRanges(pillSheetGroup, setting, [], 1),
             [],
           );
         },

--- a/test/features/menstruation/menstruation_store_test.dart
+++ b/test/features/menstruation/menstruation_store_test.dart
@@ -55,7 +55,7 @@ void main() {
             createdAt: DateTime(2021, 03, 28),
           ),
         ];
-        final calendarScheduledMenstruationBandModels = scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, menstruations, 12)
+        final calendarScheduledMenstruationBandModels = scheduledMenstruationDateRanges(pillSheetGroup, setting, menstruations, 12)
             .map((e) => CalendarScheduledMenstruationBandModel(e.begin, e.end))
             .toList();
 
@@ -93,7 +93,7 @@ void main() {
             createdAt: DateTime(2021, 03, 28),
           ),
         ];
-        final calendarScheduledMenstruationBandModels = scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, menstruations, 12)
+        final calendarScheduledMenstruationBandModels = scheduledMenstruationDateRanges(pillSheetGroup, setting, menstruations, 12)
             .map((e) => CalendarScheduledMenstruationBandModel(e.begin, e.end))
             .toList();
 
@@ -136,7 +136,7 @@ void main() {
           timezoneDatabaseName: null,
           isOnReminder: true,
         );
-        final calendarScheduledMenstruationBandModels = scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, [], 12)
+        final calendarScheduledMenstruationBandModels = scheduledMenstruationDateRanges(pillSheetGroup, setting, [], 12)
             .map((e) => CalendarScheduledMenstruationBandModel(e.begin, e.end))
             .toList();
 
@@ -185,7 +185,7 @@ void main() {
             createdAt: DateTime(2021, 03, 28),
           ),
         ];
-        final calendarScheduledMenstruationBandModels = scheduledOrInTheMiddleMenstruationDateRanges(pillSheetGroup, setting, menstruations, 12)
+        final calendarScheduledMenstruationBandModels = scheduledMenstruationDateRanges(pillSheetGroup, setting, menstruations, 12)
             .map((e) => CalendarScheduledMenstruationBandModel(e.begin, e.end))
             .toList();
         final actual = cardState(pillSheetGroup, menstruations.first, setting, calendarScheduledMenstruationBandModels);

--- a/test/features/menstruation/menstruation_store_test.dart
+++ b/test/features/menstruation/menstruation_store_test.dart
@@ -59,7 +59,7 @@ void main() {
             .map((e) => CalendarScheduledMenstruationBandModel(e.begin, e.end))
             .toList();
 
-        final actual = cardState(pillSheetGroup, menstruations.first, setting, menstruations, calendarScheduledMenstruationBandModels);
+        final actual = cardState(pillSheetGroup, menstruations.first, setting, calendarScheduledMenstruationBandModels);
 
         expect(actual, MenstruationCardState(title: "生理開始日", scheduleDate: DateTime(2021, 04, 28), countdownString: "2日目"));
       },
@@ -97,7 +97,7 @@ void main() {
             .map((e) => CalendarScheduledMenstruationBandModel(e.begin, e.end))
             .toList();
 
-        final actual = cardState(pillSheetGroup, menstruations.first, setting, menstruations, calendarScheduledMenstruationBandModels);
+        final actual = cardState(pillSheetGroup, menstruations.first, setting, calendarScheduledMenstruationBandModels);
         expect(actual, null);
       },
     );
@@ -140,12 +140,12 @@ void main() {
             .map((e) => CalendarScheduledMenstruationBandModel(e.begin, e.end))
             .toList();
 
-        final actual = cardState(pillSheetGroup, null, setting, [], calendarScheduledMenstruationBandModels);
+        final actual = cardState(pillSheetGroup, null, setting, calendarScheduledMenstruationBandModels);
         expect(actual, MenstruationCardState(title: "生理予定日", scheduleDate: DateTime(2021, 05, 13), countdownString: "あと14日"));
       },
     );
     test(
-      "if todayPillNumber > setting.pillNumberForFromMenstruation, when return card state in schedueld menstruation",
+      "if todayPillNumber > setting.pillNumberForFromMenstruation, when return card state of into duration for schedueld menstruation",
       () async {
         final originalTodayRepository = todayRepository;
         final mockTodayRepository = MockTodayService();
@@ -188,7 +188,7 @@ void main() {
         final calendarScheduledMenstruationBandModels = scheduledMenstruationDateRanges(pillSheetGroup, setting, menstruations, 12)
             .map((e) => CalendarScheduledMenstruationBandModel(e.begin, e.end))
             .toList();
-        final actual = cardState(pillSheetGroup, menstruations.first, setting, menstruations, calendarScheduledMenstruationBandModels);
+        final actual = cardState(pillSheetGroup, menstruations.first, setting, calendarScheduledMenstruationBandModels);
         expect(
           actual,
           MenstruationCardState(title: "生理予定日", scheduleDate: DateTime(2021, 04, 28), countdownString: "生理予定：2日目"),

--- a/test/features/menstruation/menstruation_store_test.dart
+++ b/test/features/menstruation/menstruation_store_test.dart
@@ -59,7 +59,7 @@ void main() {
             .map((e) => CalendarScheduledMenstruationBandModel(e.begin, e.end))
             .toList();
 
-        final actual = cardState(pillSheetGroup, menstruations.first, setting, calendarScheduledMenstruationBandModels);
+        final actual = cardState(pillSheetGroup, menstruations.first, setting, menstruations, calendarScheduledMenstruationBandModels);
 
         expect(actual, MenstruationCardState(title: "生理開始日", scheduleDate: DateTime(2021, 04, 28), countdownString: "2日目"));
       },
@@ -97,7 +97,7 @@ void main() {
             .map((e) => CalendarScheduledMenstruationBandModel(e.begin, e.end))
             .toList();
 
-        final actual = cardState(pillSheetGroup, menstruations.first, setting, calendarScheduledMenstruationBandModels);
+        final actual = cardState(pillSheetGroup, menstruations.first, setting, menstruations, calendarScheduledMenstruationBandModels);
         expect(actual, null);
       },
     );
@@ -140,12 +140,12 @@ void main() {
             .map((e) => CalendarScheduledMenstruationBandModel(e.begin, e.end))
             .toList();
 
-        final actual = cardState(pillSheetGroup, null, setting, calendarScheduledMenstruationBandModels);
+        final actual = cardState(pillSheetGroup, null, setting, [], calendarScheduledMenstruationBandModels);
         expect(actual, MenstruationCardState(title: "生理予定日", scheduleDate: DateTime(2021, 05, 13), countdownString: "あと14日"));
       },
     );
     test(
-      "if todayPillNumber > setting.pillNumberForFromMenstruation, when return card state of into duration for schedueld menstruation",
+      "if todayPillNumber > setting.pillNumberForFromMenstruation, when return card state in schedueld menstruation",
       () async {
         final originalTodayRepository = todayRepository;
         final mockTodayRepository = MockTodayService();
@@ -188,7 +188,7 @@ void main() {
         final calendarScheduledMenstruationBandModels = scheduledMenstruationDateRanges(pillSheetGroup, setting, menstruations, 12)
             .map((e) => CalendarScheduledMenstruationBandModel(e.begin, e.end))
             .toList();
-        final actual = cardState(pillSheetGroup, menstruations.first, setting, calendarScheduledMenstruationBandModels);
+        final actual = cardState(pillSheetGroup, menstruations.first, setting, menstruations, calendarScheduledMenstruationBandModels);
         expect(
           actual,
           MenstruationCardState(title: "生理予定日", scheduleDate: DateTime(2021, 04, 28), countdownString: "生理予定：2日目"),


### PR DESCRIPTION
## Abstract
- scheduled なBandModelだけを用意するのが正しかったのでメソッドをリネーム。また実記録のmensturationを足しているコードも削除
- 過去の予定日も出ていたので出ないように制御した

## Why
本来のバグが未来の生理予定日が表示されないユーザーが発生した。これは実記録の整理データが多い場合に発生する(と予想)。なぜなら、実記録を足しているコードの後に足切りで15件までのデータを使うようにしていたから

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた