### PR TITLE
Fix android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
     <!-- https://developer.android.com/about/versions/14/changes/schedule-exact-alarms?hl=ja -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"
         android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <!-- https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications#androidmanifestxml-setup -->
     <!-- <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>: this is required so the plugin can known when the device is rebooted. This is required so that the plugin can reschedule notifications upon a reboot -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>


### PR DESCRIPTION
## Abstract
USE_EXACT_ALARM の権限を削除

https://pub.dev/packages/flutter_local_notifications をよく見ると OR と書いてあり、どちらか一つ適切な方を選ぶ感じだと判断した

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた