### PR TITLE
refactor: AnnouncementBar 優先度変更 (機能訴求 > 認証推奨)

### DIFF
--- a/documents/adr/0001-feature-appeal-design.md
+++ b/documents/adr/0001-feature-appeal-design.md
@@ -84,9 +84,10 @@ SharedPreferences key も機能ごとに個別の `const` で `BoolKey` extensio
 ```text
 DiscountPriceDeadline (実利用警告)
 → EndedPillSheet     (実利用警告)
-→ RecommendSignupGeneralAnnouncementBar  (★ 新規・認証推奨)
-→ FeatureAppealBarsContainer             (★ 新規・機能アピール)
-→ PremiumTrialLimitAnnouncementBar       (フォールバック)
+→ FeatureAppealBarsContainer             (★ 機能アピール・候補あり & 当日未閉じ)
+→ PremiumTrialLimitAnnouncementBar       (トライアル残り10日以内)
+→ RecommendSignupGeneralAnnouncementBar  (★ 認証推奨・未認証時)
+→ PremiumTrialLimitAnnouncementBar       (トライアル残り10日以上)
 → PilllAds / SpecialOffering / AdMob     (既存)
 ```
 
@@ -97,16 +98,26 @@ LifetimeSubscriptionWarning  (既存)
 → RecommendSignupForPremium  (既存)
 → RestDuration               (実利用警告)
 → EndedPillSheet             (実利用警告)
-→ FeatureAppealBarsContainer (★ 新規)
+→ FeatureAppealBarsContainer (★ 機能アピール・候補あり & 当日未閉じ)
 ```
-
-`DiscountPriceDeadline` / `EndedPillSheet` / `RestDuration` は実利用上の警告系として保護し、FeatureAppealより優先する。
 
 **Why:**
 
-- 要件に「認証推奨を上げる」「FeatureAppealを入れる」と明示されている
-- 実利用警告系 (DiscountPriceDeadline・EndedPillSheet・RestDuration) は「ユーザーが今すぐ何かするべき」というアクション要請であり、マーケティング目的のFeatureAppealより優先度が高い
-- Premium ユーザーにも有料/無料機能アピールを出す要件があるが、実利用警告系の方が常に上位にある
+- 機能訴求を最優先とし、全dismiss or 当日×で閉じた場合にのみ認証推奨にフォールバックする
+- トライアル期限が10日以内に迫っている場合は認証推奨より優先する (ユーザーがアクションすべき期限が近い)
+- トライアル期限まで余裕がある (10日以上) 場合は、認証推奨の方が優先度が高い
+- 実利用警告系 (DiscountPriceDeadline・EndedPillSheet・RestDuration) は「ユーザーが今すぐ何かするべき」というアクション要請であり、すべてのFeatureAppeal/認証推奨より優先度が高い
+
+### 6. 当日 dismiss 判定: FeatureAppeal を × で閉じたら残りの当日は再表示しない
+
+FeatureAppeal の Bar を × で閉じた際に `featureAppealLastDismissedDate` (ISO 8601) を SharedPreferences に保存する。
+AnnouncementBar 構築時に `isSameDay(featureAppealLastDismissedDate, today())` で当日かどうかを判定し、当日なら FeatureAppeal をスキップしてフォールバック (認証推奨 or トライアル期限) に進む。
+
+**Why:**
+
+- 「1日1種類」の設計意図に合致: × で閉じた後に別の機能訴求を即座に表示するのはユーザー体験として押し付けがましい
+- 翌日になると `isSameDay` が false になり、自動的に次の候補が表示される
+- グローバルな日付付き composite key を作るのではなく、シンプルな「最後に閉じた日付」1本で判定できる
 
 ## Consequences
 
@@ -117,6 +128,8 @@ LifetimeSubscriptionWarning  (既存)
 - HelpPage 側に `useEffect` がなく、実装が宣言的でテストしやすい
 - BigQueryクエリ (`feature_appeal_funnel.sql` など) も `STRUCT` の配列で featureKey と HelpPage 名を対応付けるだけで済む
 - 既存の実利用警告系の挙動が保護されているため、リグレッションが小さい
+- 当日 dismiss 判定が `featureAppealLastDismissedDate` 1本で済むため、「今日見たkey」と「dismiss key」の二重管理が不要
+- PremiumTrialLimit の10日閾値分割により、期限間近のユーザーには適切に緊急性を伝えつつ、余裕があるユーザーには機能訴求/認証推奨を優先できる
 
 ### Bad
 

--- a/lib/features/feature_appeal/feature_appeal_bars_container.dart
+++ b/lib/features/feature_appeal/feature_appeal_bars_container.dart
@@ -10,6 +10,7 @@ import 'package:pilll/features/feature_appeal/menstruation/menstruation_announce
 import 'package:pilll/features/feature_appeal/record_pill/record_pill_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_announcement_bar.dart';
 import 'package:pilll/provider/shared_preferences.dart';
+import 'package:pilll/utils/datetime/date_compare.dart';
 import 'package:pilll/utils/datetime/day.dart';
 import 'package:pilll/utils/shared_preference/keys.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -23,10 +24,17 @@ final DateTime _featureAppealEpoch = DateTime(2024, 1, 1);
 class FeatureAppealBarsContainer extends HookConsumerWidget {
   /// 未リリース機能を非表示にするフラグ。
   final bool appIsReleased;
-  const FeatureAppealBarsContainer({super.key, required this.appIsReleased});
+
+  /// 親 (AnnouncementBar) が所有する「当日 dismiss 済み」フラグ。
+  /// × ボタン押下で true にし、親の再ビルドでフォールバック表示に切り替える。
+  final ValueNotifier<bool> dismissedToday;
+
+  const FeatureAppealBarsContainer({super.key, required this.appIsReleased, required this.dismissedToday});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    if (dismissedToday.value) return const SizedBox.shrink();
+
     final sharedPreferences = ref.watch(sharedPreferencesProvider);
 
     final criticalAlertIsClosed = useState(sharedPreferences.getBool(BoolKey.criticalAlertFeatureAppealIsClosed) ?? false);
@@ -40,8 +48,14 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
     final healthCareIntegrationIsClosed = useState(sharedPreferences.getBool(BoolKey.healthCareIntegrationFeatureAppealIsClosed) ?? false);
 
     useEffect(() {
+      void markDismissedToday() {
+        sharedPreferences.setString(StringKey.featureAppealLastDismissedDate, today().toIso8601String());
+        dismissedToday.value = true;
+      }
+
       void onCriticalAlert() {
         sharedPreferences.setBool(BoolKey.criticalAlertFeatureAppealIsClosed, criticalAlertIsClosed.value);
+        if (criticalAlertIsClosed.value) markDismissedToday();
       }
 
       void onReminderNotificationCustomizeWord() {
@@ -49,30 +63,37 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
           BoolKey.reminderNotificationCustomizeWordFeatureAppealIsClosed,
           reminderNotificationCustomizeWordIsClosed.value,
         );
+        if (reminderNotificationCustomizeWordIsClosed.value) markDismissedToday();
       }
 
       void onAppearanceModeDate() {
         sharedPreferences.setBool(BoolKey.appearanceModeDateFeatureAppealIsClosed, appearanceModeDateIsClosed.value);
+        if (appearanceModeDateIsClosed.value) markDismissedToday();
       }
 
       void onRecordPill() {
         sharedPreferences.setBool(BoolKey.recordPillFeatureAppealIsClosed, recordPillIsClosed.value);
+        if (recordPillIsClosed.value) markDismissedToday();
       }
 
       void onMenstruation() {
         sharedPreferences.setBool(BoolKey.menstruationFeatureAppealIsClosed, menstruationIsClosed.value);
+        if (menstruationIsClosed.value) markDismissedToday();
       }
 
       void onCalendarDiary() {
         sharedPreferences.setBool(BoolKey.calendarDiaryFeatureAppealIsClosed, calendarDiaryIsClosed.value);
+        if (calendarDiaryIsClosed.value) markDismissedToday();
       }
 
       void onFutureSchedule() {
         sharedPreferences.setBool(BoolKey.futureScheduleFeatureAppealIsClosed, futureScheduleIsClosed.value);
+        if (futureScheduleIsClosed.value) markDismissedToday();
       }
 
       void onHealthCareIntegration() {
         sharedPreferences.setBool(BoolKey.healthCareIntegrationFeatureAppealIsClosed, healthCareIntegrationIsClosed.value);
+        if (healthCareIntegrationIsClosed.value) markDismissedToday();
       }
 
       criticalAlertIsClosed.addListener(onCriticalAlert);
@@ -113,6 +134,15 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
       identifier: 'feature_appeal_bar',
       child: candidates[daysBetween(_featureAppealEpoch, today()) % candidates.length],
     );
+  }
+
+  /// 当日中に FeatureAppeal が × で閉じられたかどうか。SharedPreferences を直接読む。
+  static bool wasDismissedToday({required SharedPreferences sharedPreferences}) {
+    final featureAppealLastDismissedDate = sharedPreferences.getString(StringKey.featureAppealLastDismissedDate);
+    if (featureAppealLastDismissedDate == null) return false;
+    final parsed = DateTime.tryParse(featureAppealLastDismissedDate);
+    if (parsed == null) return false;
+    return isSameDay(parsed, today());
   }
 
   /// AnnouncementBar の `_body()` で「FeatureAppeal を出すかフォールバックに進むか」を事前判定するためのヘルパー。

--- a/lib/features/record/components/announcement_bar/announcement_bar.dart
+++ b/lib/features/record/components/announcement_bar/announcement_bar.dart
@@ -31,13 +31,18 @@ import 'package:pilll/provider/app_is_released.dart';
 import 'package:pilll/utils/shared_preference/keys.dart';
 import 'package:pilll/provider/pill_sheet_modified_history.dart';
 import 'package:pilll/entity/pill_sheet_modified_history.codegen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class AnnouncementBar extends HookConsumerWidget {
   const AnnouncementBar({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final body = _body(context, ref);
+    final sharedPreferences = ref.watch(sharedPreferencesProvider);
+    final featureAppealDismissedToday = useState(
+      FeatureAppealBarsContainer.wasDismissedToday(sharedPreferences: sharedPreferences),
+    );
+    final body = _body(context, ref, featureAppealDismissedToday: featureAppealDismissedToday, sharedPreferences: sharedPreferences);
     if (body != null) {
       return body;
     }
@@ -45,8 +50,12 @@ class AnnouncementBar extends HookConsumerWidget {
     return Container();
   }
 
-  Widget? _body(BuildContext context, WidgetRef ref) {
-    final sharedPreferences = ref.watch(sharedPreferencesProvider);
+  Widget? _body(
+    BuildContext context,
+    WidgetRef ref, {
+    required ValueNotifier<bool> featureAppealDismissedToday,
+    required SharedPreferences sharedPreferences,
+  }) {
     final remoteConfigParameter = ref.watch(remoteConfigParameterProvider);
     final latestPillSheetGroup = ref.watch(latestPillSheetGroupProvider).valueOrNull;
     final firebaseAuthUser = ref.watch(firebaseUserStateProvider).valueOrNull;
@@ -156,14 +165,24 @@ class AnnouncementBar extends HookConsumerWidget {
         return EndedPillSheet(isPremium: user.isPremium, isTrial: user.isTrial);
       }
 
-      if (!isLinkedLoginProvider) {
-        return const RecommendSignupGeneralAnnouncementBar();
-      }
       if (FeatureAppealBarsContainer.hasAnyCandidate(
         sharedPreferences: sharedPreferences,
         appIsReleased: appIsReleased,
-      )) {
-        return FeatureAppealBarsContainer(appIsReleased: appIsReleased);
+      ) && !featureAppealDismissedToday.value) {
+        return FeatureAppealBarsContainer(appIsReleased: appIsReleased, dismissedToday: featureAppealDismissedToday);
+      }
+
+      if (user.isTrial) {
+        final remainingTrialDays = PremiumTrialLimitAnnouncementBar.remainingTrialDays(user);
+        if (remainingTrialDays != null && remainingTrialDays <= 10) {
+          return PremiumTrialLimitAnnouncementBar(
+            premiumTrialLimit: PremiumTrialLimitAnnouncementBar.premiumTrialLimitMessage(user)!,
+          );
+        }
+      }
+
+      if (!isLinkedLoginProvider) {
+        return const RecommendSignupGeneralAnnouncementBar();
       }
 
       if (user.isTrial) {
@@ -173,7 +192,9 @@ class AnnouncementBar extends HookConsumerWidget {
             premiumTrialLimit: premiumTrialLimit,
           );
         }
-      } else {
+      }
+
+      if (!user.isTrial) {
         // !isPremium && !isTrial
 
         if (!isAdsDisabled && pilllAds != null) {
@@ -238,8 +259,8 @@ class AnnouncementBar extends HookConsumerWidget {
       if (FeatureAppealBarsContainer.hasAnyCandidate(
         sharedPreferences: sharedPreferences,
         appIsReleased: appIsReleased,
-      )) {
-        return FeatureAppealBarsContainer(appIsReleased: appIsReleased);
+      ) && !featureAppealDismissedToday.value) {
+        return FeatureAppealBarsContainer(appIsReleased: appIsReleased, dismissedToday: featureAppealDismissedToday);
       }
     }
 

--- a/lib/features/record/components/announcement_bar/announcement_bar.dart
+++ b/lib/features/record/components/announcement_bar/announcement_bar.dart
@@ -166,9 +166,10 @@ class AnnouncementBar extends HookConsumerWidget {
       }
 
       if (FeatureAppealBarsContainer.hasAnyCandidate(
-        sharedPreferences: sharedPreferences,
-        appIsReleased: appIsReleased,
-      ) && !featureAppealDismissedToday.value) {
+            sharedPreferences: sharedPreferences,
+            appIsReleased: appIsReleased,
+          ) &&
+          !featureAppealDismissedToday.value) {
         return FeatureAppealBarsContainer(appIsReleased: appIsReleased, dismissedToday: featureAppealDismissedToday);
       }
 
@@ -257,9 +258,10 @@ class AnnouncementBar extends HookConsumerWidget {
       }
 
       if (FeatureAppealBarsContainer.hasAnyCandidate(
-        sharedPreferences: sharedPreferences,
-        appIsReleased: appIsReleased,
-      ) && !featureAppealDismissedToday.value) {
+            sharedPreferences: sharedPreferences,
+            appIsReleased: appIsReleased,
+          ) &&
+          !featureAppealDismissedToday.value) {
         return FeatureAppealBarsContainer(appIsReleased: appIsReleased, dismissedToday: featureAppealDismissedToday);
       }
     }

--- a/lib/features/record/components/announcement_bar/components/premium_trial_limit.dart
+++ b/lib/features/record/components/announcement_bar/components/premium_trial_limit.dart
@@ -63,6 +63,15 @@ class PremiumTrialLimitAnnouncementBar extends StatelessWidget {
     );
   }
 
+  /// トライアル期限までの残り日数。トライアル中でなければ null。
+  static int? remainingTrialDays(User user) {
+    if (user.isPremium) return null;
+    if (!user.isTrial) return null;
+    final trialDeadlineDate = user.trialDeadlineDate;
+    if (trialDeadlineDate == null) return null;
+    return daysBetween(now(), trialDeadlineDate);
+  }
+
   static String? premiumTrialLimitMessage(User user) {
     if (user.isPremium) {
       return null;

--- a/lib/features/record/components/announcement_bar/components/recommend_signup_general.dart
+++ b/lib/features/record/components/announcement_bar/components/recommend_signup_general.dart
@@ -18,71 +18,71 @@ class RecommendSignupGeneralAnnouncementBar extends StatelessWidget {
     return Semantics(
       identifier: 'recommend_signup_general_bar',
       child: Container(
-      padding: const EdgeInsets.only(top: 10, bottom: 8, left: 8, right: 8),
-      color: AppColors.primary,
-      child: GestureDetector(
-        onTap: () {
-          analytics.logEvent(name: 'feature_appeal_signup_recommend_tapped');
-          showSignInSheet(context, SignInSheetStateContext.recordPage, null);
-        },
-        child: Stack(
-          children: [
-            Align(
-              alignment: Alignment.center,
-              child: Column(
-                children: [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      SvgPicture.asset(
-                        'images/alert_24.svg',
-                        width: 16,
-                        height: 16,
-                        colorFilter: const ColorFilter.mode(Colors.white, BlendMode.srcIn),
-                      ),
-                      const SizedBox(width: 5),
-                      Text(
-                        L.recommendSignupGeneralTitle,
-                        style: const TextStyle(
-                          fontFamily: FontFamily.japanese,
-                          fontWeight: FontWeight.w700,
-                          fontSize: 12,
-                          color: TextColor.white,
+        padding: const EdgeInsets.only(top: 10, bottom: 8, left: 8, right: 8),
+        color: AppColors.primary,
+        child: GestureDetector(
+          onTap: () {
+            analytics.logEvent(name: 'feature_appeal_signup_recommend_tapped');
+            showSignInSheet(context, SignInSheetStateContext.recordPage, null);
+          },
+          child: Stack(
+            children: [
+              Align(
+                alignment: Alignment.center,
+                child: Column(
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        SvgPicture.asset(
+                          'images/alert_24.svg',
+                          width: 16,
+                          height: 16,
+                          colorFilter: const ColorFilter.mode(Colors.white, BlendMode.srcIn),
                         ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    L.recommendSignupGeneralDescription,
-                    style: const TextStyle(
-                      color: TextColor.white,
-                      fontFamily: FontFamily.japanese,
-                      fontSize: 10,
-                      fontWeight: FontWeight.w700,
+                        const SizedBox(width: 5),
+                        Text(
+                          L.recommendSignupGeneralTitle,
+                          style: const TextStyle(
+                            fontFamily: FontFamily.japanese,
+                            fontWeight: FontWeight.w700,
+                            fontSize: 12,
+                            color: TextColor.white,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
                     ),
-                    textAlign: TextAlign.center,
-                  ),
-                ],
-              ),
-            ),
-            Align(
-              alignment: Alignment.centerRight,
-              child: Padding(
-                padding: const EdgeInsets.all(8),
-                child: SvgPicture.asset(
-                  'images/arrow_right.svg',
-                  colorFilter: const ColorFilter.mode(Colors.white, BlendMode.srcIn),
-                  height: 16,
-                  width: 16,
+                    const SizedBox(height: 8),
+                    Text(
+                      L.recommendSignupGeneralDescription,
+                      style: const TextStyle(
+                        color: TextColor.white,
+                        fontFamily: FontFamily.japanese,
+                        fontSize: 10,
+                        fontWeight: FontWeight.w700,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
                 ),
               ),
-            ),
-          ],
+              Align(
+                alignment: Alignment.centerRight,
+                child: Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: SvgPicture.asset(
+                    'images/arrow_right.svg',
+                    colorFilter: const ColorFilter.mode(Colors.white, BlendMode.srcIn),
+                    height: 16,
+                    width: 16,
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
-    ),
     );
   }
 }

--- a/lib/provider/app_is_released.g.dart
+++ b/lib/provider/app_is_released.g.dart
@@ -22,9 +22,7 @@ String _$appIsReleasedHash() => r'21463ba1d3ce5add8298b0bddb54bdb773ea8444';
 final appIsReleasedProvider = FutureProvider<bool>.internal(
   appIsReleased,
   name: r'appIsReleasedProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$appIsReleasedHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$appIsReleasedHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/utils/shared_preference/keys.dart
+++ b/lib/utils/shared_preference/keys.dart
@@ -38,6 +38,9 @@ extension BoolKey on String {
 extension StringKey on String {
   static const String beginVersion = 'beginingVersion';
   static const String lastSignInAnonymousUID = 'lastSigninAnonymousUID';
+
+  /// FeatureAppeal の × ボタンが最後に押された日付 (ISO 8601)。当日中は再表示しない判定に使う。
+  static const String featureAppealLastDismissedDate = 'featureAppealLastDismissedDate';
 }
 
 extension ReleaseNoteKey on String {

--- a/test/features/feature_appeal/appearance_mode_date/appearance_mode_date_announcement_bar_test.dart
+++ b/test/features/feature_appeal/appearance_mode_date/appearance_mode_date_announcement_bar_test.dart
@@ -5,7 +5,8 @@ import 'package:pilll/features/feature_appeal/appearance_mode_date/appearance_mo
 
 void main() {
   group('#AppearanceModeDateAnnouncementBar', () {
-    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(
@@ -19,7 +20,8 @@ void main() {
       expect(find.byType(Text), findsAtLeast(2));
     });
 
-    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(

--- a/test/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page_test.dart
+++ b/test/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page_test.dart
@@ -13,7 +13,8 @@ void main() {
     List<Override> helpPageProviderOverrides() {
       return [
         userProvider.overrideWith((ref) => Stream.value(const User())),
-        latestPillSheetGroupProvider.overrideWith((ref) => Stream<PillSheetGroup?>.value(null)),
+        latestPillSheetGroupProvider
+            .overrideWith((ref) => Stream<PillSheetGroup?>.value(null)),
       ];
     }
 

--- a/test/features/feature_appeal/calendar_diary/calendar_diary_announcement_bar_test.dart
+++ b/test/features/feature_appeal/calendar_diary/calendar_diary_announcement_bar_test.dart
@@ -5,7 +5,8 @@ import 'package:pilll/features/feature_appeal/calendar_diary/calendar_diary_anno
 
 void main() {
   group('#CalendarDiaryAnnouncementBar', () {
-    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(
@@ -19,7 +20,8 @@ void main() {
       expect(find.byType(Text), findsAtLeast(2));
     });
 
-    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(

--- a/test/features/feature_appeal/critical_alert/critical_alert_announcement_bar_test.dart
+++ b/test/features/feature_appeal/critical_alert/critical_alert_announcement_bar_test.dart
@@ -5,7 +5,8 @@ import 'package:pilll/features/feature_appeal/critical_alert/critical_alert_anno
 
 void main() {
   group('#CriticalAlertAnnouncementBar', () {
-    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(
@@ -19,7 +20,8 @@ void main() {
       expect(find.byType(Text), findsAtLeast(2));
     });
 
-    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(

--- a/test/features/feature_appeal/feature_appeal_bars_container_test.dart
+++ b/test/features/feature_appeal/feature_appeal_bars_container_test.dart
@@ -103,6 +103,56 @@ void main() {
     });
   });
 
+  group('#wasDismissedToday', () {
+    test('prefs 空 → false を返す', () async {
+      final mockTodayRepository = MockTodayService();
+      when(mockTodayRepository.now()).thenReturn(DateTime(2024, 1, 1));
+      todayRepository = mockTodayRepository;
+
+      SharedPreferences.setMockInitialValues({});
+      final sharedPreferences = await SharedPreferences.getInstance();
+
+      expect(
+        FeatureAppealBarsContainer.wasDismissedToday(sharedPreferences: sharedPreferences),
+        isFalse,
+      );
+    });
+
+    test('今日の日付が保存済み → true を返す', () async {
+      final mockTodayRepository = MockTodayService();
+      final mockToday = DateTime(2024, 4, 10);
+      when(mockTodayRepository.now()).thenReturn(mockToday);
+      todayRepository = mockTodayRepository;
+
+      SharedPreferences.setMockInitialValues({
+        StringKey.featureAppealLastDismissedDate: mockToday.toIso8601String(),
+      });
+      final sharedPreferences = await SharedPreferences.getInstance();
+
+      expect(
+        FeatureAppealBarsContainer.wasDismissedToday(sharedPreferences: sharedPreferences),
+        isTrue,
+      );
+    });
+
+    test('昨日の日付が保存済み → false を返す', () async {
+      final mockTodayRepository = MockTodayService();
+      final mockToday = DateTime(2024, 4, 10);
+      when(mockTodayRepository.now()).thenReturn(mockToday);
+      todayRepository = mockTodayRepository;
+
+      SharedPreferences.setMockInitialValues({
+        StringKey.featureAppealLastDismissedDate: mockToday.subtract(const Duration(days: 1)).toIso8601String(),
+      });
+      final sharedPreferences = await SharedPreferences.getInstance();
+
+      expect(
+        FeatureAppealBarsContainer.wasDismissedToday(sharedPreferences: sharedPreferences),
+        isFalse,
+      );
+    });
+  });
+
   group('#FeatureAppealBarsContainer', () {
     /// 候補リスト (本実装と同じ並び順) のうち、appIsReleased=true で全 8 件存在する状態を想定。
     /// テストでは today を任意に固定して daysBetween(epoch, today) % 8 が想定の Bar に一致するかを確認する。
@@ -133,9 +183,9 @@ void main() {
           overrides: [
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
           ],
-          child: const MaterialApp(
+          child: MaterialApp(
             home: Material(
-              child: FeatureAppealBarsContainer(appIsReleased: true),
+              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(false)),
             ),
           ),
         ),
@@ -158,9 +208,9 @@ void main() {
           overrides: [
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
           ],
-          child: const MaterialApp(
+          child: MaterialApp(
             home: Material(
-              child: FeatureAppealBarsContainer(appIsReleased: true),
+              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(false)),
             ),
           ),
         ),
@@ -185,9 +235,9 @@ void main() {
           overrides: [
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
           ],
-          child: const MaterialApp(
+          child: MaterialApp(
             home: Material(
-              child: FeatureAppealBarsContainer(appIsReleased: true),
+              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(false)),
             ),
           ),
         ),
@@ -212,9 +262,9 @@ void main() {
           overrides: [
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
           ],
-          child: const MaterialApp(
+          child: MaterialApp(
             home: Material(
-              child: FeatureAppealBarsContainer(appIsReleased: false),
+              child: FeatureAppealBarsContainer(appIsReleased: false, dismissedToday: ValueNotifier(false)),
             ),
           ),
         ),
@@ -248,9 +298,9 @@ void main() {
           overrides: [
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
           ],
-          child: const MaterialApp(
+          child: MaterialApp(
             home: Material(
-              child: FeatureAppealBarsContainer(appIsReleased: true),
+              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(false)),
             ),
           ),
         ),
@@ -265,6 +315,31 @@ void main() {
       expect(find.byType(CalendarDiaryAnnouncementBar), findsNothing);
       expect(find.byType(FutureScheduleAnnouncementBar), findsNothing);
       expect(find.byType(HealthCareIntegrationAnnouncementBar), findsNothing);
+    });
+
+    testWidgets('dismissedToday=true → 候補があっても SizedBox.shrink が表示される', (tester) async {
+      final mockTodayRepository = MockTodayService();
+      when(mockTodayRepository.now()).thenReturn(_featureAppealEpoch);
+      todayRepository = mockTodayRepository;
+
+      SharedPreferences.setMockInitialValues({});
+      final sharedPreferences = await SharedPreferences.getInstance();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
+          ],
+          child: MaterialApp(
+            home: Material(
+              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(true)),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CriticalAlertAnnouncementBar), findsNothing);
+      expect(find.byType(ReminderNotificationCustomizeWordAnnouncementBar), findsNothing);
     });
   });
 }

--- a/test/features/feature_appeal/feature_appeal_bars_container_test.dart
+++ b/test/features/feature_appeal/feature_appeal_bars_container_test.dart
@@ -58,7 +58,9 @@ void main() {
       );
     });
 
-    test('appIsReleased=false かつ appearanceModeDate のみ未 dismiss で他全 dismiss → false (appIsReleased ゲートが効く)', () async {
+    test(
+        'appIsReleased=false かつ appearanceModeDate のみ未 dismiss で他全 dismiss → false (appIsReleased ゲートが効く)',
+        () async {
       SharedPreferences.setMockInitialValues({
         BoolKey.criticalAlertFeatureAppealIsClosed: true,
         BoolKey.reminderNotificationCustomizeWordFeatureAppealIsClosed: true,
@@ -80,7 +82,9 @@ void main() {
       );
     });
 
-    test('appIsReleased=true かつ appearanceModeDate のみ未 dismiss で他全 dismiss → true', () async {
+    test(
+        'appIsReleased=true かつ appearanceModeDate のみ未 dismiss で他全 dismiss → true',
+        () async {
       SharedPreferences.setMockInitialValues({
         BoolKey.criticalAlertFeatureAppealIsClosed: true,
         BoolKey.reminderNotificationCustomizeWordFeatureAppealIsClosed: true,
@@ -113,7 +117,8 @@ void main() {
       final sharedPreferences = await SharedPreferences.getInstance();
 
       expect(
-        FeatureAppealBarsContainer.wasDismissedToday(sharedPreferences: sharedPreferences),
+        FeatureAppealBarsContainer.wasDismissedToday(
+            sharedPreferences: sharedPreferences),
         isFalse,
       );
     });
@@ -130,7 +135,8 @@ void main() {
       final sharedPreferences = await SharedPreferences.getInstance();
 
       expect(
-        FeatureAppealBarsContainer.wasDismissedToday(sharedPreferences: sharedPreferences),
+        FeatureAppealBarsContainer.wasDismissedToday(
+            sharedPreferences: sharedPreferences),
         isTrue,
       );
     });
@@ -142,12 +148,14 @@ void main() {
       todayRepository = mockTodayRepository;
 
       SharedPreferences.setMockInitialValues({
-        StringKey.featureAppealLastDismissedDate: mockToday.subtract(const Duration(days: 1)).toIso8601String(),
+        StringKey.featureAppealLastDismissedDate:
+            mockToday.subtract(const Duration(days: 1)).toIso8601String(),
       });
       final sharedPreferences = await SharedPreferences.getInstance();
 
       expect(
-        FeatureAppealBarsContainer.wasDismissedToday(sharedPreferences: sharedPreferences),
+        FeatureAppealBarsContainer.wasDismissedToday(
+            sharedPreferences: sharedPreferences),
         isFalse,
       );
     });
@@ -169,7 +177,8 @@ void main() {
       ][index];
     }
 
-    testWidgets('prefs 空 + appIsReleased=true → 当日 index に対応する Bar が表示される', (tester) async {
+    testWidgets('prefs 空 + appIsReleased=true → 当日 index に対応する Bar が表示される',
+        (tester) async {
       final mockTodayRepository = MockTodayService();
       final mockToday = DateTime(2024, 1, 1);
       when(mockTodayRepository.now()).thenReturn(mockToday);
@@ -185,7 +194,8 @@ void main() {
           ],
           child: MaterialApp(
             home: Material(
-              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(false)),
+              child: FeatureAppealBarsContainer(
+                  appIsReleased: true, dismissedToday: ValueNotifier(false)),
             ),
           ),
         ),
@@ -197,7 +207,8 @@ void main() {
 
     testWidgets('today を翌日に進める → index が +1 ずれて別の Bar が表示される', (tester) async {
       final mockTodayRepository = MockTodayService();
-      when(mockTodayRepository.now()).thenReturn(_featureAppealEpoch.add(const Duration(days: 1)));
+      when(mockTodayRepository.now())
+          .thenReturn(_featureAppealEpoch.add(const Duration(days: 1)));
       todayRepository = mockTodayRepository;
 
       SharedPreferences.setMockInitialValues({});
@@ -210,7 +221,8 @@ void main() {
           ],
           child: MaterialApp(
             home: Material(
-              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(false)),
+              child: FeatureAppealBarsContainer(
+                  appIsReleased: true, dismissedToday: ValueNotifier(false)),
             ),
           ),
         ),
@@ -220,7 +232,9 @@ void main() {
       expect(find.byType(expectedBarTypeForIndex(1)), findsOneWidget);
     });
 
-    testWidgets('criticalAlert を dismiss 済み → 残り 7 候補のうち index 0 (本来は criticalAlert) は表示されない', (tester) async {
+    testWidgets(
+        'criticalAlert を dismiss 済み → 残り 7 候補のうち index 0 (本来は criticalAlert) は表示されない',
+        (tester) async {
       final mockTodayRepository = MockTodayService();
       when(mockTodayRepository.now()).thenReturn(_featureAppealEpoch);
       todayRepository = mockTodayRepository;
@@ -237,7 +251,8 @@ void main() {
           ],
           child: MaterialApp(
             home: Material(
-              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(false)),
+              child: FeatureAppealBarsContainer(
+                  appIsReleased: true, dismissedToday: ValueNotifier(false)),
             ),
           ),
         ),
@@ -245,13 +260,17 @@ void main() {
 
       // criticalAlert は除外。残り 7 候補で daysBetween=0 → index 0 = ReminderNotificationCustomizeWord
       expect(find.byType(CriticalAlertAnnouncementBar), findsNothing);
-      expect(find.byType(ReminderNotificationCustomizeWordAnnouncementBar), findsOneWidget);
+      expect(find.byType(ReminderNotificationCustomizeWordAnnouncementBar),
+          findsOneWidget);
     });
 
-    testWidgets('appIsReleased=false → AppearanceModeDateAnnouncementBar が候補から除外される', (tester) async {
+    testWidgets(
+        'appIsReleased=false → AppearanceModeDateAnnouncementBar が候補から除外される',
+        (tester) async {
       final mockTodayRepository = MockTodayService();
       // 通常 epoch から 2 日後なら index 2 (AppearanceModeDate) になるはず。除外されると 2 番目以降がずれる。
-      when(mockTodayRepository.now()).thenReturn(_featureAppealEpoch.add(const Duration(days: 2)));
+      when(mockTodayRepository.now())
+          .thenReturn(_featureAppealEpoch.add(const Duration(days: 2)));
       todayRepository = mockTodayRepository;
 
       SharedPreferences.setMockInitialValues({});
@@ -264,7 +283,8 @@ void main() {
           ],
           child: MaterialApp(
             home: Material(
-              child: FeatureAppealBarsContainer(appIsReleased: false, dismissedToday: ValueNotifier(false)),
+              child: FeatureAppealBarsContainer(
+                  appIsReleased: false, dismissedToday: ValueNotifier(false)),
             ),
           ),
         ),
@@ -300,7 +320,8 @@ void main() {
           ],
           child: MaterialApp(
             home: Material(
-              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(false)),
+              child: FeatureAppealBarsContainer(
+                  appIsReleased: true, dismissedToday: ValueNotifier(false)),
             ),
           ),
         ),
@@ -308,7 +329,8 @@ void main() {
 
       // 全 8 個の Bar が表示されないことを確認
       expect(find.byType(CriticalAlertAnnouncementBar), findsNothing);
-      expect(find.byType(ReminderNotificationCustomizeWordAnnouncementBar), findsNothing);
+      expect(find.byType(ReminderNotificationCustomizeWordAnnouncementBar),
+          findsNothing);
       expect(find.byType(AppearanceModeDateAnnouncementBar), findsNothing);
       expect(find.byType(RecordPillAnnouncementBar), findsNothing);
       expect(find.byType(MenstruationAnnouncementBar), findsNothing);
@@ -317,7 +339,8 @@ void main() {
       expect(find.byType(HealthCareIntegrationAnnouncementBar), findsNothing);
     });
 
-    testWidgets('dismissedToday=true → 候補があっても SizedBox.shrink が表示される', (tester) async {
+    testWidgets('dismissedToday=true → 候補があっても SizedBox.shrink が表示される',
+        (tester) async {
       final mockTodayRepository = MockTodayService();
       when(mockTodayRepository.now()).thenReturn(_featureAppealEpoch);
       todayRepository = mockTodayRepository;
@@ -332,14 +355,16 @@ void main() {
           ],
           child: MaterialApp(
             home: Material(
-              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(true)),
+              child: FeatureAppealBarsContainer(
+                  appIsReleased: true, dismissedToday: ValueNotifier(true)),
             ),
           ),
         ),
       );
 
       expect(find.byType(CriticalAlertAnnouncementBar), findsNothing);
-      expect(find.byType(ReminderNotificationCustomizeWordAnnouncementBar), findsNothing);
+      expect(find.byType(ReminderNotificationCustomizeWordAnnouncementBar),
+          findsNothing);
     });
   });
 }

--- a/test/features/feature_appeal/future_schedule/future_schedule_announcement_bar_test.dart
+++ b/test/features/feature_appeal/future_schedule/future_schedule_announcement_bar_test.dart
@@ -5,7 +5,8 @@ import 'package:pilll/features/feature_appeal/future_schedule/future_schedule_an
 
 void main() {
   group('#FutureScheduleAnnouncementBar', () {
-    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(
@@ -19,7 +20,8 @@ void main() {
       expect(find.byType(Text), findsAtLeast(2));
     });
 
-    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(

--- a/test/features/feature_appeal/health_care_integration/health_care_integration_announcement_bar_test.dart
+++ b/test/features/feature_appeal/health_care_integration/health_care_integration_announcement_bar_test.dart
@@ -5,7 +5,8 @@ import 'package:pilll/features/feature_appeal/health_care_integration/health_car
 
 void main() {
   group('#HealthCareIntegrationAnnouncementBar', () {
-    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(
@@ -19,7 +20,8 @@ void main() {
       expect(find.byType(Text), findsAtLeast(2));
     });
 
-    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(

--- a/test/features/feature_appeal/menstruation/menstruation_announcement_bar_test.dart
+++ b/test/features/feature_appeal/menstruation/menstruation_announcement_bar_test.dart
@@ -5,7 +5,8 @@ import 'package:pilll/features/feature_appeal/menstruation/menstruation_announce
 
 void main() {
   group('#MenstruationAnnouncementBar', () {
-    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(
@@ -19,7 +20,8 @@ void main() {
       expect(find.byType(Text), findsAtLeast(2));
     });
 
-    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(

--- a/test/features/feature_appeal/record_pill/record_pill_announcement_bar_test.dart
+++ b/test/features/feature_appeal/record_pill/record_pill_announcement_bar_test.dart
@@ -5,7 +5,8 @@ import 'package:pilll/features/feature_appeal/record_pill/record_pill_announceme
 
 void main() {
   group('#RecordPillAnnouncementBar', () {
-    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(
@@ -19,7 +20,8 @@ void main() {
       expect(find.byType(Text), findsAtLeast(2));
     });
 
-    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(

--- a/test/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_announcement_bar_test.dart
+++ b/test/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_announcement_bar_test.dart
@@ -5,12 +5,14 @@ import 'package:pilll/features/feature_appeal/reminder_notification_customize_wo
 
 void main() {
   group('#ReminderNotificationCustomizeWordAnnouncementBar', () {
-    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
-            child: ReminderNotificationCustomizeWordAnnouncementBar(isClosed: isClosed),
+            child: ReminderNotificationCustomizeWordAnnouncementBar(
+                isClosed: isClosed),
           ),
         ),
       );
@@ -19,12 +21,14 @@ void main() {
       expect(find.byType(Text), findsAtLeast(2));
     });
 
-    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される',
+        (tester) async {
       final isClosed = ValueNotifier<bool>(false);
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
-            child: ReminderNotificationCustomizeWordAnnouncementBar(isClosed: isClosed),
+            child: ReminderNotificationCustomizeWordAnnouncementBar(
+                isClosed: isClosed),
           ),
         ),
       );
@@ -37,7 +41,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
-            child: ReminderNotificationCustomizeWordAnnouncementBar(isClosed: isClosed),
+            child: ReminderNotificationCustomizeWordAnnouncementBar(
+                isClosed: isClosed),
           ),
         ),
       );

--- a/test/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page_test.dart
+++ b/test/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page_test.dart
@@ -18,7 +18,8 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: helpPageProviderOverrides(),
-          child: const MaterialApp(home: ReminderNotificationCustomizeWordHelpPage()),
+          child: const MaterialApp(
+              home: ReminderNotificationCustomizeWordHelpPage()),
         ),
       );
       await tester.pumpAndSettle();
@@ -30,7 +31,8 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: helpPageProviderOverrides(),
-          child: const MaterialApp(home: ReminderNotificationCustomizeWordHelpPage()),
+          child: const MaterialApp(
+              home: ReminderNotificationCustomizeWordHelpPage()),
         ),
       );
       await tester.pumpAndSettle();
@@ -42,7 +44,8 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: helpPageProviderOverrides(),
-          child: const MaterialApp(home: ReminderNotificationCustomizeWordHelpPage()),
+          child: const MaterialApp(
+              home: ReminderNotificationCustomizeWordHelpPage()),
         ),
       );
       await tester.pumpAndSettle();

--- a/test/features/record/announcement_bar/announcement_bar_test.dart
+++ b/test/features/record/announcement_bar/announcement_bar_test.dart
@@ -1948,7 +1948,8 @@ void main() {
     /// FeatureAppeal が候補ゼロの状態を作るために使う。
     Map<String, Object> allFeatureAppealDismissedPrefs() {
       return {
-        IntKey.totalCountOfActionForTakenPill: totalCountOfActionForTakenPillForLongTimeUser,
+        IntKey.totalCountOfActionForTakenPill:
+            totalCountOfActionForTakenPillForLongTimeUser,
         BoolKey.criticalAlertFeatureAppealIsClosed: true,
         BoolKey.reminderNotificationCustomizeWordFeatureAppealIsClosed: true,
         BoolKey.appearanceModeDateFeatureAppealIsClosed: true,
@@ -1960,7 +1961,9 @@ void main() {
       };
     }
 
-    testWidgets('未認証 + トライアル中 + FeatureAppeal 候補あり → FeatureAppeal が RecommendSignupGeneral より優先される', (tester) async {
+    testWidgets(
+        '未認証 + トライアル中 + FeatureAppeal 候補あり → FeatureAppeal が RecommendSignupGeneral より優先される',
+        (tester) async {
       final mockTodayRepository = MockTodayService();
       final mockToday = DateTime(2024, 1, 1);
       when(mockTodayRepository.now()).thenReturn(mockToday);
@@ -1980,14 +1983,16 @@ void main() {
       );
 
       SharedPreferences.setMockInitialValues({
-        IntKey.totalCountOfActionForTakenPill: totalCountOfActionForTakenPillForLongTimeUser,
+        IntKey.totalCountOfActionForTakenPill:
+            totalCountOfActionForTakenPillForLongTimeUser,
       });
       final sharedPreferences = await SharedPreferences.getInstance();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
             appIsReleasedProvider.overrideWith((ref) => true),
-            latestPillSheetGroupProvider.overrideWith((ref) => Stream.value(pillSheetGroup)),
+            latestPillSheetGroupProvider
+                .overrideWith((ref) => Stream.value(pillSheetGroup)),
             userProvider.overrideWith(
               (ref) => Stream.value(
                 User(
@@ -2001,7 +2006,8 @@ void main() {
             isLinkedProvider.overrideWithValue(false),
             isJaLocaleProvider.overrideWithValue(true),
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
-            remoteConfigParameterProvider.overrideWithValue(RemoteConfigParameter()),
+            remoteConfigParameterProvider
+                .overrideWithValue(RemoteConfigParameter()),
           ],
           child: const MaterialApp(home: Material(child: AnnouncementBar())),
         ),
@@ -2011,16 +2017,20 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
 
       expect(
-        find.byWidgetPredicate((widget) => widget is CriticalAlertAnnouncementBar),
+        find.byWidgetPredicate(
+            (widget) => widget is CriticalAlertAnnouncementBar),
         findsOneWidget,
       );
       expect(
-        find.byWidgetPredicate((widget) => widget is RecommendSignupGeneralAnnouncementBar),
+        find.byWidgetPredicate(
+            (widget) => widget is RecommendSignupGeneralAnnouncementBar),
         findsNothing,
       );
     });
 
-    testWidgets('未認証 + トライアル中 + FeatureAppeal 全dismiss → RecommendSignupGeneralAnnouncementBar が表示される', (tester) async {
+    testWidgets(
+        '未認証 + トライアル中 + FeatureAppeal 全dismiss → RecommendSignupGeneralAnnouncementBar が表示される',
+        (tester) async {
       final mockTodayRepository = MockTodayService();
       final mockToday = DateTime(2024, 1, 1);
       when(mockTodayRepository.now()).thenReturn(mockToday);
@@ -2045,7 +2055,8 @@ void main() {
         ProviderScope(
           overrides: [
             appIsReleasedProvider.overrideWith((ref) => true),
-            latestPillSheetGroupProvider.overrideWith((ref) => Stream.value(pillSheetGroup)),
+            latestPillSheetGroupProvider
+                .overrideWith((ref) => Stream.value(pillSheetGroup)),
             userProvider.overrideWith(
               (ref) => Stream.value(
                 User(
@@ -2059,7 +2070,8 @@ void main() {
             isLinkedProvider.overrideWithValue(false),
             isJaLocaleProvider.overrideWithValue(true),
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
-            remoteConfigParameterProvider.overrideWithValue(RemoteConfigParameter()),
+            remoteConfigParameterProvider
+                .overrideWithValue(RemoteConfigParameter()),
           ],
           child: const MaterialApp(home: Material(child: AnnouncementBar())),
         ),
@@ -2069,12 +2081,15 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
 
       expect(
-        find.byWidgetPredicate((widget) => widget is RecommendSignupGeneralAnnouncementBar),
+        find.byWidgetPredicate(
+            (widget) => widget is RecommendSignupGeneralAnnouncementBar),
         findsOneWidget,
       );
     });
 
-    testWidgets('未認証 + トライアル残り10日以内 + FeatureAppeal 全dismiss → PremiumTrialLimit が RecommendSignupGeneral より優先される', (tester) async {
+    testWidgets(
+        '未認証 + トライアル残り10日以内 + FeatureAppeal 全dismiss → PremiumTrialLimit が RecommendSignupGeneral より優先される',
+        (tester) async {
       final mockTodayRepository = MockTodayService();
       final mockToday = DateTime(2024, 1, 1);
       when(mockTodayRepository.now()).thenReturn(mockToday);
@@ -2099,7 +2114,8 @@ void main() {
         ProviderScope(
           overrides: [
             appIsReleasedProvider.overrideWith((ref) => true),
-            latestPillSheetGroupProvider.overrideWith((ref) => Stream.value(pillSheetGroup)),
+            latestPillSheetGroupProvider
+                .overrideWith((ref) => Stream.value(pillSheetGroup)),
             userProvider.overrideWith(
               (ref) => Stream.value(
                 User(
@@ -2113,7 +2129,8 @@ void main() {
             isLinkedProvider.overrideWithValue(false),
             isJaLocaleProvider.overrideWithValue(true),
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
-            remoteConfigParameterProvider.overrideWithValue(RemoteConfigParameter()),
+            remoteConfigParameterProvider
+                .overrideWithValue(RemoteConfigParameter()),
           ],
           child: const MaterialApp(home: Material(child: AnnouncementBar())),
         ),
@@ -2123,16 +2140,19 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
 
       expect(
-        find.byWidgetPredicate((widget) => widget is PremiumTrialLimitAnnouncementBar),
+        find.byWidgetPredicate(
+            (widget) => widget is PremiumTrialLimitAnnouncementBar),
         findsOneWidget,
       );
       expect(
-        find.byWidgetPredicate((widget) => widget is RecommendSignupGeneralAnnouncementBar),
+        find.byWidgetPredicate(
+            (widget) => widget is RecommendSignupGeneralAnnouncementBar),
         findsNothing,
       );
     });
 
-    testWidgets('当日閉じ済み + 未認証 + トライアル残り15日 → RecommendSignupGeneral が表示される', (tester) async {
+    testWidgets('当日閉じ済み + 未認証 + トライアル残り15日 → RecommendSignupGeneral が表示される',
+        (tester) async {
       final mockTodayRepository = MockTodayService();
       final mockToday = DateTime(2024, 1, 1);
       when(mockTodayRepository.now()).thenReturn(mockToday);
@@ -2152,7 +2172,8 @@ void main() {
       );
 
       SharedPreferences.setMockInitialValues({
-        IntKey.totalCountOfActionForTakenPill: totalCountOfActionForTakenPillForLongTimeUser,
+        IntKey.totalCountOfActionForTakenPill:
+            totalCountOfActionForTakenPillForLongTimeUser,
         StringKey.featureAppealLastDismissedDate: mockToday.toIso8601String(),
       });
       final sharedPreferences = await SharedPreferences.getInstance();
@@ -2160,7 +2181,8 @@ void main() {
         ProviderScope(
           overrides: [
             appIsReleasedProvider.overrideWith((ref) => true),
-            latestPillSheetGroupProvider.overrideWith((ref) => Stream.value(pillSheetGroup)),
+            latestPillSheetGroupProvider
+                .overrideWith((ref) => Stream.value(pillSheetGroup)),
             userProvider.overrideWith(
               (ref) => Stream.value(
                 User(
@@ -2174,7 +2196,8 @@ void main() {
             isLinkedProvider.overrideWithValue(false),
             isJaLocaleProvider.overrideWithValue(true),
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
-            remoteConfigParameterProvider.overrideWithValue(RemoteConfigParameter()),
+            remoteConfigParameterProvider
+                .overrideWithValue(RemoteConfigParameter()),
           ],
           child: const MaterialApp(home: Material(child: AnnouncementBar())),
         ),
@@ -2184,12 +2207,15 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
 
       expect(
-        find.byWidgetPredicate((widget) => widget is RecommendSignupGeneralAnnouncementBar),
+        find.byWidgetPredicate(
+            (widget) => widget is RecommendSignupGeneralAnnouncementBar),
         findsOneWidget,
       );
     });
 
-    testWidgets('認証済み + トライアル中 + FeatureAppeal 候補あり → FeatureAppealBarsContainer が表示される', (tester) async {
+    testWidgets(
+        '認証済み + トライアル中 + FeatureAppeal 候補あり → FeatureAppealBarsContainer が表示される',
+        (tester) async {
       final mockTodayRepository = MockTodayService();
       final mockToday = DateTime(2024, 1, 1);
       when(mockTodayRepository.now()).thenReturn(mockToday);
@@ -2209,14 +2235,16 @@ void main() {
       );
 
       SharedPreferences.setMockInitialValues({
-        IntKey.totalCountOfActionForTakenPill: totalCountOfActionForTakenPillForLongTimeUser,
+        IntKey.totalCountOfActionForTakenPill:
+            totalCountOfActionForTakenPillForLongTimeUser,
       });
       final sharedPreferences = await SharedPreferences.getInstance();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
             appIsReleasedProvider.overrideWith((ref) => true),
-            latestPillSheetGroupProvider.overrideWith((ref) => Stream.value(pillSheetGroup)),
+            latestPillSheetGroupProvider
+                .overrideWith((ref) => Stream.value(pillSheetGroup)),
             userProvider.overrideWith(
               (ref) => Stream.value(
                 User(
@@ -2230,7 +2258,8 @@ void main() {
             isLinkedProvider.overrideWithValue(true),
             isJaLocaleProvider.overrideWithValue(true),
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
-            remoteConfigParameterProvider.overrideWithValue(RemoteConfigParameter()),
+            remoteConfigParameterProvider
+                .overrideWithValue(RemoteConfigParameter()),
           ],
           child: const MaterialApp(home: Material(child: AnnouncementBar())),
         ),
@@ -2242,12 +2271,15 @@ void main() {
       // mockToday=epoch → daysBetween=0 → index 0 = CriticalAlertAnnouncementBar
       // ローテーションロジック自体は feature_appeal_bars_container_test.dart で網羅的にテスト済み
       expect(
-        find.byWidgetPredicate((widget) => widget is CriticalAlertAnnouncementBar),
+        find.byWidgetPredicate(
+            (widget) => widget is CriticalAlertAnnouncementBar),
         findsOneWidget,
       );
     });
 
-    testWidgets('認証済み + トライアル中 + FeatureAppeal 全 dismiss → PremiumTrialLimitAnnouncementBar にフォールバックする', (tester) async {
+    testWidgets(
+        '認証済み + トライアル中 + FeatureAppeal 全 dismiss → PremiumTrialLimitAnnouncementBar にフォールバックする',
+        (tester) async {
       final mockTodayRepository = MockTodayService();
       final mockToday = DateTime(2024, 1, 1);
       when(mockTodayRepository.now()).thenReturn(mockToday);
@@ -2272,7 +2304,8 @@ void main() {
         ProviderScope(
           overrides: [
             appIsReleasedProvider.overrideWith((ref) => true),
-            latestPillSheetGroupProvider.overrideWith((ref) => Stream.value(pillSheetGroup)),
+            latestPillSheetGroupProvider
+                .overrideWith((ref) => Stream.value(pillSheetGroup)),
             userProvider.overrideWith(
               (ref) => Stream.value(
                 User(
@@ -2286,7 +2319,8 @@ void main() {
             isLinkedProvider.overrideWithValue(true),
             isJaLocaleProvider.overrideWithValue(true),
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
-            remoteConfigParameterProvider.overrideWithValue(RemoteConfigParameter()),
+            remoteConfigParameterProvider
+                .overrideWithValue(RemoteConfigParameter()),
           ],
           child: const MaterialApp(home: Material(child: AnnouncementBar())),
         ),
@@ -2296,12 +2330,15 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
 
       expect(
-        find.byWidgetPredicate((widget) => widget is PremiumTrialLimitAnnouncementBar),
+        find.byWidgetPredicate(
+            (widget) => widget is PremiumTrialLimitAnnouncementBar),
         findsOneWidget,
       );
     });
 
-    testWidgets('認証済み + Premium + FeatureAppeal 候補あり → FeatureAppealBarsContainer が RestDuration より上位に表示される', (tester) async {
+    testWidgets(
+        '認証済み + Premium + FeatureAppeal 候補あり → FeatureAppealBarsContainer が RestDuration より上位に表示される',
+        (tester) async {
       final mockTodayRepository = MockTodayService();
       final mockToday = DateTime(2024, 1, 1);
       when(mockTodayRepository.now()).thenReturn(mockToday);
@@ -2321,14 +2358,16 @@ void main() {
       );
 
       SharedPreferences.setMockInitialValues({
-        IntKey.totalCountOfActionForTakenPill: totalCountOfActionForTakenPillForLongTimeUser,
+        IntKey.totalCountOfActionForTakenPill:
+            totalCountOfActionForTakenPillForLongTimeUser,
       });
       final sharedPreferences = await SharedPreferences.getInstance();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
             appIsReleasedProvider.overrideWith((ref) => true),
-            latestPillSheetGroupProvider.overrideWith((ref) => Stream.value(pillSheetGroup)),
+            latestPillSheetGroupProvider
+                .overrideWith((ref) => Stream.value(pillSheetGroup)),
             userProvider.overrideWith(
               (ref) => Stream.value(
                 const User(
@@ -2342,7 +2381,8 @@ void main() {
             isLinkedProvider.overrideWithValue(true),
             isJaLocaleProvider.overrideWithValue(true),
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
-            remoteConfigParameterProvider.overrideWithValue(RemoteConfigParameter()),
+            remoteConfigParameterProvider
+                .overrideWithValue(RemoteConfigParameter()),
           ],
           child: const MaterialApp(home: Material(child: AnnouncementBar())),
         ),
@@ -2354,12 +2394,74 @@ void main() {
       // mockToday=epoch → daysBetween=0 → index 0 = CriticalAlertAnnouncementBar
       // ローテーションロジック自体は feature_appeal_bars_container_test.dart で網羅的にテスト済み
       expect(
-        find.byWidgetPredicate((widget) => widget is CriticalAlertAnnouncementBar),
+        find.byWidgetPredicate(
+            (widget) => widget is CriticalAlertAnnouncementBar),
         findsOneWidget,
       );
     });
 
-    testWidgets('割引期限保有 + 非トライアル + 未認証 → DiscountPriceDeadline が認証推奨より上位を維持する (リグレッション防止)', (tester) async {
+    testWidgets(
+        '認証済み + トライアル残り15日 + FeatureAppeal 全dismiss → PremiumTrialLimit (低優先度パス) が表示される',
+        (tester) async {
+      final mockTodayRepository = MockTodayService();
+      final mockToday = DateTime(2024, 1, 1);
+      when(mockTodayRepository.now()).thenReturn(mockToday);
+      todayRepository = mockTodayRepository;
+
+      final pillSheet = PillSheet.create(
+        PillSheetType.pillsheet_21,
+        lastTakenDate: mockToday,
+        beginDate: mockToday.subtract(const Duration(days: 5)),
+        pillTakenCount: 1,
+      );
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ['1'],
+        pillSheets: [pillSheet],
+        createdAt: mockToday,
+        pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+      );
+
+      SharedPreferences.setMockInitialValues(allFeatureAppealDismissedPrefs());
+      final sharedPreferences = await SharedPreferences.getInstance();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appIsReleasedProvider.overrideWith((ref) => true),
+            latestPillSheetGroupProvider
+                .overrideWith((ref) => Stream.value(pillSheetGroup)),
+            userProvider.overrideWith(
+              (ref) => Stream.value(
+                User(
+                  isPremium: false,
+                  trialDeadlineDate: mockToday.add(const Duration(days: 15)),
+                  beginTrialDate: mockToday.subtract(const Duration(days: 1)),
+                  discountEntitlementDeadlineDate: null,
+                ),
+              ),
+            ),
+            isLinkedProvider.overrideWithValue(true),
+            isJaLocaleProvider.overrideWithValue(true),
+            sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
+            remoteConfigParameterProvider
+                .overrideWithValue(RemoteConfigParameter()),
+          ],
+          child: const MaterialApp(home: Material(child: AnnouncementBar())),
+        ),
+      );
+      await tester.pump();
+
+      debugDefaultTargetPlatformOverride = null;
+
+      expect(
+        find.byWidgetPredicate(
+            (widget) => widget is PremiumTrialLimitAnnouncementBar),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        '当日閉じ済み + 未認証 + トライアル残り10日以内 → PremiumTrialLimit が RecommendSignupGeneral より優先される',
+        (tester) async {
       final mockTodayRepository = MockTodayService();
       final mockToday = DateTime(2024, 1, 1);
       when(mockTodayRepository.now()).thenReturn(mockToday);
@@ -2379,36 +2481,170 @@ void main() {
       );
 
       SharedPreferences.setMockInitialValues({
-        IntKey.totalCountOfActionForTakenPill: totalCountOfActionForTakenPillForLongTimeUser,
+        IntKey.totalCountOfActionForTakenPill:
+            totalCountOfActionForTakenPillForLongTimeUser,
+        StringKey.featureAppealLastDismissedDate: mockToday.toIso8601String(),
       });
       final sharedPreferences = await SharedPreferences.getInstance();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
             appIsReleasedProvider.overrideWith((ref) => true),
-            latestPillSheetGroupProvider.overrideWith((ref) => Stream.value(pillSheetGroup)),
+            latestPillSheetGroupProvider
+                .overrideWith((ref) => Stream.value(pillSheetGroup)),
             userProvider.overrideWith(
               (ref) => Stream.value(
                 User(
                   isPremium: false,
-                  trialDeadlineDate: mockToday.subtract(const Duration(days: 1)),
+                  trialDeadlineDate: mockToday.add(const Duration(days: 8)),
+                  beginTrialDate: mockToday.subtract(const Duration(days: 1)),
+                  discountEntitlementDeadlineDate: null,
+                ),
+              ),
+            ),
+            isLinkedProvider.overrideWithValue(false),
+            isJaLocaleProvider.overrideWithValue(true),
+            sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
+            remoteConfigParameterProvider
+                .overrideWithValue(RemoteConfigParameter()),
+          ],
+          child: const MaterialApp(home: Material(child: AnnouncementBar())),
+        ),
+      );
+      await tester.pump();
+
+      debugDefaultTargetPlatformOverride = null;
+
+      expect(
+        find.byWidgetPredicate(
+            (widget) => widget is PremiumTrialLimitAnnouncementBar),
+        findsOneWidget,
+      );
+      expect(
+        find.byWidgetPredicate(
+            (widget) => widget is RecommendSignupGeneralAnnouncementBar),
+        findsNothing,
+      );
+    });
+
+    testWidgets('非トライアル + 全dismiss + 認証済み → AdMob にフォールバックする', (tester) async {
+      final mockTodayRepository = MockTodayService();
+      final mockToday = DateTime(2024, 1, 1);
+      when(mockTodayRepository.now()).thenReturn(mockToday);
+      todayRepository = mockTodayRepository;
+
+      final pillSheet = PillSheet.create(
+        PillSheetType.pillsheet_21,
+        lastTakenDate: mockToday,
+        beginDate: mockToday.subtract(const Duration(days: 5)),
+        pillTakenCount: 1,
+      );
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ['1'],
+        pillSheets: [pillSheet],
+        createdAt: mockToday,
+        pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+      );
+
+      SharedPreferences.setMockInitialValues(allFeatureAppealDismissedPrefs());
+      final sharedPreferences = await SharedPreferences.getInstance();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appIsReleasedProvider.overrideWith((ref) => true),
+            latestPillSheetGroupProvider
+                .overrideWith((ref) => Stream.value(pillSheetGroup)),
+            userProvider.overrideWith(
+              (ref) => Stream.value(
+                User(
+                  isPremium: false,
+                  trialDeadlineDate:
+                      mockToday.subtract(const Duration(days: 1)),
                   beginTrialDate: mockToday.subtract(const Duration(days: 30)),
-                  discountEntitlementDeadlineDate: mockToday.add(const Duration(days: 2)),
+                  discountEntitlementDeadlineDate: null,
+                ),
+              ),
+            ),
+            isLinkedProvider.overrideWithValue(true),
+            isJaLocaleProvider.overrideWithValue(true),
+            sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
+            remoteConfigParameterProvider
+                .overrideWithValue(RemoteConfigParameter()),
+          ],
+          child: const MaterialApp(home: Material(child: AnnouncementBar())),
+        ),
+      );
+      await tester.pump();
+
+      debugDefaultTargetPlatformOverride = null;
+
+      expect(
+        find.byWidgetPredicate((widget) => widget is AdMob),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        '割引期限保有 + 非トライアル + 未認証 → DiscountPriceDeadline が認証推奨より上位を維持する (リグレッション防止)',
+        (tester) async {
+      final mockTodayRepository = MockTodayService();
+      final mockToday = DateTime(2024, 1, 1);
+      when(mockTodayRepository.now()).thenReturn(mockToday);
+      todayRepository = mockTodayRepository;
+
+      final pillSheet = PillSheet.create(
+        PillSheetType.pillsheet_21,
+        lastTakenDate: mockToday,
+        beginDate: mockToday.subtract(const Duration(days: 5)),
+        pillTakenCount: 1,
+      );
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ['1'],
+        pillSheets: [pillSheet],
+        createdAt: mockToday,
+        pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+      );
+
+      SharedPreferences.setMockInitialValues({
+        IntKey.totalCountOfActionForTakenPill:
+            totalCountOfActionForTakenPillForLongTimeUser,
+      });
+      final sharedPreferences = await SharedPreferences.getInstance();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appIsReleasedProvider.overrideWith((ref) => true),
+            latestPillSheetGroupProvider
+                .overrideWith((ref) => Stream.value(pillSheetGroup)),
+            userProvider.overrideWith(
+              (ref) => Stream.value(
+                User(
+                  isPremium: false,
+                  trialDeadlineDate:
+                      mockToday.subtract(const Duration(days: 1)),
+                  beginTrialDate: mockToday.subtract(const Duration(days: 30)),
+                  discountEntitlementDeadlineDate:
+                      mockToday.add(const Duration(days: 2)),
                 ),
               ),
             ),
             isLinkedProvider.overrideWithValue(false),
             isJaLocaleProvider.overrideWithValue(true),
             hiddenCountdownDiscountDeadlineProvider(
-              discountEntitlementDeadlineDate: mockToday.add(const Duration(days: 2)),
+              discountEntitlementDeadlineDate:
+                  mockToday.add(const Duration(days: 2)),
             ).overrideWith((provider) => false),
             durationToDiscountPriceDeadlineProvider(
-              discountEntitlementDeadlineDate: mockToday.add(const Duration(days: 2)),
+              discountEntitlementDeadlineDate:
+                  mockToday.add(const Duration(days: 2)),
             ).overrideWithValue(const Duration(seconds: 1000)),
             sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
-            remoteConfigParameterProvider.overrideWithValue(RemoteConfigParameter()),
-            annualPackageProvider.overrideWith((ref, user) => FakeRevenueCatPackage()),
-            monthlyPackageProvider.overrideWith((ref, user) => FakeRevenueCatPackage()),
+            remoteConfigParameterProvider
+                .overrideWithValue(RemoteConfigParameter()),
+            annualPackageProvider
+                .overrideWith((ref, user) => FakeRevenueCatPackage()),
+            monthlyPackageProvider
+                .overrideWith((ref, user) => FakeRevenueCatPackage()),
           ],
           child: const MaterialApp(home: Material(child: AnnouncementBar())),
         ),
@@ -2422,7 +2658,8 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.byWidgetPredicate((widget) => widget is RecommendSignupGeneralAnnouncementBar),
+        find.byWidgetPredicate(
+            (widget) => widget is RecommendSignupGeneralAnnouncementBar),
         findsNothing,
       );
     });

--- a/test/features/record/announcement_bar/announcement_bar_test.dart
+++ b/test/features/record/announcement_bar/announcement_bar_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter/rendering.dart';
 import 'package:pilll/entity/remote_config_parameter.codegen.dart';
 import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/features/feature_appeal/critical_alert/critical_alert_announcement_bar.dart';
-import 'package:pilll/features/feature_appeal/feature_appeal_bars_container.dart';
 import 'package:pilll/features/record/components/announcement_bar/components/admob.dart';
 import 'package:pilll/features/record/components/announcement_bar/components/recommend_signup_general.dart';
 import 'package:pilll/provider/purchase.dart';
@@ -1961,7 +1960,7 @@ void main() {
       };
     }
 
-    testWidgets('未認証 + 非Premium + トライアル中 → RecommendSignupGeneralAnnouncementBar が表示される', (tester) async {
+    testWidgets('未認証 + トライアル中 + FeatureAppeal 候補あり → FeatureAppeal が RecommendSignupGeneral より優先される', (tester) async {
       final mockTodayRepository = MockTodayService();
       final mockToday = DateTime(2024, 1, 1);
       when(mockTodayRepository.now()).thenReturn(mockToday);
@@ -1994,6 +1993,179 @@ void main() {
                 User(
                   isPremium: false,
                   trialDeadlineDate: mockToday.add(const Duration(days: 5)),
+                  beginTrialDate: mockToday.subtract(const Duration(days: 1)),
+                  discountEntitlementDeadlineDate: null,
+                ),
+              ),
+            ),
+            isLinkedProvider.overrideWithValue(false),
+            isJaLocaleProvider.overrideWithValue(true),
+            sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
+            remoteConfigParameterProvider.overrideWithValue(RemoteConfigParameter()),
+          ],
+          child: const MaterialApp(home: Material(child: AnnouncementBar())),
+        ),
+      );
+      await tester.pump();
+
+      debugDefaultTargetPlatformOverride = null;
+
+      expect(
+        find.byWidgetPredicate((widget) => widget is CriticalAlertAnnouncementBar),
+        findsOneWidget,
+      );
+      expect(
+        find.byWidgetPredicate((widget) => widget is RecommendSignupGeneralAnnouncementBar),
+        findsNothing,
+      );
+    });
+
+    testWidgets('未認証 + トライアル中 + FeatureAppeal 全dismiss → RecommendSignupGeneralAnnouncementBar が表示される', (tester) async {
+      final mockTodayRepository = MockTodayService();
+      final mockToday = DateTime(2024, 1, 1);
+      when(mockTodayRepository.now()).thenReturn(mockToday);
+      todayRepository = mockTodayRepository;
+
+      final pillSheet = PillSheet.create(
+        PillSheetType.pillsheet_21,
+        lastTakenDate: mockToday,
+        beginDate: mockToday.subtract(const Duration(days: 5)),
+        pillTakenCount: 1,
+      );
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ['1'],
+        pillSheets: [pillSheet],
+        createdAt: mockToday,
+        pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+      );
+
+      SharedPreferences.setMockInitialValues(allFeatureAppealDismissedPrefs());
+      final sharedPreferences = await SharedPreferences.getInstance();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appIsReleasedProvider.overrideWith((ref) => true),
+            latestPillSheetGroupProvider.overrideWith((ref) => Stream.value(pillSheetGroup)),
+            userProvider.overrideWith(
+              (ref) => Stream.value(
+                User(
+                  isPremium: false,
+                  trialDeadlineDate: mockToday.add(const Duration(days: 15)),
+                  beginTrialDate: mockToday.subtract(const Duration(days: 1)),
+                  discountEntitlementDeadlineDate: null,
+                ),
+              ),
+            ),
+            isLinkedProvider.overrideWithValue(false),
+            isJaLocaleProvider.overrideWithValue(true),
+            sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
+            remoteConfigParameterProvider.overrideWithValue(RemoteConfigParameter()),
+          ],
+          child: const MaterialApp(home: Material(child: AnnouncementBar())),
+        ),
+      );
+      await tester.pump();
+
+      debugDefaultTargetPlatformOverride = null;
+
+      expect(
+        find.byWidgetPredicate((widget) => widget is RecommendSignupGeneralAnnouncementBar),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('未認証 + トライアル残り10日以内 + FeatureAppeal 全dismiss → PremiumTrialLimit が RecommendSignupGeneral より優先される', (tester) async {
+      final mockTodayRepository = MockTodayService();
+      final mockToday = DateTime(2024, 1, 1);
+      when(mockTodayRepository.now()).thenReturn(mockToday);
+      todayRepository = mockTodayRepository;
+
+      final pillSheet = PillSheet.create(
+        PillSheetType.pillsheet_21,
+        lastTakenDate: mockToday,
+        beginDate: mockToday.subtract(const Duration(days: 5)),
+        pillTakenCount: 1,
+      );
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ['1'],
+        pillSheets: [pillSheet],
+        createdAt: mockToday,
+        pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+      );
+
+      SharedPreferences.setMockInitialValues(allFeatureAppealDismissedPrefs());
+      final sharedPreferences = await SharedPreferences.getInstance();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appIsReleasedProvider.overrideWith((ref) => true),
+            latestPillSheetGroupProvider.overrideWith((ref) => Stream.value(pillSheetGroup)),
+            userProvider.overrideWith(
+              (ref) => Stream.value(
+                User(
+                  isPremium: false,
+                  trialDeadlineDate: mockToday.add(const Duration(days: 5)),
+                  beginTrialDate: mockToday.subtract(const Duration(days: 1)),
+                  discountEntitlementDeadlineDate: null,
+                ),
+              ),
+            ),
+            isLinkedProvider.overrideWithValue(false),
+            isJaLocaleProvider.overrideWithValue(true),
+            sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
+            remoteConfigParameterProvider.overrideWithValue(RemoteConfigParameter()),
+          ],
+          child: const MaterialApp(home: Material(child: AnnouncementBar())),
+        ),
+      );
+      await tester.pump();
+
+      debugDefaultTargetPlatformOverride = null;
+
+      expect(
+        find.byWidgetPredicate((widget) => widget is PremiumTrialLimitAnnouncementBar),
+        findsOneWidget,
+      );
+      expect(
+        find.byWidgetPredicate((widget) => widget is RecommendSignupGeneralAnnouncementBar),
+        findsNothing,
+      );
+    });
+
+    testWidgets('当日閉じ済み + 未認証 + トライアル残り15日 → RecommendSignupGeneral が表示される', (tester) async {
+      final mockTodayRepository = MockTodayService();
+      final mockToday = DateTime(2024, 1, 1);
+      when(mockTodayRepository.now()).thenReturn(mockToday);
+      todayRepository = mockTodayRepository;
+
+      final pillSheet = PillSheet.create(
+        PillSheetType.pillsheet_21,
+        lastTakenDate: mockToday,
+        beginDate: mockToday.subtract(const Duration(days: 5)),
+        pillTakenCount: 1,
+      );
+      final pillSheetGroup = PillSheetGroup(
+        pillSheetIDs: ['1'],
+        pillSheets: [pillSheet],
+        createdAt: mockToday,
+        pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+      );
+
+      SharedPreferences.setMockInitialValues({
+        IntKey.totalCountOfActionForTakenPill: totalCountOfActionForTakenPillForLongTimeUser,
+        StringKey.featureAppealLastDismissedDate: mockToday.toIso8601String(),
+      });
+      final sharedPreferences = await SharedPreferences.getInstance();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appIsReleasedProvider.overrideWith((ref) => true),
+            latestPillSheetGroupProvider.overrideWith((ref) => Stream.value(pillSheetGroup)),
+            userProvider.overrideWith(
+              (ref) => Stream.value(
+                User(
+                  isPremium: false,
+                  trialDeadlineDate: mockToday.add(const Duration(days: 15)),
                   beginTrialDate: mockToday.subtract(const Duration(days: 1)),
                   discountEntitlementDeadlineDate: null,
                 ),

--- a/test/features/record/components/announcement_bar/components/recommend_signup_general_test.dart
+++ b/test/features/record/components/announcement_bar/components/recommend_signup_general_test.dart
@@ -17,14 +17,17 @@ void main() {
         ),
       );
 
-      expect(find.byType(RecommendSignupGeneralAnnouncementBar), findsOneWidget);
+      expect(
+          find.byType(RecommendSignupGeneralAnnouncementBar), findsOneWidget);
       // alert_24.svg + arrow_right.svg
       expect(find.byType(SvgPicture), findsNWidgets(2));
       // タイトル + 説明文
       expect(find.byType(Text), findsNWidgets(2));
     });
 
-    testWidgets('× ボタン (Icons.close) は表示されない (既存 RecommendSignupForPremium と同様)', (tester) async {
+    testWidgets(
+        '× ボタン (Icons.close) は表示されない (既存 RecommendSignupForPremium と同様)',
+        (tester) async {
       await tester.pumpWidget(
         const ProviderScope(
           child: MaterialApp(


### PR DESCRIPTION
## Abstract

AnnouncementBar の優先度を「認証推奨 → 機能訴求」から「機能訴求 → 認証推奨」に変更し、PremiumTrialLimit の10日閾値分割と当日 dismiss 判定を追加。

### 変更後の非Premium優先度

```
DiscountPriceDeadline       (実利用警告・変更なし)
→ EndedPillSheet            (実利用警告・変更なし)
→ FeatureAppeal             (候補あり & 当日未閉じ) ★上に移動
→ PremiumTrialLimit         (残り10日以内)           ★条件分割
→ RecommendSignupGeneral    (未認証)                 ★下に移動
→ PremiumTrialLimit         (残り10日以上)           ★条件分割
→ PilllAds / SpecialOffering / AdMob (既存・変更なし)
```

## Why

### 優先度変更
- トライアル中のユーザーに対して、まず機能の魅力を訴求し、その後に認証を促す方が効果的
- 「1日1種類」の設計を維持しつつ、× で閉じた当日はフォールバック表示に切り替える

### 当日 dismiss 判定
- `featureAppealLastDismissedDate` (ISO 8601) を SharedPreferences に保存
- `isSameDay(lastDismissedDate, today())` で判定し、当日は FeatureAppeal をスキップ
- 翌日には自動的に次の候補が表示される

### PremiumTrialLimit 10日閾値分割
- トライアル残り10日以内: RecommendSignupGeneral より優先 (期限の緊急性)
- トライアル残り10日以上: FeatureAppeal / RecommendSignupGeneral より低優先度

### 主な変更ファイル
- `lib/utils/shared_preference/keys.dart` (StringKey 追加)
- `lib/features/feature_appeal/feature_appeal_bars_container.dart` (dismissedToday, wasDismissedToday)
- `lib/features/record/components/announcement_bar/components/premium_trial_limit.dart` (remainingTrialDays)
- `lib/features/record/components/announcement_bar/announcement_bar.dart` (優先度書き換え)
- `documents/adr/0001-feature-appeal-design.md` (決定5更新, 決定6追加)

## Links

- ベースPR: #1782
- ADR: `documents/adr/0001-feature-appeal-design.md` (決定5, 決定6)

## Checked
- [x] Analyticsのログを入れたか (既存のログ構成を維持、新規ログ追加なし)
- [x] 境界値に対してのUnitTestを書いた (wasDismissedToday: 当日/昨日/空、PremiumTrialLimit: 10日以内/15日)
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた (FeatureAppealIntegration: 8テストケース)