### PR TITLE
Add path_provider dependency

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -824,7 +824,7 @@ packages:
     source: hosted
     version: "1.0.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,7 @@ dependencies:
     git:
       url: https://github.com/bannzai/home_widget.git
       ref: main
+  path_provider: ^2.1.3
 
 dev_dependencies:
   # The "flutter_lints" package below contains a set of recommended lints to


### PR DESCRIPTION
## Abstract


```
These packages are no longer being depended on:
- path_provider 2.1.3
- path_provider_android 2.2.4
- path_provider_foundation 2.4.0
Changed 3 dependencies!

...

Error: Couldn't resolve the package 'path_provider' in 'package:path_provider/path_provider.dart'.
Error: Couldn't resolve the package 'path_provider_foundation' in 'package:path_provider_foundation/path_provider_foundation.dart'.
../.pub-cache/git/home_widget-2bb2581557a6020160c2cd80bb114beca6b7f5d7/lib/src/home_widget.dart:10:8: Error: Not found: 'package:path_provider/path_provider.dart'
import 'package:path_provider/path_provider.dart';
       ^
../.pub-cache/git/home_widget-2bb2581557a6020160c2cd80bb114beca6b7f5d7/lib/src/home_widget.dart:11:8: Error: Not found: 'package:path_provider_foundation/path_provider_foundation.dart'
import 'package:path_provider_foundation/path_provider_foundation.dart';
       ^
../.pub-cache/git/home_widget-2bb2581557a6020160c2cd80bb114beca6b7f5d7/lib/src/home_widget.dart:234:17: Error: 'PathProviderFoundation' isn't a type.
          final PathProviderFoundation provider = PathProviderFoundation();
                ^^^^^^^^^^^^^^^^^^^^^^
../.pub-cache/git/home_widget-2bb2581557a6020160c2cd80bb114beca6b7f5d7/lib/src/home_widget.dart:234:51: Error: Method not found: 'PathProviderFoundation'.
          final PathProviderFoundation provider = PathProviderFoundation();
                                                  ^^^^^^^^^^^^^^^^^^^^^^
../.pub-cache/git/home_widget-2bb2581557a6020160c2cd80bb114beca6b7f5d7/lib/src/home_widget.dart:244:30: Error: Method not found: 'getApplicationSupportDirectory'.
          directory = (await getApplicationSupportDirectory()).path;
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Unhandled exception:
FileSystemException(uri=org-dartlang-untranslatable-uri:package%3Apath_provider%2Fpath_provider.dart; message=StandardFileSystem only supports file:* and data:* URIs)
#0      StandardFileSystem.entityForUri (package:front_end/src/api_prototype/standard_file_system.dart:34)
#1      asFileUri (package:vm/kernel_front_end.dart:752)
#2      writeDepfile (package:vm/kernel_front_end.dart:892)
<asynchronous suspension>
#3      FrontendCompiler.compile (package:frontend_server/frontend_server.dart:680)
<asynchronous suspension>
#4      starter (package:frontend_server/starter.dart:101)
<asynchronous suspension>
#5      main (file:///Volumes/Work/s/w/ir/x/w/sdk/pkg/frontend_server/bin/frontend_server_starter.dart:13)
<asynchronous suspension>
Target kernel_snapshot failed: Exception

...

Run: failed to build Android app: exit status 1
```

## Why

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた