### PR TITLE
Ignore error for fix ParallelWaitError

### DIFF
--- a/lib/provider/remote_config_parameter.dart
+++ b/lib/provider/remote_config_parameter.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:pilll/entity/remote_config_parameter.codegen.dart';
 import 'package:pilll/utils/remote_config.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -8,10 +9,43 @@ part 'remote_config_parameter.g.dart';
 RemoteConfigParameter remoteConfigParameter(RemoteConfigParameterRef ref) {
   // fetchAndActiveをentrypointで完了しているので値が取れる想定
   return RemoteConfigParameter(
-    isPaywallFirst: remoteConfig.getBool(RemoteConfigKeys.isPaywallFirst),
-    skipInitialSetting: remoteConfig.getBool(RemoteConfigKeys.skipInitialSetting),
-    trialDeadlineDateOffsetDay: remoteConfig.getInt(RemoteConfigKeys.trialDeadlineDateOffsetDay),
-    discountEntitlementOffsetDay: remoteConfig.getInt(RemoteConfigKeys.discountEntitlementOffsetDay),
-    discountCountdownBoundaryHour: remoteConfig.getInt(RemoteConfigKeys.discountCountdownBoundaryHour),
+    isPaywallFirst: remoteConfig.getBoolOrDefault(
+      RemoteConfigKeys.isPaywallFirst,
+      RemoteConfigParameterDefaultValues.isPaywallFirst,
+    ),
+    skipInitialSetting: remoteConfig.getBoolOrDefault(
+      RemoteConfigKeys.skipInitialSetting,
+      RemoteConfigParameterDefaultValues.skipInitialSetting,
+    ),
+    trialDeadlineDateOffsetDay: remoteConfig.getIntOrDefault(
+      RemoteConfigKeys.trialDeadlineDateOffsetDay,
+      RemoteConfigParameterDefaultValues.trialDeadlineDateOffsetDay,
+    ),
+    discountEntitlementOffsetDay: remoteConfig.getIntOrDefault(
+      RemoteConfigKeys.discountEntitlementOffsetDay,
+      RemoteConfigParameterDefaultValues.discountEntitlementOffsetDay,
+    ),
+    discountCountdownBoundaryHour: remoteConfig.getIntOrDefault(
+      RemoteConfigKeys.discountCountdownBoundaryHour,
+      RemoteConfigParameterDefaultValues.discountCountdownBoundaryHour,
+    ),
   );
+}
+
+extension RemoteConfigExt on FirebaseRemoteConfig {
+  bool getBoolOrDefault(String key, bool defaultValue) {
+    try {
+      return getAll().containsKey(key) ? getBool(key) : defaultValue;
+    } catch (error) {
+      return defaultValue;
+    }
+  }
+
+  int getIntOrDefault(String key, int defaultValue) {
+    try {
+      return getAll().containsKey(key) ? getInt(key) : defaultValue;
+    } catch (error) {
+      return defaultValue;
+    }
+  }
 }

--- a/lib/provider/remote_config_parameter.g.dart
+++ b/lib/provider/remote_config_parameter.g.dart
@@ -7,7 +7,7 @@ part of 'remote_config_parameter.dart';
 // **************************************************************************
 
 String _$remoteConfigParameterHash() =>
-    r'2be68ca99f9b909111793557fccb8ad1081a028d';
+    r'23c34d845e8be5bcee7eee2cadff31080abe2f6c';
 
 /// See also [remoteConfigParameter].
 @ProviderFor(remoteConfigParameter)

--- a/lib/utils/remote_config.dart
+++ b/lib/utils/remote_config.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:flutter/widgets.dart';
 import 'package:pilll/entity/remote_config_parameter.codegen.dart';
+import 'package:pilll/utils/error_log.dart';
 
 final remoteConfig = FirebaseRemoteConfig.instance;
 
@@ -26,9 +27,10 @@ Future<void> setupRemoteConfig() async {
     remoteConfig.onConfigUpdated.listen((event) {
       remoteConfig.activate();
     });
-  } catch (error) {
+  } catch (error, st) {
     // ignore error
     debugPrint(error.toString());
+    errorLogger.recordError(error, st);
   }
 }
 

--- a/lib/utils/remote_config.dart
+++ b/lib/utils/remote_config.dart
@@ -5,26 +5,31 @@ import 'package:pilll/entity/remote_config_parameter.codegen.dart';
 final remoteConfig = FirebaseRemoteConfig.instance;
 
 Future<void> setupRemoteConfig() async {
-  await (
-    remoteConfig.setConfigSettings(RemoteConfigSettings(
-      fetchTimeout: const Duration(minutes: 1),
-      minimumFetchInterval: const Duration(hours: 1),
-    )),
-    remoteConfig.setDefaults({
-      RemoteConfigKeys.isPaywallFirst: RemoteConfigParameterDefaultValues.isPaywallFirst,
-      RemoteConfigKeys.skipInitialSetting: RemoteConfigParameterDefaultValues.skipInitialSetting,
-      RemoteConfigKeys.trialDeadlineDateOffsetDay: RemoteConfigParameterDefaultValues.trialDeadlineDateOffsetDay,
-      RemoteConfigKeys.discountEntitlementOffsetDay: RemoteConfigParameterDefaultValues.discountEntitlementOffsetDay,
-      RemoteConfigKeys.discountCountdownBoundaryHour: RemoteConfigParameterDefaultValues.discountCountdownBoundaryHour,
-    }),
-    remoteConfig.fetchAndActivate()
-  ).wait;
+  try {
+    await (
+      remoteConfig.setConfigSettings(RemoteConfigSettings(
+        fetchTimeout: const Duration(minutes: 1),
+        minimumFetchInterval: const Duration(hours: 1),
+      )),
+      remoteConfig.setDefaults({
+        RemoteConfigKeys.isPaywallFirst: RemoteConfigParameterDefaultValues.isPaywallFirst,
+        RemoteConfigKeys.skipInitialSetting: RemoteConfigParameterDefaultValues.skipInitialSetting,
+        RemoteConfigKeys.trialDeadlineDateOffsetDay: RemoteConfigParameterDefaultValues.trialDeadlineDateOffsetDay,
+        RemoteConfigKeys.discountEntitlementOffsetDay: RemoteConfigParameterDefaultValues.discountEntitlementOffsetDay,
+        RemoteConfigKeys.discountCountdownBoundaryHour: RemoteConfigParameterDefaultValues.discountCountdownBoundaryHour,
+      }),
+      remoteConfig.fetchAndActivate()
+    ).wait;
 
-  debugPrintRemoteConfig();
+    debugPrintRemoteConfig();
 
-  remoteConfig.onConfigUpdated.listen((event) {
-    remoteConfig.activate();
-  });
+    remoteConfig.onConfigUpdated.listen((event) {
+      remoteConfig.activate();
+    });
+  } catch (error) {
+    // ignore error
+    debugPrint(error.toString());
+  }
 }
 
 void debugPrintRemoteConfig() {

--- a/lib/utils/remote_config.dart
+++ b/lib/utils/remote_config.dart
@@ -29,6 +29,7 @@ Future<void> setupRemoteConfig() async {
     });
   } catch (error, st) {
     // ignore error
+    // ParallelWaitErrorとentrypointでRemoteConfigを導入してからエラーが出るようになった。RemoteConfigの設定は失敗しても最悪どうにかなるだろう。ということでエラーは無視する
     debugPrint(error.toString());
     errorLogger.recordError(error, st);
   }


### PR DESCRIPTION
## Abstract
ParallelWaitError とRemoteConfigを導入してからエラーが出るようになった。RemoteConfigの設定は失敗しても最悪どうにかなるだろう。ということでエラーは無視する

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた