### PR TITLE
bugfix/view/pill sheet modified history o list

### DIFF
--- a/lib/features/calendar/components/pill_sheet_modified_history/components/core/taken_pill_action_o_list.dart
+++ b/lib/features/calendar/components/pill_sheet_modified_history/components/core/taken_pill_action_o_list.dart
@@ -23,19 +23,20 @@ class TakenPillActionOList extends StatelessWidget {
   Widget build(BuildContext context) {
     final beforePillSheet = beforePillSheetGroup.lastTakenPillSheetOrFirstPillSheet;
     final afterPillSheet = afterPillSheetGroup.lastTakenPillSheetOrFirstPillSheet;
-    final int count;
+    final int takenPillCount;
     if (beforePillSheet.groupIndex == afterPillSheet.groupIndex) {
-      count = max(afterPillSheet.lastTakenOrZeroPillNumber - beforePillSheet.lastTakenOrZeroPillNumber, 1);
+      takenPillCount = max(afterPillSheet.lastTakenOrZeroPillNumber - beforePillSheet.lastTakenOrZeroPillNumber, 1);
     } else {
       // beforePillSheet.groupIndex != afterPillSheet.groupIndex
       // groupIndexが異なる場合は、beforePillSheetの合計数 - 最後に飲んだ番号を beforePilSheetの服用した数。それにafterPillSheetで記録した番号を足すことで服用したピルの数を計算する
       // 厳密にはbeforePillSheetが最後のピルシートで、服用記録対象がafterPillSheetの最初のピルシートの場合に合致する条件だが、それ以外のケースがレアケースのため条件式を省く
-      count = (beforePillSheet.pillSheetType.totalCount - beforePillSheet.lastTakenOrZeroPillNumber) + afterPillSheet.lastTakenOrZeroPillNumber;
+      takenPillCount =
+          (beforePillSheet.pillSheetType.totalCount - beforePillSheet.lastTakenOrZeroPillNumber) + afterPillSheet.lastTakenOrZeroPillNumber;
     }
     return Row(
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,
-        children: List.generate(min(count, 4), (index) {
+        children: List.generate(min(takenPillCount, 4), (index) {
           final inRestDuration = _inRestDuration(afterPillSheet, value.afterLastTakenPillNumber, index);
           if (index == 0) {
             return inRestDuration ? SvgPicture.asset('images/dash_o.svg') : SvgPicture.asset('images/o.svg');

--- a/lib/features/calendar/components/pill_sheet_modified_history/components/core/taken_pill_action_o_list.dart
+++ b/lib/features/calendar/components/pill_sheet_modified_history/components/core/taken_pill_action_o_list.dart
@@ -23,10 +23,15 @@ class TakenPillActionOList extends StatelessWidget {
   Widget build(BuildContext context) {
     final beforePillSheet = beforePillSheetGroup.lastTakenPillSheetOrFirstPillSheet;
     final afterPillSheet = afterPillSheetGroup.lastTakenPillSheetOrFirstPillSheet;
-    if (beforePillSheet.groupIndex != afterPillSheet.groupIndex) {
-      return SvgPicture.asset('images/dots.svg');
+    final int count;
+    if (beforePillSheet.groupIndex == afterPillSheet.groupIndex) {
+      count = max(afterPillSheet.lastTakenOrZeroPillNumber - beforePillSheet.lastTakenOrZeroPillNumber, 1);
+    } else {
+      // beforePillSheet.groupIndex != afterPillSheet.groupIndex
+      // groupIndexが異なる場合は、beforePillSheetの合計数 - 最後に飲んだ番号を beforePilSheetの服用した数。それにafterPillSheetで記録した番号を足すことで服用したピルの数を計算する
+      // 厳密にはbeforePillSheetが最後のピルシートで、服用記録対象がafterPillSheetの最初のピルシートの場合に合致する条件だが、それ以外のケースがレアケースのため条件式を省く
+      count = (beforePillSheet.pillSheetType.totalCount - beforePillSheet.lastTakenOrZeroPillNumber) + afterPillSheet.lastTakenOrZeroPillNumber;
     }
-    final count = max(value.afterLastTakenPillNumber - value.beforeLastTakenPillNumber, 1);
     return Row(
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/features/calendar/components/pill_sheet_modified_history/components/core/taken_pill_action_o_list.dart
+++ b/lib/features/calendar/components/pill_sheet_modified_history/components/core/taken_pill_action_o_list.dart
@@ -26,7 +26,7 @@ class TakenPillActionOList extends StatelessWidget {
     if (beforePillSheet.groupIndex != afterPillSheet.groupIndex) {
       return SvgPicture.asset('images/dots.svg');
     }
-    final count = max(value.afterLastTakenPillNumber - (value.beforeLastTakenPillNumber), 1);
+    final count = max(value.afterLastTakenPillNumber - value.beforeLastTakenPillNumber, 1);
     return Row(
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
## Abstract

服用履歴に不具合が出た。PillSheetのgroupIndexを跨ぐ場合の服用記録の場合で、beforePillSheetは最後まで服用。afterPillSheetは1番目を服用記録。とした時に ... 表示になってしまう。原因を調査したところ groupIndexに差異があったら問答無用で ... の SVG を返却していたので修正。

groupIndexが違う場合は、before,afterで飲まれた量を計算して合算して返却する