### PR TITLE
fix: ref.watch修正 + FeatureAppeal CLAUDE.md 指示書追加

### DIFF
--- a/lib/features/feature_appeal/CLAUDE.md
+++ b/lib/features/feature_appeal/CLAUDE.md
@@ -14,9 +14,9 @@ Scaffold
 │     ├─ Feature Cards × 3 (_featureCard)
 │     ├─ 「アプリ内の場所」ラベル (L.featureAppealLocationLabel)
 │     ├─ _mockTabBar(selectedIndex: N)
-│     ├─ ↓ 矢印
-│     └─ コンポーネントプレビュー
-└─ bottomNavigationBar: SafeArea > Padding(16) > PrimaryButton
+│     ├─ ↓ 矢印 (Icons.arrow_downward, size: 28, AppColors.primary)
+│     └─ コンポーネントプレビュー（任意・タブバーだけでも可）
+└─ bottomNavigationBar: SafeArea > Padding(16) > PrimaryButton(L.featureAppealTryFeature = "確認する")
 ```
 
 ## レイアウト禁止事項
@@ -24,16 +24,22 @@ Scaffold
 - `bottomNavigationBar` 内に `Center` を入れない。Scaffold が loose height constraints を渡すため `Center` が最大高さに膨張し body 領域が 0 になる
 - `if (!xxxAsync.hasValue) return SizedBox.shrink()` でローディングガードしない。ページ全体（AppBar 含む）が消える
 
+## 「確認する」ボタンの遷移先ルール
+
+**遷移先はタブ移動のみに統一する**。個別の機能ページへの直接遷移はしない。
+
+- 理由: 動線の判断コストを下げる。まずは該当タブに飛ばしてユーザーに探索させる方針
+- ボタン文言も「確認する」（履歴確認など「試す」でない機能にも合わせるため）
+
+```dart
+final tabController = ref.read(homeTabControllerProvider);
+Navigator.of(context).popUntil((r) => r.isFirst);
+tabController?.animateTo(HomePageTabType.{record|menstruation|calendar|setting}.index);
+```
+
+Premium 機能の場合のみ、タブ移動前に `ref.watch(userProvider).requireValue` で user を取得し、`!user.premiumOrTrial` のとき `showPremiumIntroductionSheet(context)` でペイウォール表示。
+
 ## ステップバイステップガイド
-
-機能のアクセス経路に応じてコンポーネントプレビューを使い分ける:
-
-| アクセス経路 | タブ選択 | プレビュー |
-|---|---|---|
-| 設定タブ内の行 | `selectedIndex: 3` | `Container(primary border) > IgnorePointer > ListTile` |
-| ピルタブの操作 | `selectedIndex: 0` | pill mark 行 + touch_app → 矢印 → 服用履歴リスト |
-| カレンダータブの操作 | `selectedIndex: 2` | ミニカレンダー(曜日 + 日付行) + touch_app |
-| ピルタブのボタン | `selectedIndex: 0` | ボタン風 Container（実際の設定ボタンの見た目を再現） |
 
 ### 矢印
 
@@ -45,6 +51,12 @@ Scaffold
 - `Positioned(bottom: 0, right: -4〜-6)` + `Icon(Icons.touch_app, size: 22)`
 - 親 Container に `clipBehavior: Clip.none` と bottom padding を多めに設定して見切れを防ぐ
 
+## Feature Card の文言
+
+- **実機能と齟齬がないか必ず確認**する（実装されていない機能を書かない）
+- 過去の事例: 「検索」機能は未実装なのに Feature Card に記載されていた
+- アイコンも内容と合っているか確認
+
 ## L10n キー命名
 
 | キー | 用途 |
@@ -54,7 +66,7 @@ Scaffold
 | `{feature}FeatureAppealBody` | 本文（将来用） |
 | `{feature}FeatureAppealPoint1/2/3` | フィーチャーカードのテキスト |
 | `featureAppealLocationLabel` | 「アプリ内の場所」共通ラベル |
-| `featureAppealTryFeature` | 「実際に試す」共通ボタンテキスト |
+| `featureAppealTryFeature` | 「確認する」共通ボタンテキスト |
 
 ## AnnouncementBar との関係
 
@@ -79,9 +91,9 @@ extension XxxHelpPageRoute on XxxHelpPage {
 ## 新規 HelpPage 追加時の手順
 
 1. `lib/features/feature_appeal/{feature}/` にディレクトリ作成
-2. `{feature}_help_page.dart` を既存ページをコピーして作成
+2. `{feature}_help_page.dart` を既存ページをコピーして作成（ConsumerWidget推奨）
 3. `{feature}_announcement_bar.dart` を作成
-4. `lib/l10n/app_ja.arb` に L10n キーを追加（Title, Headline, Point1/2/3）
+4. `lib/l10n/app_ja.arb` / `app_en.arb` に L10n キーを追加（Title, Headline, Point1/2/3）
 5. `flutter gen-l10n` で生成
 6. `lib/features/feature_appeal/feature_appeal_bars_container.dart` に AnnouncementBar を登録
 7. `lib/features/settings/components/rows/feature_appeal_help_page_list_page.dart` の `pages` リストにエントリを追加

--- a/lib/features/feature_appeal/CLAUDE.md
+++ b/lib/features/feature_appeal/CLAUDE.md
@@ -1,0 +1,87 @@
+# FeatureAppeal HelpPage 指示書
+
+HelpPage を新規追加・修正する際のルール。既存8ページの実装パターンに従うこと。
+
+## ページ構成
+
+```
+Scaffold
+├─ AppBar (機能名)
+├─ body: SingleChildScrollView(padding: fromLTRB(24, 24, 24, 40))
+│  └─ Column
+│     ├─ SVG Icon (Center, 80x80)
+│     ├─ Headline (fontSize: 22, w700)
+│     ├─ Feature Cards × 3 (_featureCard)
+│     ├─ 「アプリ内の場所」ラベル (L.featureAppealLocationLabel)
+│     ├─ _mockTabBar(selectedIndex: N)
+│     ├─ ↓ 矢印
+│     └─ コンポーネントプレビュー
+└─ bottomNavigationBar: SafeArea > Padding(16) > PrimaryButton
+```
+
+## レイアウト禁止事項
+
+- `bottomNavigationBar` 内に `Center` を入れない。Scaffold が loose height constraints を渡すため `Center` が最大高さに膨張し body 領域が 0 になる
+- `if (!xxxAsync.hasValue) return SizedBox.shrink()` でローディングガードしない。ページ全体（AppBar 含む）が消える
+
+## ステップバイステップガイド
+
+機能のアクセス経路に応じてコンポーネントプレビューを使い分ける:
+
+| アクセス経路 | タブ選択 | プレビュー |
+|---|---|---|
+| 設定タブ内の行 | `selectedIndex: 3` | `Container(primary border) > IgnorePointer > ListTile` |
+| ピルタブの操作 | `selectedIndex: 0` | pill mark 行 + touch_app → 矢印 → 服用履歴リスト |
+| カレンダータブの操作 | `selectedIndex: 2` | ミニカレンダー(曜日 + 日付行) + touch_app |
+| ピルタブのボタン | `selectedIndex: 0` | ボタン風 Container（実際の設定ボタンの見た目を再現） |
+
+### 矢印
+
+`Icons.arrow_downward`（size: 28, color: AppColors.primary）を使う。`Icons.keyboard_arrow_down` は Expandable に見えるため使わない。
+
+### touch_app アイコン
+
+- 対象の**下側**に配置する（指先がタップ位置に触れる見た目）
+- `Positioned(bottom: 0, right: -4〜-6)` + `Icon(Icons.touch_app, size: 22)`
+- 親 Container に `clipBehavior: Clip.none` と bottom padding を多めに設定して見切れを防ぐ
+
+## L10n キー命名
+
+| キー | 用途 |
+|---|---|
+| `{feature}FeatureAppealTitle` | AppBar タイトル |
+| `{feature}FeatureAppealHeadline` | 見出し |
+| `{feature}FeatureAppealBody` | 本文（将来用） |
+| `{feature}FeatureAppealPoint1/2/3` | フィーチャーカードのテキスト |
+| `featureAppealLocationLabel` | 「アプリ内の場所」共通ラベル |
+| `featureAppealTryFeature` | 「実際に試す」共通ボタンテキスト |
+
+## AnnouncementBar との関係
+
+- 各機能には AnnouncementBar (`*_announcement_bar.dart`) と HelpPage (`*_help_page.dart`) がセット
+- AnnouncementBar タップで HelpPage に遷移する
+- 日次ローテーション: `daysBetween(epoch, today()) % candidates.length`
+- dismiss は SharedPreferences のキーで機能ごとに管理
+
+## Route 定義
+
+```dart
+extension XxxHelpPageRoute on XxxHelpPage {
+  static Route<dynamic> route() => MaterialPageRoute(
+    settings: const RouteSettings(name: 'XxxHelpPage'),
+    builder: (_) => const XxxHelpPage(),
+  );
+}
+```
+
+`RouteSettings.name` は必須（FirebaseAnalyticsObserver の screen_view 送信に使用）。
+
+## 新規 HelpPage 追加時の手順
+
+1. `lib/features/feature_appeal/{feature}/` にディレクトリ作成
+2. `{feature}_help_page.dart` を既存ページをコピーして作成
+3. `{feature}_announcement_bar.dart` を作成
+4. `lib/l10n/app_ja.arb` に L10n キーを追加（Title, Headline, Point1/2/3）
+5. `flutter gen-l10n` で生成
+6. `lib/features/feature_appeal/feature_appeal_bars_container.dart` に AnnouncementBar を登録
+7. `lib/features/settings/components/rows/feature_appeal_help_page_list_page.dart` の `pages` リストにエントリを追加

--- a/lib/features/feature_appeal/CLAUDE.md
+++ b/lib/features/feature_appeal/CLAUDE.md
@@ -10,7 +10,7 @@ Scaffold
 ├─ body: SingleChildScrollView(padding: fromLTRB(24, 24, 24, 40))
 │  └─ Column
 │     ├─ SVG Icon (Center, 80x80)
-│     ├─ Headline (fontSize: 22, w700)
+│     ├─ Headline (Center, fontSize: 22, w700)
 │     ├─ Feature Cards × 3 (_featureCard)
 │     ├─ 「アプリ内の場所」ラベル (L.featureAppealLocationLabel)
 │     ├─ _mockTabBar(selectedIndex: N)

--- a/lib/features/feature_appeal/alarm_kit/alarm_kit_announcement_bar.dart
+++ b/lib/features/feature_appeal/alarm_kit/alarm_kit_announcement_bar.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/features/feature_appeal/alarm_kit/alarm_kit_help_page.dart';
+import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/utils/analytics.dart';
+
+/// AlarmKit (Premium機能: iOS 26+) を AnnouncementBar 領域でアピールする Bar。
+/// iOS 26 未満・Android にも表示するが、HelpPage 内で利用条件を明示している。
+class AlarmKitAnnouncementBar extends StatelessWidget {
+  /// 親 (FeatureAppealBarsContainer) が所有する dismissed フラグ。× ボタン押下で true にする。
+  final ValueNotifier<bool> isClosed;
+  const AlarmKitAnnouncementBar({super.key, required this.isClosed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.primary,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+      child: GestureDetector(
+        onTap: () {
+          analytics.logEvent(
+            name: 'feature_appeal_bar_tapped',
+            parameters: {'feature_key': 'alarm_kit', 'feature_type': 'premium'},
+          );
+          Navigator.of(context).push(AlarmKitHelpPageRoute.route());
+        },
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Semantics(
+              identifier: 'feature_appeal_dismiss_button',
+              child: IconButton(
+                tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+                icon: const Icon(Icons.close, color: Colors.white, size: 24),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+                onPressed: () {
+                  analytics.logEvent(
+                    name: 'feature_appeal_bar_dismissed',
+                    parameters: {'feature_key': 'alarm_kit', 'feature_type': 'premium'},
+                  );
+                  isClosed.value = true;
+                },
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    L.alarmKitFeatureAppealTitle,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontFamily: FontFamily.japanese,
+                      fontWeight: FontWeight.w700,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    L.alarmKitFeatureAppealShortDescription,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontFamily: FontFamily.japanese,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 10),
+            SvgPicture.asset(
+              'images/arrow_right.svg',
+              colorFilter: const ColorFilter.mode(Colors.white, BlendMode.srcIn),
+              height: 16,
+              width: 16,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/feature_appeal/alarm_kit/alarm_kit_help_page.dart
+++ b/lib/features/feature_appeal/alarm_kit/alarm_kit_help_page.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/home/page.dart';
+import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
+import 'package:pilll/provider/user.dart';
+import 'package:pilll/utils/analytics.dart';
+
+/// AlarmKit (Premium機能: iOS 26+ で目覚ましアラームとして通知) の説明と「実際に試す」導線を持つヘルプページ。
+/// 「実際に試す」では設定タブへ案内する。iOS 26 未満 / Android では設定行が消えているが、訴求自体は行う。
+/// プレビューは設定行の文言がハードコード日本語のため、ここでも同一文言をハードコードで再現する。
+class AlarmKitHelpPage extends ConsumerWidget {
+  const AlarmKitHelpPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        title: Text(L.alarmKitFeatureAppealTitle),
+        backgroundColor: AppColors.background,
+        leading: IconButton(
+          onPressed: () => Navigator.of(context).pop(),
+          icon: const Icon(Icons.arrow_back),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(24, 24, 24, 40),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: SvgPicture.asset(
+                'images/alerm.svg',
+                width: 80,
+                height: 80,
+                colorFilter: const ColorFilter.mode(AppColors.primary, BlendMode.srcIn),
+              ),
+            ),
+            const SizedBox(height: 32),
+            Center(
+              child: Text(
+                L.alarmKitFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            _featureCard(icon: Icons.alarm, text: L.alarmKitFeatureAppealPoint1),
+            const SizedBox(height: 8),
+            _featureCard(icon: Icons.volume_up, text: L.alarmKitFeatureAppealPoint2),
+            const SizedBox(height: 8),
+            _featureCard(icon: Icons.phone_iphone, text: L.alarmKitFeatureAppealPoint3),
+            const SizedBox(height: 28),
+            Text(
+              L.featureAppealLocationLabel,
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                fontFamily: FontFamily.japanese,
+                color: TextColor.darkGray,
+              ),
+            ),
+            const SizedBox(height: 8),
+            _mockTabBar(selectedIndex: 3),
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 6),
+              child: Center(child: Icon(Icons.arrow_downward, size: 28, color: AppColors.primary)),
+            ),
+            Container(
+              decoration: BoxDecoration(
+                color: AppColors.white,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: AppColors.primary, width: 1.5),
+              ),
+              child: const IgnorePointer(
+                // 設定行 (lib/features/settings/components/rows/alarm_kit.dart) 側が L10n 未整備のハードコード日本語のため、ここでも一貫性を保つために同一文言をハードコードで再現する。L10n 化は後続タスク。
+                child: ListTile(
+                  title: Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          'アラーム機能',
+                          style: TextStyle(
+                            fontFamily: FontFamily.japanese,
+                            fontWeight: FontWeight.w300,
+                            fontSize: 16,
+                          ),
+                        ),
+                      ),
+                      SizedBox(width: 8),
+                      PremiumBadge(),
+                    ],
+                  ),
+                  subtitle: Text(
+                    '目覚まし同様の通知が鳴ります。サイレントモードや集中モード時でも確実に通知されます',
+                    style: TextStyle(
+                      fontFamily: FontFamily.japanese,
+                      fontWeight: FontWeight.w300,
+                      fontSize: 14,
+                    ),
+                  ),
+                  trailing: Switch(value: false, onChanged: null),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: PrimaryButton(
+            text: L.featureAppealTryFeature,
+            onPressed: () async {
+              final user = ref.read(userProvider).requireValue;
+              analytics.logEvent(
+                name: 'feature_appeal_try_tapped',
+                parameters: {
+                  'feature_key': 'alarm_kit',
+                  'feature_type': 'premium',
+                  'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+                },
+              );
+              if (!user.premiumOrTrial) {
+                analytics.logEvent(
+                  name: 'feature_appeal_paywall_shown',
+                  parameters: {'feature_key': 'alarm_kit'},
+                );
+                await showPremiumIntroductionSheet(context);
+                return;
+              }
+              final tabController = ref.read(homeTabControllerProvider);
+              Navigator.of(context).popUntil((r) => r.isFirst);
+              tabController?.animateTo(HomePageTabType.setting.index);
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _mockTabBar({required int selectedIndex}) {
+    final tabs = [
+      (icon: 'images/tab_icon_pill_enable.svg', disabledIcon: 'images/tab_icon_pill_disable.svg', label: L.pill),
+      (icon: 'images/menstruation.svg', disabledIcon: 'images/menstruation_disable.svg', label: L.menstruation),
+      (icon: 'images/tab_icon_calendar_enable.svg', disabledIcon: 'images/tab_icon_calendar_disable.svg', label: L.calendar),
+      (icon: 'images/tab_icon_setting_enable.svg', disabledIcon: 'images/tab_icon_setting_disable.svg', label: L.settings),
+    ];
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border),
+      ),
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          for (var i = 0; i < tabs.length; i++)
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(6),
+                  decoration: i == selectedIndex
+                      ? BoxDecoration(shape: BoxShape.circle, border: Border.all(color: AppColors.primary, width: 2))
+                      : null,
+                  child: SvgPicture.asset(
+                    i == selectedIndex ? tabs[i].icon : tabs[i].disabledIcon,
+                    width: 24,
+                    height: 24,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  tabs[i].label,
+                  style: TextStyle(
+                    fontSize: 10,
+                    fontFamily: FontFamily.japanese,
+                    color: i == selectedIndex ? AppColors.primary : TextColor.darkGray,
+                    fontWeight: i == selectedIndex ? FontWeight.w600 : FontWeight.w400,
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _featureCard({required IconData icon, required String text}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 22, color: AppColors.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              text,
+              style: const TextStyle(
+                fontSize: 14,
+                fontFamily: FontFamily.japanese,
+                fontWeight: FontWeight.w500,
+                color: TextColor.main,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// FirebaseAnalyticsObserver が自動で screen_view を送信するため、
+/// RouteSettings.name は必ず設定する (lib/app.dart で MaterialApp に登録済み)。
+extension AlarmKitHelpPageRoute on AlarmKitHelpPage {
+  static Route<dynamic> route() => MaterialPageRoute(
+        settings: const RouteSettings(name: 'AlarmKitHelpPage'),
+        builder: (_) => const AlarmKitHelpPage(),
+      );
+}

--- a/lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart
+++ b/lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart
@@ -44,13 +44,15 @@ class AppearanceModeDateHelpPage extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 32),
-            Text(
-              L.appearanceModeDateFeatureAppealHeadline,
-              style: const TextStyle(
-                fontSize: 22,
-                fontWeight: FontWeight.w700,
-                fontFamily: FontFamily.japanese,
-                color: TextColor.main,
+            Center(
+              child: Text(
+                L.appearanceModeDateFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
               ),
             ),
             const SizedBox(height: 20),

--- a/lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart
+++ b/lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart
@@ -18,6 +18,9 @@ class AppearanceModeDateHelpPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final user = ref.watch(userProvider).requireValue;
+    final pillSheetGroup = ref.watch(latestPillSheetGroupProvider).valueOrNull;
+
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -100,7 +103,6 @@ class AppearanceModeDateHelpPage extends ConsumerWidget {
           child: PrimaryButton(
             text: L.featureAppealTryFeature,
             onPressed: () async {
-              final user = ref.read(userProvider).requireValue;
               analytics.logEvent(
                 name: 'feature_appeal_try_tapped',
                 parameters: {
@@ -117,7 +119,6 @@ class AppearanceModeDateHelpPage extends ConsumerWidget {
                 await showPremiumIntroductionSheet(context);
                 return;
               }
-              final pillSheetGroup = ref.read(latestPillSheetGroupProvider).valueOrNull;
               if (pillSheetGroup == null) {
                 return;
               }

--- a/lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart
+++ b/lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart
@@ -5,10 +5,9 @@ import 'package:pilll/components/atoms/button.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
-import 'package:pilll/features/record/components/setting/components/appearance_mode/select_appearance_mode_modal.dart';
-import 'package:pilll/provider/pill_sheet_group.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
 
@@ -18,9 +17,6 @@ class AppearanceModeDateHelpPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final user = ref.watch(userProvider).requireValue;
-    final pillSheetGroup = ref.watch(latestPillSheetGroupProvider).valueOrNull;
-
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -105,6 +101,7 @@ class AppearanceModeDateHelpPage extends ConsumerWidget {
           child: PrimaryButton(
             text: L.featureAppealTryFeature,
             onPressed: () async {
+              final user = ref.read(userProvider).requireValue;
               analytics.logEvent(
                 name: 'feature_appeal_try_tapped',
                 parameters: {
@@ -121,14 +118,9 @@ class AppearanceModeDateHelpPage extends ConsumerWidget {
                 await showPremiumIntroductionSheet(context);
                 return;
               }
-              if (pillSheetGroup == null) {
-                return;
-              }
-              showSelectAppearanceModeModal(
-                context,
-                user: user,
-                pillSheetGroup: pillSheetGroup,
-              );
+              final tabController = ref.read(homeTabControllerProvider);
+              Navigator.of(context).popUntil((r) => r.isFirst);
+              tabController?.animateTo(HomePageTabType.record.index);
             },
           ),
         ),
@@ -159,9 +151,8 @@ class AppearanceModeDateHelpPage extends ConsumerWidget {
               children: [
                 Container(
                   padding: const EdgeInsets.all(6),
-                  decoration: i == selectedIndex
-                      ? BoxDecoration(shape: BoxShape.circle, border: Border.all(color: AppColors.primary, width: 2))
-                      : null,
+                  decoration:
+                      i == selectedIndex ? BoxDecoration(shape: BoxShape.circle, border: Border.all(color: AppColors.primary, width: 2)) : null,
                   child: SvgPicture.asset(
                     i == selectedIndex ? tabs[i].icon : tabs[i].disabledIcon,
                     width: 24,

--- a/lib/features/feature_appeal/calendar_diary/calendar_diary_help_page.dart
+++ b/lib/features/feature_appeal/calendar_diary/calendar_diary_help_page.dart
@@ -54,7 +54,7 @@ class CalendarDiaryHelpPage extends ConsumerWidget {
             const SizedBox(height: 8),
             _featureCard(icon: Icons.note_add, text: L.calendarDiaryFeatureAppealPoint2),
             const SizedBox(height: 8),
-            _featureCard(icon: Icons.search, text: L.calendarDiaryFeatureAppealPoint3),
+            _featureCard(icon: Icons.history, text: L.calendarDiaryFeatureAppealPoint3),
             const SizedBox(height: 28),
             Text(
               L.featureAppealLocationLabel,

--- a/lib/features/feature_appeal/calendar_diary/calendar_diary_help_page.dart
+++ b/lib/features/feature_appeal/calendar_diary/calendar_diary_help_page.dart
@@ -38,13 +38,15 @@ class CalendarDiaryHelpPage extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 32),
-            Text(
-              L.calendarDiaryFeatureAppealHeadline,
-              style: const TextStyle(
-                fontSize: 22,
-                fontWeight: FontWeight.w700,
-                fontFamily: FontFamily.japanese,
-                color: TextColor.main,
+            Center(
+              child: Text(
+                L.calendarDiaryFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
               ),
             ),
             const SizedBox(height: 20),

--- a/lib/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_announcement_bar.dart
+++ b/lib/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_announcement_bar.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page.dart';
+import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/utils/analytics.dart';
+
+/// ピルシートグループ自動追加 (Premium機能) を AnnouncementBar 領域でアピールする Bar。
+class CreatingNewPillSheetAnnouncementBar extends StatelessWidget {
+  /// 親 (FeatureAppealBarsContainer) が所有する dismissed フラグ。× ボタン押下で true にする。
+  final ValueNotifier<bool> isClosed;
+  const CreatingNewPillSheetAnnouncementBar({super.key, required this.isClosed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.primary,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+      child: GestureDetector(
+        onTap: () {
+          analytics.logEvent(
+            name: 'feature_appeal_bar_tapped',
+            parameters: {'feature_key': 'creating_new_pillsheet', 'feature_type': 'premium'},
+          );
+          Navigator.of(context).push(CreatingNewPillSheetHelpPageRoute.route());
+        },
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Semantics(
+              identifier: 'feature_appeal_dismiss_button',
+              child: IconButton(
+                tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+                icon: const Icon(Icons.close, color: Colors.white, size: 24),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+                onPressed: () {
+                  analytics.logEvent(
+                    name: 'feature_appeal_bar_dismissed',
+                    parameters: {'feature_key': 'creating_new_pillsheet', 'feature_type': 'premium'},
+                  );
+                  isClosed.value = true;
+                },
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    L.creatingNewPillSheetFeatureAppealTitle,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontFamily: FontFamily.japanese,
+                      fontWeight: FontWeight.w700,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    L.creatingNewPillSheetFeatureAppealShortDescription,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontFamily: FontFamily.japanese,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 10),
+            SvgPicture.asset(
+              'images/arrow_right.svg',
+              colorFilter: const ColorFilter.mode(Colors.white, BlendMode.srcIn),
+              height: 16,
+              width: 16,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page.dart
+++ b/lib/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/home/page.dart';
+import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
+import 'package:pilll/provider/user.dart';
+import 'package:pilll/utils/analytics.dart';
+
+/// ピルシートグループ自動追加 (Premium機能) の説明と「実際に試す」導線を持つヘルプページ。
+/// 「実際に試す」では設定タブへ案内する (設定画面のピルシートグループ自動追加トグルから操作する)。
+/// 非 Premium / 非トライアルユーザーには PremiumIntroductionSheet を開く。
+class CreatingNewPillSheetHelpPage extends ConsumerWidget {
+  const CreatingNewPillSheetHelpPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        title: Text(L.creatingNewPillSheetFeatureAppealTitle),
+        backgroundColor: AppColors.background,
+        leading: IconButton(
+          onPressed: () => Navigator.of(context).pop(),
+          icon: const Icon(Icons.arrow_back),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(24, 24, 24, 40),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: SvgPicture.asset(
+                'images/empty_pill_sheet_type.svg',
+                width: 80,
+                height: 80,
+                colorFilter: const ColorFilter.mode(AppColors.primary, BlendMode.srcIn),
+              ),
+            ),
+            const SizedBox(height: 32),
+            Center(
+              child: Text(
+                L.creatingNewPillSheetFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            _featureCard(icon: Icons.auto_awesome, text: L.creatingNewPillSheetFeatureAppealPoint1),
+            const SizedBox(height: 8),
+            _featureCard(icon: Icons.autorenew, text: L.creatingNewPillSheetFeatureAppealPoint2),
+            const SizedBox(height: 8),
+            _featureCard(icon: Icons.toggle_on, text: L.creatingNewPillSheetFeatureAppealPoint3),
+            const SizedBox(height: 28),
+            Text(
+              L.featureAppealLocationLabel,
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                fontFamily: FontFamily.japanese,
+                color: TextColor.darkGray,
+              ),
+            ),
+            const SizedBox(height: 8),
+            _mockTabBar(selectedIndex: 3),
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 6),
+              child: Center(child: Icon(Icons.arrow_downward, size: 28, color: AppColors.primary)),
+            ),
+            Container(
+              decoration: BoxDecoration(
+                color: AppColors.white,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: AppColors.primary, width: 1.5),
+              ),
+              child: IgnorePointer(
+                child: SwitchListTile(
+                  value: false,
+                  onChanged: (_) {},
+                  title: Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          L.autoAddPillSheetGroup,
+                          style: const TextStyle(
+                            fontFamily: FontFamily.japanese,
+                            fontWeight: FontWeight.w300,
+                            fontSize: 16,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      const PremiumBadge(),
+                    ],
+                  ),
+                  subtitle: Text(
+                    L.autoAddNewSheetAfterCurrentEnds,
+                    style: const TextStyle(
+                      fontFamily: FontFamily.japanese,
+                      fontWeight: FontWeight.w300,
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: PrimaryButton(
+            text: L.featureAppealTryFeature,
+            onPressed: () async {
+              final user = ref.read(userProvider).requireValue;
+              analytics.logEvent(
+                name: 'feature_appeal_try_tapped',
+                parameters: {
+                  'feature_key': 'creating_new_pillsheet',
+                  'feature_type': 'premium',
+                  'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+                },
+              );
+              if (!user.premiumOrTrial) {
+                analytics.logEvent(
+                  name: 'feature_appeal_paywall_shown',
+                  parameters: {'feature_key': 'creating_new_pillsheet'},
+                );
+                await showPremiumIntroductionSheet(context);
+                return;
+              }
+              final tabController = ref.read(homeTabControllerProvider);
+              Navigator.of(context).popUntil((r) => r.isFirst);
+              tabController?.animateTo(HomePageTabType.setting.index);
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _mockTabBar({required int selectedIndex}) {
+    final tabs = [
+      (icon: 'images/tab_icon_pill_enable.svg', disabledIcon: 'images/tab_icon_pill_disable.svg', label: L.pill),
+      (icon: 'images/menstruation.svg', disabledIcon: 'images/menstruation_disable.svg', label: L.menstruation),
+      (icon: 'images/tab_icon_calendar_enable.svg', disabledIcon: 'images/tab_icon_calendar_disable.svg', label: L.calendar),
+      (icon: 'images/tab_icon_setting_enable.svg', disabledIcon: 'images/tab_icon_setting_disable.svg', label: L.settings),
+    ];
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border),
+      ),
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          for (var i = 0; i < tabs.length; i++)
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(6),
+                  decoration: i == selectedIndex
+                      ? BoxDecoration(shape: BoxShape.circle, border: Border.all(color: AppColors.primary, width: 2))
+                      : null,
+                  child: SvgPicture.asset(
+                    i == selectedIndex ? tabs[i].icon : tabs[i].disabledIcon,
+                    width: 24,
+                    height: 24,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  tabs[i].label,
+                  style: TextStyle(
+                    fontSize: 10,
+                    fontFamily: FontFamily.japanese,
+                    color: i == selectedIndex ? AppColors.primary : TextColor.darkGray,
+                    fontWeight: i == selectedIndex ? FontWeight.w600 : FontWeight.w400,
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _featureCard({required IconData icon, required String text}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 22, color: AppColors.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              text,
+              style: const TextStyle(
+                fontSize: 14,
+                fontFamily: FontFamily.japanese,
+                fontWeight: FontWeight.w500,
+                color: TextColor.main,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// FirebaseAnalyticsObserver が自動で screen_view を送信するため、
+/// RouteSettings.name は必ず設定する (lib/app.dart で MaterialApp に登録済み)。
+extension CreatingNewPillSheetHelpPageRoute on CreatingNewPillSheetHelpPage {
+  static Route<dynamic> route() => MaterialPageRoute(
+        settings: const RouteSettings(name: 'CreatingNewPillSheetHelpPage'),
+        builder: (_) => const CreatingNewPillSheetHelpPage(),
+      );
+}

--- a/lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart
+++ b/lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart
@@ -19,6 +19,9 @@ class CriticalAlertHelpPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final user = ref.watch(userProvider).requireValue;
+    final setting = ref.watch(settingProvider).requireValue;
+
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -118,8 +121,6 @@ class CriticalAlertHelpPage extends ConsumerWidget {
           child: PrimaryButton(
             text: L.featureAppealTryFeature,
             onPressed: () async {
-              final user = ref.read(userProvider).requireValue;
-              final setting = ref.read(settingProvider).requireValue;
               analytics.logEvent(
                 name: 'feature_appeal_try_tapped',
                 parameters: {

--- a/lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart
+++ b/lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart
@@ -6,10 +6,9 @@ import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
-import 'package:pilll/features/settings/critical_alert/page.dart';
-import 'package:pilll/provider/setting.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
 
@@ -19,9 +18,6 @@ class CriticalAlertHelpPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final user = ref.watch(userProvider).requireValue;
-    final setting = ref.watch(settingProvider).requireValue;
-
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -123,6 +119,7 @@ class CriticalAlertHelpPage extends ConsumerWidget {
           child: PrimaryButton(
             text: L.featureAppealTryFeature,
             onPressed: () async {
+              final user = ref.read(userProvider).requireValue;
               analytics.logEvent(
                 name: 'feature_appeal_try_tapped',
                 parameters: {
@@ -139,9 +136,9 @@ class CriticalAlertHelpPage extends ConsumerWidget {
                 await showPremiumIntroductionSheet(context);
                 return;
               }
-              await Navigator.of(context).push(
-                CriticalAlertPageRoutes.route(setting: setting),
-              );
+              final tabController = ref.read(homeTabControllerProvider);
+              Navigator.of(context).popUntil((r) => r.isFirst);
+              tabController?.animateTo(HomePageTabType.setting.index);
             },
           ),
         ),

--- a/lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart
+++ b/lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart
@@ -46,13 +46,15 @@ class CriticalAlertHelpPage extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 32),
-            Text(
-              L.criticalAlertFeatureAppealHeadline,
-              style: const TextStyle(
-                fontSize: 22,
-                fontWeight: FontWeight.w700,
-                fontFamily: FontFamily.japanese,
-                color: TextColor.main,
+            Center(
+              child: Text(
+                L.criticalAlertFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
               ),
             ),
             const SizedBox(height: 20),

--- a/lib/features/feature_appeal/feature_appeal_bars_container.dart
+++ b/lib/features/feature_appeal/feature_appeal_bars_container.dart
@@ -1,14 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/features/feature_appeal/alarm_kit/alarm_kit_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/appearance_mode_date/appearance_mode_date_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/calendar_diary/calendar_diary_announcement_bar.dart';
+import 'package:pilll/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/critical_alert/critical_alert_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/future_schedule/future_schedule_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/health_care_integration/health_care_integration_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/menstruation/menstruation_announcement_bar.dart';
+import 'package:pilll/features/feature_appeal/quick_record/quick_record_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/record_pill/record_pill_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_announcement_bar.dart';
+import 'package:pilll/features/feature_appeal/rest_duration/rest_duration_announcement_bar.dart';
+import 'package:pilll/features/feature_appeal/today_pill_number/today_pill_number_announcement_bar.dart';
 import 'package:pilll/provider/shared_preferences.dart';
 import 'package:pilll/utils/datetime/date_compare.dart';
 import 'package:pilll/utils/datetime/day.dart';
@@ -46,6 +51,11 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
     final calendarDiaryIsClosed = useState(sharedPreferences.getBool(BoolKey.calendarDiaryFeatureAppealIsClosed) ?? false);
     final futureScheduleIsClosed = useState(sharedPreferences.getBool(BoolKey.futureScheduleFeatureAppealIsClosed) ?? false);
     final healthCareIntegrationIsClosed = useState(sharedPreferences.getBool(BoolKey.healthCareIntegrationFeatureAppealIsClosed) ?? false);
+    final quickRecordIsClosed = useState(sharedPreferences.getBool(BoolKey.quickRecordFeatureAppealIsClosed) ?? false);
+    final creatingNewPillSheetIsClosed = useState(sharedPreferences.getBool(BoolKey.creatingNewPillSheetFeatureAppealIsClosed) ?? false);
+    final alarmKitIsClosed = useState(sharedPreferences.getBool(BoolKey.alarmKitFeatureAppealIsClosed) ?? false);
+    final todayPillNumberIsClosed = useState(sharedPreferences.getBool(BoolKey.todayPillNumberFeatureAppealIsClosed) ?? false);
+    final restDurationIsClosed = useState(sharedPreferences.getBool(BoolKey.restDurationFeatureAppealIsClosed) ?? false);
 
     useEffect(() {
       void markDismissedToday() {
@@ -96,6 +106,31 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
         if (healthCareIntegrationIsClosed.value) markDismissedToday();
       }
 
+      void onQuickRecord() {
+        sharedPreferences.setBool(BoolKey.quickRecordFeatureAppealIsClosed, quickRecordIsClosed.value);
+        if (quickRecordIsClosed.value) markDismissedToday();
+      }
+
+      void onCreatingNewPillSheet() {
+        sharedPreferences.setBool(BoolKey.creatingNewPillSheetFeatureAppealIsClosed, creatingNewPillSheetIsClosed.value);
+        if (creatingNewPillSheetIsClosed.value) markDismissedToday();
+      }
+
+      void onAlarmKit() {
+        sharedPreferences.setBool(BoolKey.alarmKitFeatureAppealIsClosed, alarmKitIsClosed.value);
+        if (alarmKitIsClosed.value) markDismissedToday();
+      }
+
+      void onTodayPillNumber() {
+        sharedPreferences.setBool(BoolKey.todayPillNumberFeatureAppealIsClosed, todayPillNumberIsClosed.value);
+        if (todayPillNumberIsClosed.value) markDismissedToday();
+      }
+
+      void onRestDuration() {
+        sharedPreferences.setBool(BoolKey.restDurationFeatureAppealIsClosed, restDurationIsClosed.value);
+        if (restDurationIsClosed.value) markDismissedToday();
+      }
+
       criticalAlertIsClosed.addListener(onCriticalAlert);
       reminderNotificationCustomizeWordIsClosed.addListener(onReminderNotificationCustomizeWord);
       appearanceModeDateIsClosed.addListener(onAppearanceModeDate);
@@ -104,6 +139,11 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
       calendarDiaryIsClosed.addListener(onCalendarDiary);
       futureScheduleIsClosed.addListener(onFutureSchedule);
       healthCareIntegrationIsClosed.addListener(onHealthCareIntegration);
+      quickRecordIsClosed.addListener(onQuickRecord);
+      creatingNewPillSheetIsClosed.addListener(onCreatingNewPillSheet);
+      alarmKitIsClosed.addListener(onAlarmKit);
+      todayPillNumberIsClosed.addListener(onTodayPillNumber);
+      restDurationIsClosed.addListener(onRestDuration);
       return () {
         criticalAlertIsClosed.removeListener(onCriticalAlert);
         reminderNotificationCustomizeWordIsClosed.removeListener(onReminderNotificationCustomizeWord);
@@ -113,6 +153,11 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
         calendarDiaryIsClosed.removeListener(onCalendarDiary);
         futureScheduleIsClosed.removeListener(onFutureSchedule);
         healthCareIntegrationIsClosed.removeListener(onHealthCareIntegration);
+        quickRecordIsClosed.removeListener(onQuickRecord);
+        creatingNewPillSheetIsClosed.removeListener(onCreatingNewPillSheet);
+        alarmKitIsClosed.removeListener(onAlarmKit);
+        todayPillNumberIsClosed.removeListener(onTodayPillNumber);
+        restDurationIsClosed.removeListener(onRestDuration);
       };
     }, [sharedPreferences]);
 
@@ -126,6 +171,11 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
       if (!calendarDiaryIsClosed.value) CalendarDiaryAnnouncementBar(isClosed: calendarDiaryIsClosed),
       if (!futureScheduleIsClosed.value) FutureScheduleAnnouncementBar(isClosed: futureScheduleIsClosed),
       if (!healthCareIntegrationIsClosed.value) HealthCareIntegrationAnnouncementBar(isClosed: healthCareIntegrationIsClosed),
+      if (!quickRecordIsClosed.value) QuickRecordAnnouncementBar(isClosed: quickRecordIsClosed),
+      if (!creatingNewPillSheetIsClosed.value) CreatingNewPillSheetAnnouncementBar(isClosed: creatingNewPillSheetIsClosed),
+      if (!alarmKitIsClosed.value) AlarmKitAnnouncementBar(isClosed: alarmKitIsClosed),
+      if (!todayPillNumberIsClosed.value) TodayPillNumberAnnouncementBar(isClosed: todayPillNumberIsClosed),
+      if (!restDurationIsClosed.value) RestDurationAnnouncementBar(isClosed: restDurationIsClosed),
     ];
     if (candidates.isEmpty) {
       return const SizedBox.shrink();
@@ -160,6 +210,11 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
       !(sharedPreferences.getBool(BoolKey.calendarDiaryFeatureAppealIsClosed) ?? false),
       !(sharedPreferences.getBool(BoolKey.futureScheduleFeatureAppealIsClosed) ?? false),
       !(sharedPreferences.getBool(BoolKey.healthCareIntegrationFeatureAppealIsClosed) ?? false),
+      !(sharedPreferences.getBool(BoolKey.quickRecordFeatureAppealIsClosed) ?? false),
+      !(sharedPreferences.getBool(BoolKey.creatingNewPillSheetFeatureAppealIsClosed) ?? false),
+      !(sharedPreferences.getBool(BoolKey.alarmKitFeatureAppealIsClosed) ?? false),
+      !(sharedPreferences.getBool(BoolKey.todayPillNumberFeatureAppealIsClosed) ?? false),
+      !(sharedPreferences.getBool(BoolKey.restDurationFeatureAppealIsClosed) ?? false),
     ].any((available) => available);
   }
 }

--- a/lib/features/feature_appeal/feature_appeal_bars_container.dart
+++ b/lib/features/feature_appeal/feature_appeal_bars_container.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -162,7 +164,9 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
     }, [sharedPreferences]);
 
     final candidates = <Widget>[
-      if (!criticalAlertIsClosed.value) CriticalAlertAnnouncementBar(isClosed: criticalAlertIsClosed),
+      // CriticalAlert と AlarmKit の設定行は settings/page.dart で Platform.isIOS 配下にあるため、
+      // Bar も iOS に限定する (Android ユーザーが HelpPage から設定タブに飛んでも該当行がないため)。
+      if (Platform.isIOS && !criticalAlertIsClosed.value) CriticalAlertAnnouncementBar(isClosed: criticalAlertIsClosed),
       if (!reminderNotificationCustomizeWordIsClosed.value)
         ReminderNotificationCustomizeWordAnnouncementBar(isClosed: reminderNotificationCustomizeWordIsClosed),
       if (appIsReleased && !appearanceModeDateIsClosed.value) AppearanceModeDateAnnouncementBar(isClosed: appearanceModeDateIsClosed),
@@ -173,7 +177,7 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
       if (!healthCareIntegrationIsClosed.value) HealthCareIntegrationAnnouncementBar(isClosed: healthCareIntegrationIsClosed),
       if (!quickRecordIsClosed.value) QuickRecordAnnouncementBar(isClosed: quickRecordIsClosed),
       if (!creatingNewPillSheetIsClosed.value) CreatingNewPillSheetAnnouncementBar(isClosed: creatingNewPillSheetIsClosed),
-      if (!alarmKitIsClosed.value) AlarmKitAnnouncementBar(isClosed: alarmKitIsClosed),
+      if (Platform.isIOS && !alarmKitIsClosed.value) AlarmKitAnnouncementBar(isClosed: alarmKitIsClosed),
       if (!todayPillNumberIsClosed.value) TodayPillNumberAnnouncementBar(isClosed: todayPillNumberIsClosed),
       if (!restDurationIsClosed.value) RestDurationAnnouncementBar(isClosed: restDurationIsClosed),
     ];
@@ -202,7 +206,8 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
     required bool appIsReleased,
   }) {
     return [
-      !(sharedPreferences.getBool(BoolKey.criticalAlertFeatureAppealIsClosed) ?? false),
+      // CriticalAlert / AlarmKit は iOS 限定機能のため、Android では候補から除外する。
+      Platform.isIOS && !(sharedPreferences.getBool(BoolKey.criticalAlertFeatureAppealIsClosed) ?? false),
       !(sharedPreferences.getBool(BoolKey.reminderNotificationCustomizeWordFeatureAppealIsClosed) ?? false),
       appIsReleased && !(sharedPreferences.getBool(BoolKey.appearanceModeDateFeatureAppealIsClosed) ?? false),
       !(sharedPreferences.getBool(BoolKey.recordPillFeatureAppealIsClosed) ?? false),
@@ -212,7 +217,7 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
       !(sharedPreferences.getBool(BoolKey.healthCareIntegrationFeatureAppealIsClosed) ?? false),
       !(sharedPreferences.getBool(BoolKey.quickRecordFeatureAppealIsClosed) ?? false),
       !(sharedPreferences.getBool(BoolKey.creatingNewPillSheetFeatureAppealIsClosed) ?? false),
-      !(sharedPreferences.getBool(BoolKey.alarmKitFeatureAppealIsClosed) ?? false),
+      Platform.isIOS && !(sharedPreferences.getBool(BoolKey.alarmKitFeatureAppealIsClosed) ?? false),
       !(sharedPreferences.getBool(BoolKey.todayPillNumberFeatureAppealIsClosed) ?? false),
       !(sharedPreferences.getBool(BoolKey.restDurationFeatureAppealIsClosed) ?? false),
     ].any((available) => available);

--- a/lib/features/feature_appeal/future_schedule/future_schedule_help_page.dart
+++ b/lib/features/feature_appeal/future_schedule/future_schedule_help_page.dart
@@ -39,13 +39,15 @@ class FutureScheduleHelpPage extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 32),
-            Text(
-              L.futureScheduleFeatureAppealHeadline,
-              style: const TextStyle(
-                fontSize: 22,
-                fontWeight: FontWeight.w700,
-                fontFamily: FontFamily.japanese,
-                color: TextColor.main,
+            Center(
+              child: Text(
+                L.futureScheduleFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
               ),
             ),
             const SizedBox(height: 20),

--- a/lib/features/feature_appeal/health_care_integration/health_care_integration_help_page.dart
+++ b/lib/features/feature_appeal/health_care_integration/health_care_integration_help_page.dart
@@ -40,13 +40,15 @@ class HealthCareIntegrationHelpPage extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 32),
-            Text(
-              L.healthCareIntegrationFeatureAppealHeadline,
-              style: const TextStyle(
-                fontSize: 22,
-                fontWeight: FontWeight.w700,
-                fontFamily: FontFamily.japanese,
-                color: TextColor.main,
+            Center(
+              child: Text(
+                L.healthCareIntegrationFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
               ),
             ),
             const SizedBox(height: 20),

--- a/lib/features/feature_appeal/menstruation/menstruation_help_page.dart
+++ b/lib/features/feature_appeal/menstruation/menstruation_help_page.dart
@@ -37,13 +37,15 @@ class MenstruationHelpPage extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 32),
-            Text(
-              L.menstruationFeatureAppealHeadline,
-              style: const TextStyle(
-                fontSize: 22,
-                fontWeight: FontWeight.w700,
-                fontFamily: FontFamily.japanese,
-                color: TextColor.main,
+            Center(
+              child: Text(
+                L.menstruationFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
               ),
             ),
             const SizedBox(height: 20),

--- a/lib/features/feature_appeal/menstruation/menstruation_help_page.dart
+++ b/lib/features/feature_appeal/menstruation/menstruation_help_page.dart
@@ -1,19 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/components/atoms/button.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
-import 'package:pilll/features/settings/menstruation/page.dart';
 import 'package:pilll/utils/analytics.dart';
 
-/// 生理記録 (無料機能) の説明と「実際に試す」導線を持つヘルプページ。
-class MenstruationHelpPage extends StatelessWidget {
+/// 生理記録 (無料機能) の説明と「確認する」導線を持つヘルプページ。
+class MenstruationHelpPage extends ConsumerWidget {
   const MenstruationHelpPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -106,7 +107,9 @@ class MenstruationHelpPage extends StatelessWidget {
                   'is_paywall_shown': 0,
                 },
               );
-              Navigator.of(context).push(SettingMenstruationPageRoute.route());
+              final tabController = ref.read(homeTabControllerProvider);
+              Navigator.of(context).popUntil((r) => r.isFirst);
+              tabController?.animateTo(HomePageTabType.setting.index);
             },
           ),
         ),

--- a/lib/features/feature_appeal/quick_record/quick_record_announcement_bar.dart
+++ b/lib/features/feature_appeal/quick_record/quick_record_announcement_bar.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/features/feature_appeal/quick_record/quick_record_help_page.dart';
+import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/utils/analytics.dart';
+
+/// クイックレコード (Premium機能) を AnnouncementBar 領域でアピールする Bar。
+class QuickRecordAnnouncementBar extends StatelessWidget {
+  /// 親 (FeatureAppealBarsContainer) が所有する dismissed フラグ。× ボタン押下で true にする。
+  final ValueNotifier<bool> isClosed;
+  const QuickRecordAnnouncementBar({super.key, required this.isClosed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.primary,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+      child: GestureDetector(
+        onTap: () {
+          analytics.logEvent(
+            name: 'feature_appeal_bar_tapped',
+            parameters: {'feature_key': 'quick_record', 'feature_type': 'premium'},
+          );
+          Navigator.of(context).push(QuickRecordHelpPageRoute.route());
+        },
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Semantics(
+              identifier: 'feature_appeal_dismiss_button',
+              child: IconButton(
+                tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+                icon: const Icon(Icons.close, color: Colors.white, size: 24),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+                onPressed: () {
+                  analytics.logEvent(
+                    name: 'feature_appeal_bar_dismissed',
+                    parameters: {'feature_key': 'quick_record', 'feature_type': 'premium'},
+                  );
+                  isClosed.value = true;
+                },
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    L.quickRecordFeatureAppealTitle,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontFamily: FontFamily.japanese,
+                      fontWeight: FontWeight.w700,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    L.quickRecordFeatureAppealShortDescription,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontFamily: FontFamily.japanese,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 10),
+            SvgPicture.asset(
+              'images/arrow_right.svg',
+              colorFilter: const ColorFilter.mode(Colors.white, BlendMode.srcIn),
+              height: 16,
+              width: 16,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/feature_appeal/quick_record/quick_record_help_page.dart
+++ b/lib/features/feature_appeal/quick_record/quick_record_help_page.dart
@@ -1,0 +1,245 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/home/page.dart';
+import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
+import 'package:pilll/provider/user.dart';
+import 'package:pilll/utils/analytics.dart';
+
+/// クイックレコード (Premium機能: 通知アクションから服用記録) の説明と「実際に試す」導線を持つヘルプページ。
+/// 「実際に試す」では設定タブへ案内する (設定画面のクイックレコード行から案内される)。
+/// 非 Premium / 非トライアルユーザーには PremiumIntroductionSheet を開く。
+class QuickRecordHelpPage extends ConsumerWidget {
+  const QuickRecordHelpPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        title: Text(L.quickRecordFeatureAppealTitle),
+        backgroundColor: AppColors.background,
+        leading: IconButton(
+          onPressed: () => Navigator.of(context).pop(),
+          icon: const Icon(Icons.arrow_back),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(24, 24, 24, 40),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: SvgPicture.asset(
+                'images/dots.svg',
+                width: 80,
+                height: 80,
+                colorFilter: const ColorFilter.mode(AppColors.primary, BlendMode.srcIn),
+              ),
+            ),
+            const SizedBox(height: 32),
+            Center(
+              child: Text(
+                L.quickRecordFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            _featureCard(icon: Icons.notifications_active, text: L.quickRecordFeatureAppealPoint1),
+            const SizedBox(height: 8),
+            _featureCard(icon: Icons.touch_app, text: L.quickRecordFeatureAppealPoint2),
+            const SizedBox(height: 8),
+            _featureCard(icon: Icons.settings, text: L.quickRecordFeatureAppealPoint3),
+            const SizedBox(height: 24),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: Image.asset(
+                Platform.isIOS ? 'images/ios-quick-record.gif' : 'images/android-quick-record.gif',
+              ),
+            ),
+            const SizedBox(height: 28),
+            Text(
+              L.featureAppealLocationLabel,
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                fontFamily: FontFamily.japanese,
+                color: TextColor.darkGray,
+              ),
+            ),
+            const SizedBox(height: 8),
+            _mockTabBar(selectedIndex: 3),
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 6),
+              child: Center(child: Icon(Icons.arrow_downward, size: 28, color: AppColors.primary)),
+            ),
+            Container(
+              decoration: BoxDecoration(
+                color: AppColors.white,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: AppColors.primary, width: 1.5),
+              ),
+              child: IgnorePointer(
+                child: ListTile(
+                  title: Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          L.quickRecord,
+                          style: const TextStyle(
+                            fontFamily: FontFamily.japanese,
+                            fontWeight: FontWeight.w300,
+                            fontSize: 16,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      const PremiumBadge(),
+                    ],
+                  ),
+                  subtitle: Text(
+                    L.quickRecordDescription,
+                    style: const TextStyle(
+                      fontFamily: FontFamily.japanese,
+                      fontWeight: FontWeight.w300,
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: PrimaryButton(
+            text: L.featureAppealTryFeature,
+            onPressed: () async {
+              final user = ref.read(userProvider).requireValue;
+              analytics.logEvent(
+                name: 'feature_appeal_try_tapped',
+                parameters: {
+                  'feature_key': 'quick_record',
+                  'feature_type': 'premium',
+                  'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+                },
+              );
+              if (!user.premiumOrTrial) {
+                analytics.logEvent(
+                  name: 'feature_appeal_paywall_shown',
+                  parameters: {'feature_key': 'quick_record'},
+                );
+                await showPremiumIntroductionSheet(context);
+                return;
+              }
+              final tabController = ref.read(homeTabControllerProvider);
+              Navigator.of(context).popUntil((r) => r.isFirst);
+              tabController?.animateTo(HomePageTabType.setting.index);
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _mockTabBar({required int selectedIndex}) {
+    final tabs = [
+      (icon: 'images/tab_icon_pill_enable.svg', disabledIcon: 'images/tab_icon_pill_disable.svg', label: L.pill),
+      (icon: 'images/menstruation.svg', disabledIcon: 'images/menstruation_disable.svg', label: L.menstruation),
+      (icon: 'images/tab_icon_calendar_enable.svg', disabledIcon: 'images/tab_icon_calendar_disable.svg', label: L.calendar),
+      (icon: 'images/tab_icon_setting_enable.svg', disabledIcon: 'images/tab_icon_setting_disable.svg', label: L.settings),
+    ];
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border),
+      ),
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          for (var i = 0; i < tabs.length; i++)
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(6),
+                  decoration: i == selectedIndex
+                      ? BoxDecoration(shape: BoxShape.circle, border: Border.all(color: AppColors.primary, width: 2))
+                      : null,
+                  child: SvgPicture.asset(
+                    i == selectedIndex ? tabs[i].icon : tabs[i].disabledIcon,
+                    width: 24,
+                    height: 24,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  tabs[i].label,
+                  style: TextStyle(
+                    fontSize: 10,
+                    fontFamily: FontFamily.japanese,
+                    color: i == selectedIndex ? AppColors.primary : TextColor.darkGray,
+                    fontWeight: i == selectedIndex ? FontWeight.w600 : FontWeight.w400,
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _featureCard({required IconData icon, required String text}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 22, color: AppColors.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              text,
+              style: const TextStyle(
+                fontSize: 14,
+                fontFamily: FontFamily.japanese,
+                fontWeight: FontWeight.w500,
+                color: TextColor.main,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// FirebaseAnalyticsObserver が自動で screen_view を送信するため、
+/// RouteSettings.name は必ず設定する (lib/app.dart で MaterialApp に登録済み)。
+extension QuickRecordHelpPageRoute on QuickRecordHelpPage {
+  static Route<dynamic> route() => MaterialPageRoute(
+        settings: const RouteSettings(name: 'QuickRecordHelpPage'),
+        builder: (_) => const QuickRecordHelpPage(),
+      );
+}

--- a/lib/features/feature_appeal/quick_record/quick_record_help_page.dart
+++ b/lib/features/feature_appeal/quick_record/quick_record_help_page.dart
@@ -62,7 +62,7 @@ class QuickRecordHelpPage extends ConsumerWidget {
             const SizedBox(height: 8),
             _featureCard(icon: Icons.touch_app, text: L.quickRecordFeatureAppealPoint2),
             const SizedBox(height: 8),
-            _featureCard(icon: Icons.settings, text: L.quickRecordFeatureAppealPoint3),
+            _featureCard(icon: Icons.workspace_premium, text: L.quickRecordFeatureAppealPoint3),
             const SizedBox(height: 24),
             ClipRRect(
               borderRadius: BorderRadius.circular(12),

--- a/lib/features/feature_appeal/record_pill/record_pill_help_page.dart
+++ b/lib/features/feature_appeal/record_pill/record_pill_help_page.dart
@@ -1,19 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/components/atoms/button.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
-import 'package:pilll/features/pill_sheet_modified_history/page.dart';
 import 'package:pilll/utils/analytics.dart';
 
-/// ピル記録/服用履歴 (無料機能) の説明と「実際に試す」導線を持つヘルプページ。
-class RecordPillHelpPage extends StatelessWidget {
+/// ピル記録/服用履歴 (無料機能) の説明と「確認する」導線を持つヘルプページ。
+class RecordPillHelpPage extends ConsumerWidget {
   const RecordPillHelpPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -99,27 +100,6 @@ class RecordPillHelpPage extends StatelessWidget {
                 ],
               ),
             ),
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 6),
-              child: Center(child: Icon(Icons.arrow_downward, size: 28, color: AppColors.primary)),
-            ),
-            Container(
-              decoration: BoxDecoration(
-                color: AppColors.white,
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(color: AppColors.border),
-              ),
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-              child: Column(
-                children: [
-                  _mockHistoryRow(day: DateTime.now().subtract(const Duration(days: 2)), pillNumber: 1, time: '19:00'),
-                  const Divider(height: 16),
-                  _mockHistoryRow(day: DateTime.now().subtract(const Duration(days: 1)), pillNumber: 2, time: '19:30'),
-                  const Divider(height: 16),
-                  _mockHistoryRow(day: DateTime.now(), pillNumber: 3, time: '20:00'),
-                ],
-              ),
-            ),
           ],
         ),
       ),
@@ -137,7 +117,9 @@ class RecordPillHelpPage extends StatelessWidget {
                   'is_paywall_shown': 0,
                 },
               );
-              Navigator.of(context).push(PillSheetModifiedHistoriesPageRoute.route());
+              final tabController = ref.read(homeTabControllerProvider);
+              Navigator.of(context).popUntil((r) => r.isFirst);
+              tabController?.animateTo(HomePageTabType.record.index);
             },
           ),
         ),
@@ -191,40 +173,6 @@ class RecordPillHelpPage extends StatelessWidget {
             ),
         ],
       ),
-    );
-  }
-
-  Widget _mockHistoryRow({required DateTime day, required int pillNumber, required String time}) {
-    return Row(
-      children: [
-        SizedBox(
-          width: 40,
-          child: Text(
-            '${day.month}/${day.day}',
-            style: const TextStyle(fontSize: 12, fontFamily: FontFamily.number, color: TextColor.main),
-          ),
-        ),
-        const SizedBox(width: 8),
-        Container(height: 20, width: 0.5, color: AppColors.border),
-        const SizedBox(width: 8),
-        SizedBox(
-          width: 50,
-          child: Text(
-            '$pillNumber番',
-            style: const TextStyle(fontSize: 12, fontFamily: FontFamily.japanese, fontWeight: FontWeight.w500, color: TextColor.main),
-          ),
-        ),
-        const SizedBox(width: 8),
-        Text(
-          time,
-          style: const TextStyle(fontSize: 12, fontFamily: FontFamily.number, color: TextColor.darkGray),
-        ),
-        const Spacer(),
-        for (var i = 0; i < pillNumber; i++) ...[
-          if (i > 0) const SizedBox(width: 2),
-          Container(width: 8, height: 8, decoration: const BoxDecoration(color: AppColors.primary, shape: BoxShape.circle)),
-        ],
-      ],
     );
   }
 

--- a/lib/features/feature_appeal/record_pill/record_pill_help_page.dart
+++ b/lib/features/feature_appeal/record_pill/record_pill_help_page.dart
@@ -37,13 +37,15 @@ class RecordPillHelpPage extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 32),
-            Text(
-              L.recordPillFeatureAppealHeadline,
-              style: const TextStyle(
-                fontSize: 22,
-                fontWeight: FontWeight.w700,
-                fontFamily: FontFamily.japanese,
-                color: TextColor.main,
+            Center(
+              child: Text(
+                L.recordPillFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
               ),
             ),
             const SizedBox(height: 20),

--- a/lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart
+++ b/lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart
@@ -6,9 +6,9 @@ import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
-import 'package:pilll/features/reminder_notification_customize_word/page.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
 
@@ -18,8 +18,6 @@ class ReminderNotificationCustomizeWordHelpPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final user = ref.watch(userProvider).requireValue;
-
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -119,6 +117,7 @@ class ReminderNotificationCustomizeWordHelpPage extends ConsumerWidget {
           child: PrimaryButton(
             text: L.featureAppealTryFeature,
             onPressed: () async {
+              final user = ref.read(userProvider).requireValue;
               analytics.logEvent(
                 name: 'feature_appeal_try_tapped',
                 parameters: {
@@ -135,7 +134,9 @@ class ReminderNotificationCustomizeWordHelpPage extends ConsumerWidget {
                 await showPremiumIntroductionSheet(context);
                 return;
               }
-              await Navigator.of(context).push(ReminderNotificationCustomizeWordPageRoutes.route());
+              final tabController = ref.read(homeTabControllerProvider);
+              Navigator.of(context).popUntil((r) => r.isFirst);
+              tabController?.animateTo(HomePageTabType.setting.index);
             },
           ),
         ),

--- a/lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart
+++ b/lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart
@@ -44,13 +44,15 @@ class ReminderNotificationCustomizeWordHelpPage extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 32),
-            Text(
-              L.reminderNotificationCustomizeWordFeatureAppealHeadline,
-              style: const TextStyle(
-                fontSize: 22,
-                fontWeight: FontWeight.w700,
-                fontFamily: FontFamily.japanese,
-                color: TextColor.main,
+            Center(
+              child: Text(
+                L.reminderNotificationCustomizeWordFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
               ),
             ),
             const SizedBox(height: 20),

--- a/lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart
+++ b/lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart
@@ -18,6 +18,8 @@ class ReminderNotificationCustomizeWordHelpPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final user = ref.watch(userProvider).requireValue;
+
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -115,7 +117,6 @@ class ReminderNotificationCustomizeWordHelpPage extends ConsumerWidget {
           child: PrimaryButton(
             text: L.featureAppealTryFeature,
             onPressed: () async {
-              final user = ref.read(userProvider).requireValue;
               analytics.logEvent(
                 name: 'feature_appeal_try_tapped',
                 parameters: {

--- a/lib/features/feature_appeal/rest_duration/rest_duration_announcement_bar.dart
+++ b/lib/features/feature_appeal/rest_duration/rest_duration_announcement_bar.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/features/feature_appeal/rest_duration/rest_duration_help_page.dart';
+import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/utils/analytics.dart';
+
+/// 服用おやすみ (無料機能) を AnnouncementBar 領域でアピールする Bar。
+class RestDurationAnnouncementBar extends StatelessWidget {
+  /// 親 (FeatureAppealBarsContainer) が所有する dismissed フラグ。× ボタン押下で true にする。
+  final ValueNotifier<bool> isClosed;
+  const RestDurationAnnouncementBar({super.key, required this.isClosed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.primary,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+      child: GestureDetector(
+        onTap: () {
+          analytics.logEvent(
+            name: 'feature_appeal_bar_tapped',
+            parameters: {'feature_key': 'rest_duration', 'feature_type': 'free'},
+          );
+          Navigator.of(context).push(RestDurationHelpPageRoute.route());
+        },
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Semantics(
+              identifier: 'feature_appeal_dismiss_button',
+              child: IconButton(
+                tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+                icon: const Icon(Icons.close, color: Colors.white, size: 24),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+                onPressed: () {
+                  analytics.logEvent(
+                    name: 'feature_appeal_bar_dismissed',
+                    parameters: {'feature_key': 'rest_duration', 'feature_type': 'free'},
+                  );
+                  isClosed.value = true;
+                },
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    L.restDurationFeatureAppealTitle,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontFamily: FontFamily.japanese,
+                      fontWeight: FontWeight.w700,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    L.restDurationFeatureAppealShortDescription,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontFamily: FontFamily.japanese,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 10),
+            SvgPicture.asset(
+              'images/arrow_right.svg',
+              colorFilter: const ColorFilter.mode(Colors.white, BlendMode.srcIn),
+              height: 16,
+              width: 16,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/feature_appeal/rest_duration/rest_duration_help_page.dart
+++ b/lib/features/feature_appeal/rest_duration/rest_duration_help_page.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/features/home/page.dart';
+import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/utils/analytics.dart';
+
+/// 服用おやすみ (無料機能) の説明と「実際に試す」導線を持つヘルプページ。
+/// 「実際に試す」ではピル記録タブへ案内する (ピルシート右上の歯車から「服用をお休みする」を開く動線)。
+class RestDurationHelpPage extends ConsumerWidget {
+  const RestDurationHelpPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        title: Text(L.restDurationFeatureAppealTitle),
+        backgroundColor: AppColors.background,
+        leading: IconButton(
+          onPressed: () => Navigator.of(context).pop(),
+          icon: const Icon(Icons.arrow_back),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(24, 24, 24, 40),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: SvgPicture.asset(
+                'images/explain_rest_duration_date.svg',
+                width: 80,
+                height: 80,
+              ),
+            ),
+            const SizedBox(height: 32),
+            Center(
+              child: Text(
+                L.restDurationFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            _featureCard(icon: Icons.dark_mode_outlined, text: L.restDurationFeatureAppealPoint1),
+            const SizedBox(height: 8),
+            _featureCard(icon: Icons.settings, text: L.restDurationFeatureAppealPoint2),
+            const SizedBox(height: 8),
+            _featureCard(icon: Icons.event_repeat, text: L.restDurationFeatureAppealPoint3),
+            const SizedBox(height: 28),
+            Text(
+              L.featureAppealLocationLabel,
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                fontFamily: FontFamily.japanese,
+                color: TextColor.darkGray,
+              ),
+            ),
+            const SizedBox(height: 8),
+            _mockTabBar(selectedIndex: 0),
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 6),
+              child: Center(child: Icon(Icons.arrow_downward, size: 28, color: AppColors.primary)),
+            ),
+            Container(
+              decoration: BoxDecoration(
+                color: AppColors.white,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: AppColors.primary, width: 1.5),
+              ),
+              child: IgnorePointer(
+                child: ListTile(
+                  leading: const Icon(Icons.settings, color: AppColors.primary),
+                  title: Text(
+                    L.startPauseTaking,
+                    style: const TextStyle(
+                      fontFamily: FontFamily.japanese,
+                      fontWeight: FontWeight.w300,
+                      fontSize: 16,
+                    ),
+                  ),
+                  trailing: const Icon(Icons.chevron_right),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: PrimaryButton(
+            text: L.featureAppealTryFeature,
+            onPressed: () async {
+              analytics.logEvent(
+                name: 'feature_appeal_try_tapped',
+                parameters: {
+                  'feature_key': 'rest_duration',
+                  'feature_type': 'free',
+                  'is_paywall_shown': 0,
+                },
+              );
+              final tabController = ref.read(homeTabControllerProvider);
+              Navigator.of(context).popUntil((r) => r.isFirst);
+              tabController?.animateTo(HomePageTabType.record.index);
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _mockTabBar({required int selectedIndex}) {
+    final tabs = [
+      (icon: 'images/tab_icon_pill_enable.svg', disabledIcon: 'images/tab_icon_pill_disable.svg', label: L.pill),
+      (icon: 'images/menstruation.svg', disabledIcon: 'images/menstruation_disable.svg', label: L.menstruation),
+      (icon: 'images/tab_icon_calendar_enable.svg', disabledIcon: 'images/tab_icon_calendar_disable.svg', label: L.calendar),
+      (icon: 'images/tab_icon_setting_enable.svg', disabledIcon: 'images/tab_icon_setting_disable.svg', label: L.settings),
+    ];
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border),
+      ),
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          for (var i = 0; i < tabs.length; i++)
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(6),
+                  decoration: i == selectedIndex
+                      ? BoxDecoration(shape: BoxShape.circle, border: Border.all(color: AppColors.primary, width: 2))
+                      : null,
+                  child: SvgPicture.asset(
+                    i == selectedIndex ? tabs[i].icon : tabs[i].disabledIcon,
+                    width: 24,
+                    height: 24,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  tabs[i].label,
+                  style: TextStyle(
+                    fontSize: 10,
+                    fontFamily: FontFamily.japanese,
+                    color: i == selectedIndex ? AppColors.primary : TextColor.darkGray,
+                    fontWeight: i == selectedIndex ? FontWeight.w600 : FontWeight.w400,
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _featureCard({required IconData icon, required String text}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 22, color: AppColors.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              text,
+              style: const TextStyle(
+                fontSize: 14,
+                fontFamily: FontFamily.japanese,
+                fontWeight: FontWeight.w500,
+                color: TextColor.main,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// FirebaseAnalyticsObserver が自動で screen_view を送信するため、
+/// RouteSettings.name は必ず設定する (lib/app.dart で MaterialApp に登録済み)。
+extension RestDurationHelpPageRoute on RestDurationHelpPage {
+  static Route<dynamic> route() => MaterialPageRoute(
+        settings: const RouteSettings(name: 'RestDurationHelpPage'),
+        builder: (_) => const RestDurationHelpPage(),
+      );
+}

--- a/lib/features/feature_appeal/today_pill_number/today_pill_number_announcement_bar.dart
+++ b/lib/features/feature_appeal/today_pill_number/today_pill_number_announcement_bar.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/features/feature_appeal/today_pill_number/today_pill_number_help_page.dart';
+import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/utils/analytics.dart';
+
+/// 今日の服用番号変更 (無料機能) を AnnouncementBar 領域でアピールする Bar。
+class TodayPillNumberAnnouncementBar extends StatelessWidget {
+  /// 親 (FeatureAppealBarsContainer) が所有する dismissed フラグ。× ボタン押下で true にする。
+  final ValueNotifier<bool> isClosed;
+  const TodayPillNumberAnnouncementBar({super.key, required this.isClosed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.primary,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+      child: GestureDetector(
+        onTap: () {
+          analytics.logEvent(
+            name: 'feature_appeal_bar_tapped',
+            parameters: {'feature_key': 'today_pill_number', 'feature_type': 'free'},
+          );
+          Navigator.of(context).push(TodayPillNumberHelpPageRoute.route());
+        },
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Semantics(
+              identifier: 'feature_appeal_dismiss_button',
+              child: IconButton(
+                tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+                icon: const Icon(Icons.close, color: Colors.white, size: 24),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+                onPressed: () {
+                  analytics.logEvent(
+                    name: 'feature_appeal_bar_dismissed',
+                    parameters: {'feature_key': 'today_pill_number', 'feature_type': 'free'},
+                  );
+                  isClosed.value = true;
+                },
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    L.todayPillNumberFeatureAppealTitle,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontFamily: FontFamily.japanese,
+                      fontWeight: FontWeight.w700,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    L.todayPillNumberFeatureAppealShortDescription,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontFamily: FontFamily.japanese,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 10),
+            SvgPicture.asset(
+              'images/arrow_right.svg',
+              colorFilter: const ColorFilter.mode(Colors.white, BlendMode.srcIn),
+              height: 16,
+              width: 16,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/feature_appeal/today_pill_number/today_pill_number_help_page.dart
+++ b/lib/features/feature_appeal/today_pill_number/today_pill_number_help_page.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/features/home/page.dart';
+import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/utils/analytics.dart';
+
+/// 今日の服用番号変更 (無料機能) の説明と「実際に試す」導線を持つヘルプページ。
+/// 「実際に試す」では設定タブへ案内する (設定画面の TodayPllNumberRow からページに遷移する)。
+class TodayPillNumberHelpPage extends ConsumerWidget {
+  const TodayPillNumberHelpPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        title: Text(L.todayPillNumberFeatureAppealTitle),
+        backgroundColor: AppColors.background,
+        leading: IconButton(
+          onPressed: () => Navigator.of(context).pop(),
+          icon: const Icon(Icons.arrow_back),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(24, 24, 24, 40),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: SvgPicture.asset(
+                'images/display_number_edit_icon.svg',
+                width: 80,
+                height: 80,
+                colorFilter: const ColorFilter.mode(AppColors.primary, BlendMode.srcIn),
+              ),
+            ),
+            const SizedBox(height: 32),
+            Center(
+              child: Text(
+                L.todayPillNumberFeatureAppealHeadline,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.japanese,
+                  color: TextColor.main,
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            _featureCard(icon: Icons.edit, text: L.todayPillNumberFeatureAppealPoint1),
+            const SizedBox(height: 8),
+            _featureCard(icon: Icons.settings, text: L.todayPillNumberFeatureAppealPoint2),
+            const SizedBox(height: 8),
+            _featureCard(icon: Icons.touch_app, text: L.todayPillNumberFeatureAppealPoint3),
+            const SizedBox(height: 28),
+            Text(
+              L.featureAppealLocationLabel,
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                fontFamily: FontFamily.japanese,
+                color: TextColor.darkGray,
+              ),
+            ),
+            const SizedBox(height: 8),
+            _mockTabBar(selectedIndex: 3),
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 6),
+              child: Center(child: Icon(Icons.arrow_downward, size: 28, color: AppColors.primary)),
+            ),
+            Container(
+              decoration: BoxDecoration(
+                color: AppColors.white,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: AppColors.primary, width: 1.5),
+              ),
+              child: IgnorePointer(
+                child: ListTile(
+                  title: Text(
+                    L.changePillNumberForToday,
+                    style: const TextStyle(
+                      fontFamily: FontFamily.japanese,
+                      fontWeight: FontWeight.w300,
+                      fontSize: 16,
+                    ),
+                  ),
+                  trailing: const Icon(Icons.chevron_right),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: PrimaryButton(
+            text: L.featureAppealTryFeature,
+            onPressed: () async {
+              analytics.logEvent(
+                name: 'feature_appeal_try_tapped',
+                parameters: {
+                  'feature_key': 'today_pill_number',
+                  'feature_type': 'free',
+                  'is_paywall_shown': 0,
+                },
+              );
+              final tabController = ref.read(homeTabControllerProvider);
+              Navigator.of(context).popUntil((r) => r.isFirst);
+              tabController?.animateTo(HomePageTabType.setting.index);
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _mockTabBar({required int selectedIndex}) {
+    final tabs = [
+      (icon: 'images/tab_icon_pill_enable.svg', disabledIcon: 'images/tab_icon_pill_disable.svg', label: L.pill),
+      (icon: 'images/menstruation.svg', disabledIcon: 'images/menstruation_disable.svg', label: L.menstruation),
+      (icon: 'images/tab_icon_calendar_enable.svg', disabledIcon: 'images/tab_icon_calendar_disable.svg', label: L.calendar),
+      (icon: 'images/tab_icon_setting_enable.svg', disabledIcon: 'images/tab_icon_setting_disable.svg', label: L.settings),
+    ];
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border),
+      ),
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          for (var i = 0; i < tabs.length; i++)
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(6),
+                  decoration: i == selectedIndex
+                      ? BoxDecoration(shape: BoxShape.circle, border: Border.all(color: AppColors.primary, width: 2))
+                      : null,
+                  child: SvgPicture.asset(
+                    i == selectedIndex ? tabs[i].icon : tabs[i].disabledIcon,
+                    width: 24,
+                    height: 24,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  tabs[i].label,
+                  style: TextStyle(
+                    fontSize: 10,
+                    fontFamily: FontFamily.japanese,
+                    color: i == selectedIndex ? AppColors.primary : TextColor.darkGray,
+                    fontWeight: i == selectedIndex ? FontWeight.w600 : FontWeight.w400,
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _featureCard({required IconData icon, required String text}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 22, color: AppColors.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              text,
+              style: const TextStyle(
+                fontSize: 14,
+                fontFamily: FontFamily.japanese,
+                fontWeight: FontWeight.w500,
+                color: TextColor.main,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// FirebaseAnalyticsObserver が自動で screen_view を送信するため、
+/// RouteSettings.name は必ず設定する (lib/app.dart で MaterialApp に登録済み)。
+extension TodayPillNumberHelpPageRoute on TodayPillNumberHelpPage {
+  static Route<dynamic> route() => MaterialPageRoute(
+        settings: const RouteSettings(name: 'TodayPillNumberHelpPage'),
+        builder: (_) => const TodayPillNumberHelpPage(),
+      );
+}

--- a/lib/features/settings/components/rows/feature_appeal_help_page_list_page.dart
+++ b/lib/features/settings/components/rows/feature_appeal_help_page_list_page.dart
@@ -1,13 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/features/feature_appeal/alarm_kit/alarm_kit_help_page.dart';
 import 'package:pilll/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart';
 import 'package:pilll/features/feature_appeal/calendar_diary/calendar_diary_help_page.dart';
+import 'package:pilll/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page.dart';
 import 'package:pilll/features/feature_appeal/critical_alert/critical_alert_help_page.dart';
 import 'package:pilll/features/feature_appeal/future_schedule/future_schedule_help_page.dart';
 import 'package:pilll/features/feature_appeal/health_care_integration/health_care_integration_help_page.dart';
 import 'package:pilll/features/feature_appeal/menstruation/menstruation_help_page.dart';
+import 'package:pilll/features/feature_appeal/quick_record/quick_record_help_page.dart';
 import 'package:pilll/features/feature_appeal/record_pill/record_pill_help_page.dart';
 import 'package:pilll/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart';
+import 'package:pilll/features/feature_appeal/rest_duration/rest_duration_help_page.dart';
+import 'package:pilll/features/feature_appeal/today_pill_number/today_pill_number_help_page.dart';
 
 /// FeatureAppeal の全 HelpPage への遷移リンクを一覧表示するページ。
 /// 開発者オプションからアクセスし、各ページの内容を確認・評価する用途。
@@ -25,6 +30,11 @@ class FeatureAppealHelpPageListPage extends StatelessWidget {
       (label: 'カレンダー・日記', type: 'free', routeFactory: CalendarDiaryHelpPageRoute.route),
       (label: '未来の予定', type: 'free', routeFactory: FutureScheduleHelpPageRoute.route),
       (label: 'ヘルスケア連携', type: 'free', routeFactory: HealthCareIntegrationHelpPageRoute.route),
+      (label: 'クイックレコード', type: 'premium', routeFactory: QuickRecordHelpPageRoute.route),
+      (label: 'ピルシート自動追加', type: 'premium', routeFactory: CreatingNewPillSheetHelpPageRoute.route),
+      (label: 'AlarmKit (iOS 26+)', type: 'premium', routeFactory: AlarmKitHelpPageRoute.route),
+      (label: '今日の服用番号変更', type: 'free', routeFactory: TodayPillNumberHelpPageRoute.route),
+      (label: '服用おやすみ', type: 'free', routeFactory: RestDurationHelpPageRoute.route),
     ];
 
     return Scaffold(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2403,7 +2403,7 @@
   "@inquiryContentRequired": {
     "description": "お問い合わせフォームで内容が未入力の場合に表示されるバリデーションエラーメッセージです。"
   },
-  "featureAppealTryFeature": "Try this feature",
+  "featureAppealTryFeature": "View",
   "@featureAppealTryFeature": {
     "description": "FeatureAppealのヘルプページのフッターに表示する「実際にこの機能を試す」ボタンのラベル"
   },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2544,5 +2544,90 @@
     "description": "ヘルスケア連携機能のヘルプページの本文"
   },
   "calendarDiaryFeatureAppealLocationHint": "Tap a date to log how you feel",
-  "futureScheduleFeatureAppealLocationHint": "Tap a date to add a plan"
+  "futureScheduleFeatureAppealLocationHint": "Tap a date to add a plan",
+
+  "quickRecordFeatureAppealTitle": "Record from the notification",
+  "@quickRecordFeatureAppealTitle": {
+    "description": "クイックレコード機能のFeatureAppeal Barタイトル"
+  },
+  "quickRecordFeatureAppealShortDescription": "Log your dose right from the push",
+  "@quickRecordFeatureAppealShortDescription": {
+    "description": "クイックレコード機能のFeatureAppeal Barの短い説明文"
+  },
+  "quickRecordFeatureAppealHeadline": "Tap the notification to record",
+  "@quickRecordFeatureAppealHeadline": {
+    "description": "クイックレコード機能のヘルプページのヘッドライン"
+  },
+  "quickRecordFeatureAppealBody": "Long-press the reminder notification to reveal a \"Taken\" action and log your dose without opening the app.",
+  "@quickRecordFeatureAppealBody": {
+    "description": "クイックレコード機能のヘルプページの本文"
+  },
+
+  "creatingNewPillSheetFeatureAppealTitle": "Automatically add a new pill sheet",
+  "@creatingNewPillSheetFeatureAppealTitle": {
+    "description": "ピルシート自動追加機能のFeatureAppeal Barタイトル"
+  },
+  "creatingNewPillSheetFeatureAppealShortDescription": "The next sheet appears automatically",
+  "@creatingNewPillSheetFeatureAppealShortDescription": {
+    "description": "ピルシート自動追加機能のFeatureAppeal Barの短い説明文"
+  },
+  "creatingNewPillSheetFeatureAppealHeadline": "Start your next pill sheet automatically",
+  "@creatingNewPillSheetFeatureAppealHeadline": {
+    "description": "ピルシート自動追加機能のヘルプページのヘッドライン"
+  },
+  "creatingNewPillSheetFeatureAppealBody": "When your current pill sheet group ends, a new one is created for you automatically so you never miss a record.",
+  "@creatingNewPillSheetFeatureAppealBody": {
+    "description": "ピルシート自動追加機能のヘルプページの本文"
+  },
+
+  "alarmKitFeatureAppealTitle": "Wake-up style medication alarm",
+  "@alarmKitFeatureAppealTitle": {
+    "description": "AlarmKit機能のFeatureAppeal Barタイトル"
+  },
+  "alarmKitFeatureAppealShortDescription": "Rings even on silent or focus mode",
+  "@alarmKitFeatureAppealShortDescription": {
+    "description": "AlarmKit機能のFeatureAppeal Barの短い説明文"
+  },
+  "alarmKitFeatureAppealHeadline": "Medication alarm like your wake-up",
+  "@alarmKitFeatureAppealHeadline": {
+    "description": "AlarmKit機能のヘルプページのヘッドライン"
+  },
+  "alarmKitFeatureAppealBody": "Powered by AlarmKit on iOS 26+, this alarm rings through silent mode and focus modes so you won't miss a dose.",
+  "@alarmKitFeatureAppealBody": {
+    "description": "AlarmKit機能のヘルプページの本文"
+  },
+
+  "todayPillNumberFeatureAppealTitle": "Align today's pill number",
+  "@todayPillNumberFeatureAppealTitle": {
+    "description": "今日の服用番号変更機能のFeatureAppeal Barタイトル"
+  },
+  "todayPillNumberFeatureAppealShortDescription": "Fix the number if it drifted",
+  "@todayPillNumberFeatureAppealShortDescription": {
+    "description": "今日の服用番号変更機能のFeatureAppeal Barの短い説明文"
+  },
+  "todayPillNumberFeatureAppealHeadline": "Change today's pill number",
+  "@todayPillNumberFeatureAppealHeadline": {
+    "description": "今日の服用番号変更機能のヘルプページのヘッドライン"
+  },
+  "todayPillNumberFeatureAppealBody": "If your pill number and what you actually took get out of sync, realign today's number in one tap. You can also open this from the pill number on the home screen.",
+  "@todayPillNumberFeatureAppealBody": {
+    "description": "今日の服用番号変更機能のヘルプページの本文"
+  },
+
+  "restDurationFeatureAppealTitle": "Log a pause in your medication",
+  "@restDurationFeatureAppealTitle": {
+    "description": "服用おやすみ機能のFeatureAppeal Barタイトル"
+  },
+  "restDurationFeatureAppealShortDescription": "Track breaks and interruptions",
+  "@restDurationFeatureAppealShortDescription": {
+    "description": "服用おやすみ機能のFeatureAppeal Barの短い説明文"
+  },
+  "restDurationFeatureAppealHeadline": "Pause your pill schedule",
+  "@restDurationFeatureAppealHeadline": {
+    "description": "服用おやすみ機能のヘルプページのヘッドライン"
+  },
+  "restDurationFeatureAppealBody": "Record a pause in your medication. The pill number stops advancing while you're on break and resumes the moment you restart.",
+  "@restDurationFeatureAppealBody": {
+    "description": "服用おやすみ機能のヘルプページの本文"
+  }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -2419,7 +2419,7 @@
   "@lifetimePurchaseNotice3": {
     "description": "Paywallのフッターに表示する、買い切りプラン購入時の注意文言（後半部分）"
   },
-  "featureAppealTryFeature": "実際に試す",
+  "featureAppealTryFeature": "確認する",
   "@featureAppealTryFeature": {
     "description": "FeatureAppealのヘルプページのフッターに表示する「実際にこの機能を試す」ボタンのラベル"
   },
@@ -2571,7 +2571,7 @@
   "reminderNotificationCustomizeWordFeatureAppealPoint3": "自分だけの通知メッセージに",
 
   "appearanceModeDateFeatureAppealPoint1": "ピルシートを日付で表示",
-  "appearanceModeDateFeatureAppealPoint2": "何日目か一目で把握できる",
+  "appearanceModeDateFeatureAppealPoint2": "カレンダーを見なくても日付がわかる",
   "appearanceModeDateFeatureAppealPoint3": "ピルシート設定から変更可能",
 
   "recordPillFeatureAppealPoint1": "ピルシートをタップで服用記録",
@@ -2584,7 +2584,7 @@
 
   "calendarDiaryFeatureAppealPoint1": "カレンダーで記録を一覧",
   "calendarDiaryFeatureAppealPoint2": "体調をメモして振り返り",
-  "calendarDiaryFeatureAppealPoint3": "過去の記録をかんたん検索",
+  "calendarDiaryFeatureAppealPoint3": "過去の記録をカレンダーで振り返り",
   "calendarDiaryFeatureAppealLocationHint": "日付をタップして体調を記録",
 
   "futureScheduleFeatureAppealPoint1": "カレンダーに予定を書き込み",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -2560,6 +2560,91 @@
     "description": "ヘルスケア連携機能のヘルプページの本文"
   },
 
+  "quickRecordFeatureAppealTitle": "通知からそのまま服用記録",
+  "@quickRecordFeatureAppealTitle": {
+    "description": "クイックレコード機能のFeatureAppeal Barタイトル"
+  },
+  "quickRecordFeatureAppealShortDescription": "アプリを開かず通知上で記録",
+  "@quickRecordFeatureAppealShortDescription": {
+    "description": "クイックレコード機能のFeatureAppeal Barの短い説明文"
+  },
+  "quickRecordFeatureAppealHeadline": "通知画面でワンタップ服用記録",
+  "@quickRecordFeatureAppealHeadline": {
+    "description": "クイックレコード機能のヘルプページのヘッドライン"
+  },
+  "quickRecordFeatureAppealBody": "リマインダー通知を長押しすると「服用した」のアクションが表示され、アプリを開かずに服用を記録できます。",
+  "@quickRecordFeatureAppealBody": {
+    "description": "クイックレコード機能のヘルプページの本文"
+  },
+
+  "creatingNewPillSheetFeatureAppealTitle": "ピルシートを自動で追加",
+  "@creatingNewPillSheetFeatureAppealTitle": {
+    "description": "ピルシート自動追加機能のFeatureAppeal Barタイトル"
+  },
+  "creatingNewPillSheetFeatureAppealShortDescription": "次のシートを自動生成",
+  "@creatingNewPillSheetFeatureAppealShortDescription": {
+    "description": "ピルシート自動追加機能のFeatureAppeal Barの短い説明文"
+  },
+  "creatingNewPillSheetFeatureAppealHeadline": "次のピルシートを自動で作成",
+  "@creatingNewPillSheetFeatureAppealHeadline": {
+    "description": "ピルシート自動追加機能のヘルプページのヘッドライン"
+  },
+  "creatingNewPillSheetFeatureAppealBody": "現在のピルシートグループが終わると、新しいピルシートグループが自動で作成されます。手動の切り替え操作が不要で、記録の抜けが起きません。",
+  "@creatingNewPillSheetFeatureAppealBody": {
+    "description": "ピルシート自動追加機能のヘルプページの本文"
+  },
+
+  "alarmKitFeatureAppealTitle": "目覚ましのように鳴るアラーム",
+  "@alarmKitFeatureAppealTitle": {
+    "description": "AlarmKit機能のFeatureAppeal Barタイトル"
+  },
+  "alarmKitFeatureAppealShortDescription": "サイレントでも確実に鳴る通知",
+  "@alarmKitFeatureAppealShortDescription": {
+    "description": "AlarmKit機能のFeatureAppeal Barの短い説明文"
+  },
+  "alarmKitFeatureAppealHeadline": "目覚まし同様の服用アラーム",
+  "@alarmKitFeatureAppealHeadline": {
+    "description": "AlarmKit機能のヘルプページのヘッドライン"
+  },
+  "alarmKitFeatureAppealBody": "iOS 26以降で利用できるAlarmKitを使って、サイレントモードや集中モードでも確実に鳴るアラームでピルの服用を知らせます。",
+  "@alarmKitFeatureAppealBody": {
+    "description": "AlarmKit機能のヘルプページの本文"
+  },
+
+  "todayPillNumberFeatureAppealTitle": "今日の服用番号を合わせる",
+  "@todayPillNumberFeatureAppealTitle": {
+    "description": "今日の服用番号変更機能のFeatureAppeal Barタイトル"
+  },
+  "todayPillNumberFeatureAppealShortDescription": "番号がずれたら設定で修正",
+  "@todayPillNumberFeatureAppealShortDescription": {
+    "description": "今日の服用番号変更機能のFeatureAppeal Barの短い説明文"
+  },
+  "todayPillNumberFeatureAppealHeadline": "今日飲むピル番号を変更できる",
+  "@todayPillNumberFeatureAppealHeadline": {
+    "description": "今日の服用番号変更機能のヘルプページのヘッドライン"
+  },
+  "todayPillNumberFeatureAppealBody": "飲み忘れや取り違えでピルシート上の番号と実際の服用がずれたときに、今日飲むピル番号を手動で合わせ直せます。ホームのピル数字表示からも同じ画面を開けます。",
+  "@todayPillNumberFeatureAppealBody": {
+    "description": "今日の服用番号変更機能のヘルプページの本文"
+  },
+
+  "restDurationFeatureAppealTitle": "服用お休み期間を記録",
+  "@restDurationFeatureAppealTitle": {
+    "description": "服用おやすみ機能のFeatureAppeal Barタイトル"
+  },
+  "restDurationFeatureAppealShortDescription": "休薬・中断を正確に管理",
+  "@restDurationFeatureAppealShortDescription": {
+    "description": "服用おやすみ機能のFeatureAppeal Barの短い説明文"
+  },
+  "restDurationFeatureAppealHeadline": "ピルの服用をお休みする",
+  "@restDurationFeatureAppealHeadline": {
+    "description": "服用おやすみ機能のヘルプページのヘッドライン"
+  },
+  "restDurationFeatureAppealBody": "しばらく服用をやめる期間をピルシートに記録できます。お休み中は服用番号が進まず、再開時にすぐ記録を再開できます。",
+  "@restDurationFeatureAppealBody": {
+    "description": "服用おやすみ機能のヘルプページの本文"
+  },
+
   "featureAppealLocationLabel": "アプリ内の場所",
 
   "criticalAlertFeatureAppealPoint1": "集中モード中でも通知が届く",
@@ -2594,5 +2679,25 @@
 
   "healthCareIntegrationFeatureAppealPoint1": "生理記録を自動でデータ連携",
   "healthCareIntegrationFeatureAppealPoint2": "ヘルスケアアプリに同期",
-  "healthCareIntegrationFeatureAppealPoint3": "Appleヘルスケア対応"
+  "healthCareIntegrationFeatureAppealPoint3": "Appleヘルスケア対応",
+
+  "quickRecordFeatureAppealPoint1": "通知のアクションで服用記録",
+  "quickRecordFeatureAppealPoint2": "アプリを開かずに完了",
+  "quickRecordFeatureAppealPoint3": "設定タブ > クイックレコードで有効化",
+
+  "creatingNewPillSheetFeatureAppealPoint1": "ピルシート終了で自動切り替え",
+  "creatingNewPillSheetFeatureAppealPoint2": "手動の作成操作が不要",
+  "creatingNewPillSheetFeatureAppealPoint3": "設定タブのスイッチで切り替え",
+
+  "alarmKitFeatureAppealPoint1": "サイレント/集中モードでも鳴る",
+  "alarmKitFeatureAppealPoint2": "目覚まし同様のアラーム音",
+  "alarmKitFeatureAppealPoint3": "iOS 26以降・設定タブから有効化",
+
+  "todayPillNumberFeatureAppealPoint1": "無料で使える番号合わせ機能",
+  "todayPillNumberFeatureAppealPoint2": "設定タブから変更できる",
+  "todayPillNumberFeatureAppealPoint3": "ホームの数字タップでも開ける",
+
+  "restDurationFeatureAppealPoint1": "無料で使える休薬記録",
+  "restDurationFeatureAppealPoint2": "ピルシート右上の歯車から開始",
+  "restDurationFeatureAppealPoint3": "期間の編集・再開もかんたん"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -2683,7 +2683,7 @@
 
   "quickRecordFeatureAppealPoint1": "通知のアクションで服用記録",
   "quickRecordFeatureAppealPoint2": "アプリを開かずに完了",
-  "quickRecordFeatureAppealPoint3": "設定タブ > クイックレコードで有効化",
+  "quickRecordFeatureAppealPoint3": "Premium加入でそのまま利用可能",
 
   "creatingNewPillSheetFeatureAppealPoint1": "ピルシート終了で自動切り替え",
   "creatingNewPillSheetFeatureAppealPoint2": "手動の作成操作が不要",

--- a/lib/utils/shared_preference/keys.dart
+++ b/lib/utils/shared_preference/keys.dart
@@ -33,6 +33,21 @@ extension BoolKey on String {
 
   /// ヘルスケア連携 (無料機能) のアピール Bar を × で閉じたかどうか。
   static const healthCareIntegrationFeatureAppealIsClosed = 'healthCareIntegrationFeatureAppealIsClosed';
+
+  /// クイックレコード (Premium機能: 通知アクションでの服用記録) のアピール Bar を × で閉じたかどうか。
+  static const quickRecordFeatureAppealIsClosed = 'quickRecordFeatureAppealIsClosed';
+
+  /// ピルシートグループ自動追加 (Premium機能) のアピール Bar を × で閉じたかどうか。
+  static const creatingNewPillSheetFeatureAppealIsClosed = 'creatingNewPillSheetFeatureAppealIsClosed';
+
+  /// AlarmKit (Premium機能: iOS 26+) のアピール Bar を × で閉じたかどうか。
+  static const alarmKitFeatureAppealIsClosed = 'alarmKitFeatureAppealIsClosed';
+
+  /// 今日の服用番号変更 (無料機能) のアピール Bar を × で閉じたかどうか。
+  static const todayPillNumberFeatureAppealIsClosed = 'todayPillNumberFeatureAppealIsClosed';
+
+  /// 服用おやすみ (無料機能) のアピール Bar を × で閉じたかどうか。
+  static const restDurationFeatureAppealIsClosed = 'restDurationFeatureAppealIsClosed';
 }
 
 extension StringKey on String {

--- a/plans/async-growing-oasis.md
+++ b/plans/async-growing-oasis.md
@@ -1,99 +1,145 @@
-# FeatureAppeal HelpPage の CLAUDE.md 指示書を作成
+# HelpPage の遷移をタブ移動に統一 + 文言齟齬修正 + CLAUDE.md 更新
 
 ## Context
 
-FeatureAppeal HelpPage 8ページの実装で得たルール・パターン・アンチパターンを `lib/features/feature_appeal/CLAUDE.md` にまとめる。新しい HelpPage を量産する際に読み込んで、同じ品質・パターンで実装するための指示書。
+FeatureAppeal HelpPage について以下の方針変更:
 
-## 記載内容
+1. **ボタン文言**: "実際に試す" → "確認する"（履歴確認等「試す」でない機能もあるため）
+2. **遷移先を全てタブ移動に統一**: 個別ページ遷移をやめる（動線の判断コストを下げる）
+3. **実機能との齟齬修正**:
+   - `calendar_diary` Point3 "過去の記録をかんたん検索" → 検索機能は未実装
+   - `appearance_mode_date` Point2 "何日目か一目で把握できる" → date モードは「日付」表示であり「何日目か」は number モード。誤解を招く
+4. **CLAUDE.md に方針を追記**: 「遷移先は全てタブ移動に統一」
 
-### 1. ページ構成（レイアウト）
+## Step 1: L10n 文字列の修正（app_ja.arb / app_en.arb）
 
-```
-Scaffold
-├─ AppBar (機能名)
-├─ body: SingleChildScrollView(padding: fromLTRB(24, 24, 24, 40))
-│  └─ Column
-│     ├─ SVG Icon (Center, 80x80)
-│     ├─ Headline (fontSize: 22, w700)
-│     ├─ Feature Cards × 3 (_featureCard)
-│     ├─ 「アプリ内の場所」ラベル
-│     ├─ _mockTabBar(selectedIndex: N)
-│     ├─ ↓ 矢印 (Icons.arrow_downward, size: 28)
-│     └─ コンポーネントプレビュー
-└─ bottomNavigationBar: SafeArea > Padding(16) > PrimaryButton
-```
+### ボタン文言変更
+- `featureAppealTryFeature`: "実際に試す" → "確認する"（en: "Try feature" → "View"）
 
-### 2. レイアウトの禁止事項
+### 齟齬修正
+- `calendarDiaryFeatureAppealPoint3`: "過去の記録をかんたん検索" → "過去の記録をカレンダーで振り返り"
+- `appearanceModeDateFeatureAppealPoint2`: "何日目か一目で把握できる" → "カレンダーを見なくても日付がわかる"
 
-- `bottomNavigationBar` 内に `Center` を入れない
-  - **理由**: Scaffold が loose height constraints を渡すため `Center` が最大高さに膨張し、body の領域が 0 になる
-- `if (!xxxAsync.hasValue) return SizedBox.shrink()` のガードパターン禁止
-  - **理由**: ページ全体（AppBar含む）が消える
+実行後 `flutter gen-l10n` で生成。
 
-### 3. ステップバイステップガイドのパターン
+## Step 2: 全 HelpPage の遷移先をタブ移動に統一
 
-コンポーネントプレビューは機能のアクセス経路に応じて使い分ける:
+### 各ページの遷移先タブ
 
-| アクセス経路 | タブ選択 | プレビュー |
+| ページ | タブ (selectedIndex) | Premium チェック |
 |---|---|---|
-| 設定タブ内の行 | `selectedIndex: 3` | `Container(primary border) > IgnorePointer > ListTile` |
-| ピルタブの操作 | `selectedIndex: 0` | pill mark 行 + touch_app アイコン → 矢印 → 服用履歴リスト |
-| カレンダータブの操作 | `selectedIndex: 2` | ミニカレンダー(曜日 + 日付行) + touch_app アイコン |
-| ピルタブのボタン | `selectedIndex: 0` | ボタン風 Container (実際の設定ボタンの見た目を再現) |
+| critical_alert | 設定 (3) | あり → 非Premium: ペイウォール / Premium: 設定タブ |
+| reminder_notification_customize_word | 設定 (3) | あり → 非Premium: ペイウォール / Premium: 設定タブ |
+| appearance_mode_date | ピル (0) | あり → 非Premium: ペイウォール / Premium: ピルタブ |
+| record_pill | ピル (0) | なし |
+| menstruation | 設定 (3) | なし |
+| calendar_diary | カレンダー (2) | なし（現状維持） |
+| future_schedule | カレンダー (2) | なし（現状維持） |
+| health_care_integration | 設定 (3) | なし（現状維持） |
 
-### 4. touch_app アイコンの配置ルール
+### 実装変更
 
-- 対象の**下側**に配置（指先がタップ位置に触れる見た目）
-- `Positioned(bottom: 0, right: -4〜-6)` + `Icon(Icons.touch_app, size: 22)`
-- 親 Container に `clipBehavior: Clip.none` と bottom padding を多めに取る
+**遷移コードの共通パターン**:
+```dart
+final tabController = ref.read(homeTabControllerProvider);
+Navigator.of(context).popUntil((r) => r.isFirst);
+tabController?.animateTo(HomePageTabType.{tab}.index);
+```
 
-### 5. 矢印
+### 変更箇所
 
-- `Icons.arrow_downward`（size: 28, color: AppColors.primary）
-- `Icons.keyboard_arrow_down` は使わない（Expandable に見えるため）
+- `critical_alert_help_page.dart`: `CriticalAlertPageRoutes.route` → setting タブ
+  - import 削除: `pilll/features/settings/critical_alert/page.dart`, `pilll/provider/setting.dart`
+  - 不要になる: `ref.watch(settingProvider).requireValue`
+  - 追加: `ref.read(homeTabControllerProvider)`, `features/home/page.dart` import
 
-### 6. L10n キー命名規則
+- `reminder_notification_customize_word_help_page.dart`: `ReminderNotificationCustomizeWordPageRoutes.route` → setting タブ
+  - import 削除: `features/reminder_notification_customize_word/page.dart`
+  - 追加: `ref.read(homeTabControllerProvider)`, `features/home/page.dart` import
 
-| キー | 用途 |
-|---|---|
-| `{feature}FeatureAppealTitle` | AppBar タイトル |
-| `{feature}FeatureAppealHeadline` | 見出し |
-| `{feature}FeatureAppealBody` | 本文（現在未使用、将来用） |
-| `{feature}FeatureAppealPoint1/2/3` | フィーチャーカードのテキスト |
-| `featureAppealLocationLabel` | 「アプリ内の場所」共通ラベル |
-| `featureAppealTryFeature` | 「実際に試す」共通ボタンテキスト |
+- `appearance_mode_date_help_page.dart`: `showSelectAppearanceModeModal` → pill タブ
+  - import 削除: `features/record/components/setting/components/appearance_mode/select_appearance_mode_modal.dart`, `provider/pill_sheet_group.dart`
+  - 不要になる: `ref.watch(latestPillSheetGroupProvider).valueOrNull`
+  - 追加: `ref.read(homeTabControllerProvider)`, `features/home/page.dart` import
 
-### 7. AnnouncementBar との関係
+- `record_pill_help_page.dart`:
+  - `PillSheetModifiedHistoriesPageRoute.route()` → pill タブ
+  - import 削除: `features/pill_sheet_modified_history/page.dart`
+  - 追加: `features/home/page.dart` import, `ConsumerWidget` 化して `ref.read(homeTabControllerProvider)`
+  - **履歴リストプレビュー削除**: `_mockHistoryRow` メソッドと下向き矢印+履歴Container を削除（タブバー + 矢印 + pill mark 行 だけにする）
 
-- 各機能には AnnouncementBar (`*_announcement_bar.dart`) と HelpPage (`*_help_page.dart`) がセット
-- AnnouncementBar タップで HelpPage に遷移
-- 日次ローテーション: `daysBetween(epoch, today()) % candidates.length`
-- dismiss は SharedPreferences のキーで機能ごとに管理
+- `menstruation_help_page.dart`: `SettingMenstruationPageRoute.route()` → setting タブ
+  - import 削除: `features/settings/menstruation/page.dart`
+  - 追加: `features/home/page.dart` import, `ConsumerWidget` 化
+  - モックタブバー `selectedIndex` を `3` (設定) に変更（現在は?）
 
-### 8. Route 定義
+- `calendar_diary_help_page.dart`, `future_schedule_help_page.dart`, `health_care_integration_help_page.dart`: 既にタブ移動なので変更なし
+
+### Premium チェックの保持
+
+Premium ページ3つは `ref.watch(userProvider).requireValue` で user を取得し、`!user.premiumOrTrial` のときはペイウォール表示、そうでなければタブ移動。
+
+## Step 3: calendar_diary の Feature Card アイコン修正
+
+`Icons.search` (Point3) → 齟齬修正後の文言に合うアイコンに変更。`Icons.replay` or `Icons.history` が候補。
+
+## Step 4: CLAUDE.md 更新
+
+`lib/features/feature_appeal/CLAUDE.md` に以下を追記/修正:
+
+### 追記セクション: 「遷移先のルール」
+
+```markdown
+## 遷移先のルール
+
+「確認する」ボタンの遷移先は**タブ移動のみに統一**する。個別の機能ページへの直接遷移はしない。
+理由: 動線を機能ごとに判断するコストを下げる。まずは該当タブに飛ばしてユーザーに探索してもらう方針。
 
 ```dart
-extension XxxHelpPageRoute on XxxHelpPage {
-  static Route<dynamic> route() => MaterialPageRoute(
-    settings: const RouteSettings(name: 'XxxHelpPage'),
-    builder: (_) => const XxxHelpPage(),
-  );
-}
+final tabController = ref.read(homeTabControllerProvider);
+Navigator.of(context).popUntil((r) => r.isFirst);
+tabController?.animateTo(HomePageTabType.{tab}.index);
 ```
 
-`RouteSettings.name` は必須（FirebaseAnalyticsObserver の screen_view 送信に使用）
+Premium 機能の場合は `ref.watch(userProvider).requireValue` で user を取得し、非Premium のときは `showPremiumIntroductionSheet(context)` でペイウォール、Premium のときはタブ移動。
+```
 
-### 9. 開発者オプションへの登録
+### 既存記述の更新
 
-新しい HelpPage を追加したら `lib/features/settings/components/rows/feature_appeal_help_page_list_page.dart` の `pages` リストにエントリを追加する
+- ページ構成セクション: bottomNavigationBar の PrimaryButton の text を「確認する」と明記
+- ステップバイステップガイドの表から「コンポーネントプレビュー」の個別具体例（服用履歴リスト等）を削除、シンプルに「タブバー + 矢印 + 機能画面の象徴的なUI（任意）」へ簡素化
+- L10n 命名規則は変更なし
 
 ## 対象ファイル
 
 | ファイル | 操作 |
 |---|---|
-| `lib/features/feature_appeal/CLAUDE.md` | 新規作成 |
+| `lib/l10n/app_ja.arb` | `featureAppealTryFeature`, `calendarDiaryFeatureAppealPoint3`, `appearanceModeDateFeatureAppealPoint2` 修正 |
+| `lib/l10n/app_en.arb` | 同上 |
+| `lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart` | 遷移先を setting タブに |
+| `lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart` | 遷移先を setting タブに |
+| `lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart` | 遷移先を pill タブに、selectedIndex を 0 に |
+| `lib/features/feature_appeal/record_pill/record_pill_help_page.dart` | 遷移先を pill タブに、履歴リストプレビュー削除、ConsumerWidget化 |
+| `lib/features/feature_appeal/menstruation/menstruation_help_page.dart` | 遷移先を setting タブに、selectedIndex を 3 に、ConsumerWidget化 |
+| `lib/features/feature_appeal/calendar_diary/calendar_diary_help_page.dart` | Point3 アイコン修正 |
+| `lib/features/feature_appeal/CLAUDE.md` | 遷移先ルール追記、「確認する」ボタン文言明記 |
 
 ## 検証
 
-- CLAUDE.md の内容が既存8ページの実装と矛盾しないこと
-- 新しい HelpPage を追加する手順が CLAUDE.md だけで分かること
+1. `flutter gen-l10n` 成功
+2. `flutter analyze` error/warning なし
+3. `flutter test` 全件パス
+4. シミュレータで各ページを確認:
+   - ボタンテキストが「確認する」
+   - タップで該当タブに切り替わる
+   - Premium ページは非Premium の場合ペイウォール表示
+
+## チェックリスト
+
+- [ ] 変更対象ファイルごとに具体的なコード提案をコードブロックで記載している
+- [ ] 既存コードのパターン・構成を確認し、同じパターンで実装している
+- [ ] コード生成: `flutter gen-l10n` で生成ファイル更新
+- [ ] 静的解析: `flutter analyze` エラーなし
+- [ ] テスト: `flutter test` 全件パス
+- [ ] 引数: 関数・コンストラクタの引数に `{required}` あり
+- [ ] ref使い分け: build内は `ref.watch`、コールバック・操作は `ref.read`

--- a/plans/async-growing-oasis.md
+++ b/plans/async-growing-oasis.md
@@ -1,248 +1,99 @@
-# FeatureAppeal HelpPage を「機能説明ページ」として完成させる
+# FeatureAppeal HelpPage の CLAUDE.md 指示書を作成
 
 ## Context
 
-PR #1782 の HelpPage 8ページに以下の修正を行った（実装済み）:
-- `bottomNavigationBar` 内の `Center` が body 領域を奪う問題を修正
-- Premium系3ページの `SizedBox.shrink()` ガードを除去、`ref.read` をコールバック内に移動
-- 遷移先の修正（record_pill → 服用履歴、menstruation → 生理設定、calendar_diary/future_schedule → カレンダータブ）
+FeatureAppeal HelpPage 8ページの実装で得たルール・パターン・アンチパターンを `lib/features/feature_appeal/CLAUDE.md` にまとめる。新しい HelpPage を量産する際に読み込んで、同じ品質・パターンで実装するための指示書。
 
-**次のステップ**: 各ページにビジュアルな機能説明を追加する。
-- アイコン付きのフィーチャーカード（2-3個/ページ）で機能のポイントをアピール
-- 実際のアプリUIコンポーネントを埋め込んで「どこからアクセスできるか」を視覚的に示す
+## 記載内容
 
----
-
-## Step 1 (実装済み): レンダリング修正・遷移先修正
-
-- `bottomNavigationBar` から `Center` ラッパー削除（全8ページ）
-- Premium系3ページの `hasValue` ガード削除、`ref.read` をコールバックに移動
-- 遷移先修正: record_pill→服用履歴, menstruation→生理設定, calendar_diary/future_schedule→カレンダータブ
-- テスト1386件全パス、`flutter analyze` error/warningなし、シミュレータでコンテンツ表示確認済み
-
----
-
-## Step 2: ビジュアルな機能説明を追加
-
-### ページレイアウト構成
+### 1. ページ構成（レイアウト）
 
 ```
-AppBar (機能名)
-─────────────────
-[SVG Icon]
-
-見出し (Headline)
-
-[Feature Cards]
-  ┌ Icon ─ ポイント1 ┐
-  ├ Icon ─ ポイント2 ├
-  └ Icon ─ ポイント3 ┘
-
-[Location Preview]  ← "アプリ内の場所"
-  パス: "設定 > 通知"
-  ┌──────────────────┐
-  │ 実際の設定行の    │
-  │ プレビュー        │
-  └──────────────────┘
-
-─────────────────
-[FAB] 実際に試す
+Scaffold
+├─ AppBar (機能名)
+├─ body: SingleChildScrollView(padding: fromLTRB(24, 24, 24, 40))
+│  └─ Column
+│     ├─ SVG Icon (Center, 80x80)
+│     ├─ Headline (fontSize: 22, w700)
+│     ├─ Feature Cards × 3 (_featureCard)
+│     ├─ 「アプリ内の場所」ラベル
+│     ├─ _mockTabBar(selectedIndex: N)
+│     ├─ ↓ 矢印 (Icons.arrow_downward, size: 28)
+│     └─ コンポーネントプレビュー
+└─ bottomNavigationBar: SafeArea > Padding(16) > PrimaryButton
 ```
 
-### 各ページの Feature Cards + Location Preview
+### 2. レイアウトの禁止事項
 
-| # | 機能 | Feature Cards (Icon + テキスト) | Location Preview |
-|---|---|---|---|
-| 1 | Critical Alert | `Icons.notifications_active` 集中モード中も通知 / `Icons.schedule` 設定時刻に確実リマインド / `Icons.touch_app` ワンタップで設定 | パス: 設定 > 通知 / プレビュー: `ListTile(title: L.enableNotificationInSilentModeSetting, subtitle: L.silentModeNotificationDescription)` + PremiumBadge |
-| 2 | 通知カスタマイズ | `Icons.edit` 通知メッセージを自由に編集 / `Icons.notifications` 毎日の通知に反映 / `Icons.favorite` 自分だけの通知に | パス: 設定 > 通知 / プレビュー: `ListTile(title: L.customizeMedicationNotifications)` + PremiumBadge |
-| 3 | 外観モード(date) | `Icons.calendar_today` 日付で表示 / `Icons.visibility` 何日目か一目で把握 / `Icons.settings` ピルシート設定から変更 | パス: 設定 > ピルシート / プレビュー: `ListTile(title: "ピルシートの自動追加", subtitle: "Premium")` |
-| 4 | ピル記録 | `Icons.touch_app` ピルシートをタップで記録 / `Icons.undo` 間違えても取り消し可能 / `Icons.history` 服用履歴を確認 | パス: ピルタブ / プレビュー: タブアイコン(tab_icon_pill_enable.svg) + 説明 |
-| 5 | 生理記録 | `Icons.edit_calendar` 生理開始日を記録 / `Icons.trending_up` 周期を自動で把握 / `Icons.tune` 設定をカスタマイズ | パス: 設定 > 生理 / プレビュー: `ListTile(title: L.aboutMenstruation)` |
-| 6 | カレンダー日記 | `Icons.calendar_month` カレンダーで一覧 / `Icons.note_add` 体調をメモ / `Icons.search` 過去の記録を振り返り | パス: カレンダータブ / プレビュー: タブアイコン(tab_icon_calendar_enable.svg) + 説明 |
-| 7 | 未来の予定 | `Icons.event` 予定を書き込み / `Icons.local_hospital` 通院日を管理 / `Icons.alarm` リマインダーで通知 | パス: カレンダータブ / プレビュー: タブアイコン(tab_icon_calendar_enable.svg) + 説明 |
-| 8 | ヘルスケア連携 | `Icons.sync` 自動でデータ連携 / `Icons.favorite` 生理記録をヘルスケアに同期 / `Icons.phone_iphone` Apple ヘルスケア対応 | パス: 設定 > 生理 / プレビュー: `ListTile(title: L.healthCareIntegration, subtitle: L.healthCareIntegrationDescription)` |
+- `bottomNavigationBar` 内に `Center` を入れない
+  - **理由**: Scaffold が loose height constraints を渡すため `Center` が最大高さに膨張し、body の領域が 0 になる
+- `if (!xxxAsync.hasValue) return SizedBox.shrink()` のガードパターン禁止
+  - **理由**: ページ全体（AppBar含む）が消える
 
-### 実装方針
+### 3. ステップバイステップガイドのパターン
 
-- **L10n**: Feature Cards のテキストは `app_ja.arb` / `app_en.arb` に追加（各ページ3個 × 8ページ = 24文字列）→ 実装済み
-- **Location Preview**: ステップバイステップガイドとして実装:
-  1. モックタブバー（4タブ、対象に丸インジケーター）
-  2. `Icons.arrow_downward`（サイズ28、primary色）で次ステップへ
-  3. 実際の UI コンポーネントプレビュー（設定行 ListTile or ピルシートの pill mark 行）
-- **ピルシート行のモック**: `AppColors.potti`(20px円) × 未服用、`AppColors.lightGray` + ✓ × 服用済み、`AppColors.enable`(オレンジ) × 選択中 を並べて表現
-- **各 HelpPage に直接記述**: 共通コンポーネントは作らず、各ページの `body` 内の `Column` に直接 Widget を追加
+コンポーネントプレビューは機能のアクセス経路に応じて使い分ける:
 
----
-
-## Step 1 (実装済み) の元の内容
-
-### Premium系3ページの `SizedBox.shrink()` ガードを除去
-
-コーディング規約に従い `requireValue` を使う。ただし `ref.watch` を build で呼ぶ必要はない（provider の値はボタンコールバックでのみ使う）ため、`ref.read` に変更する。
-
-### 1-1. `critical_alert_help_page.dart`
-
-**まずデバッグ状態を HEAD に戻す**。その上で以下を変更:
-
-- `ref.watch(userProvider)` / `ref.watch(settingProvider)` + `hasValue` ガード → 削除
-- ボタンコールバック内で `ref.read(userProvider).requireValue` / `ref.read(settingProvider).requireValue` を使う
-
-```dart
-// Before (build内)
-final userAsync = ref.watch(userProvider);
-final settingAsync = ref.watch(settingProvider);
-if (!userAsync.hasValue || !settingAsync.hasValue) return const SizedBox.shrink();
-final user = userAsync.requireValue;
-final setting = settingAsync.requireValue;
-
-// After (build内のガードを削除、ボタンコールバック内で read)
-onPressed: () async {
-  final user = ref.read(userProvider).requireValue;
-  final setting = ref.read(settingProvider).requireValue;
-  analytics.logEvent(...);
-  if (!user.premiumOrTrial) { ... return; }
-  await Navigator.of(context).push(CriticalAlertPageRoutes.route(setting: setting));
-},
-```
-
-### 1-2. `reminder_notification_customize_word_help_page.dart`
-
-同様に `ref.watch(userProvider)` + `hasValue` ガード → 削除、コールバック内で `ref.read`
-
-```dart
-// Before (build内)
-final userAsync = ref.watch(userProvider);
-if (!userAsync.hasValue) return const SizedBox.shrink();
-final user = userAsync.requireValue;
-
-// After (build内のガードを削除、ボタンコールバック内で read)
-onPressed: () async {
-  final user = ref.read(userProvider).requireValue;
-  analytics.logEvent(...);
-  if (!user.premiumOrTrial) { ... return; }
-  await Navigator.of(context).push(ReminderNotificationCustomizeWordPageRoutes.route());
-},
-```
-
-### 1-3. `appearance_mode_date_help_page.dart`
-
-`ref.watch(userProvider)` + `hasValue` ガード → 削除、コールバック内で `ref.read`。
-`ref.watch(latestPillSheetGroupProvider).valueOrNull` も `ref.read` に変更。
-
-```dart
-// Before (build内)
-final userAsync = ref.watch(userProvider);
-if (!userAsync.hasValue) return const SizedBox.shrink();
-final user = userAsync.requireValue;
-final pillSheetGroup = ref.watch(latestPillSheetGroupProvider).valueOrNull;
-
-// After (build内のガードを削除、ボタンコールバック内で read)
-onPressed: () async {
-  final user = ref.read(userProvider).requireValue;
-  analytics.logEvent(...);
-  if (!user.premiumOrTrial) { ... return; }
-  final pillSheetGroup = ref.read(latestPillSheetGroupProvider).valueOrNull;
-  if (pillSheetGroup == null) return;
-  showSelectAppearanceModeModal(context, user: user, pillSheetGroup: pillSheetGroup);
-},
-```
-
----
-
-## Step 2: 無料機能ページの「実際に試す」遷移先を意味のある画面に変更
-
-全て `ref` 不要になるため `StatelessWidget` に変更。
-
-| ページ | 現在 | 変更後 |
+| アクセス経路 | タブ選択 | プレビュー |
 |---|---|---|
-| `record_pill_help_page.dart` | record タブ切替 | `PillSheetModifiedHistoriesPageRoute.route()` (服用履歴) |
-| `menstruation_help_page.dart` | ✅ 修正済み | `SettingMenstruationPageRoute.route()` |
-| `calendar_diary_help_page.dart` | calendar タブ切替 | `DiaryPostPageRoute.route(today(), null)` (日記入力) |
-| `future_schedule_help_page.dart` | calendar タブ切替 | `SchedulePostPageRoute.route(today().add(Duration(days: 1)))` (予定作成) |
-| `health_care_integration_help_page.dart` | setting タブ切替 | 設定タブ切替を維持 (専用ページが存在しない) |
+| 設定タブ内の行 | `selectedIndex: 3` | `Container(primary border) > IgnorePointer > ListTile` |
+| ピルタブの操作 | `selectedIndex: 0` | pill mark 行 + touch_app アイコン → 矢印 → 服用履歴リスト |
+| カレンダータブの操作 | `selectedIndex: 2` | ミニカレンダー(曜日 + 日付行) + touch_app アイコン |
+| ピルタブのボタン | `selectedIndex: 0` | ボタン風 Container (実際の設定ボタンの見た目を再現) |
 
-### 具体的な変更
+### 4. touch_app アイコンの配置ルール
 
-**record_pill**: `ConsumerWidget` → `StatelessWidget`、import変更
-```dart
-// Before
-final tabController = ref.read(homeTabControllerProvider);
-Navigator.of(context).popUntil((r) => r.isFirst);
-tabController?.animateTo(HomePageTabType.record.index);
+- 対象の**下側**に配置（指先がタップ位置に触れる見た目）
+- `Positioned(bottom: 0, right: -4〜-6)` + `Icon(Icons.touch_app, size: 22)`
+- 親 Container に `clipBehavior: Clip.none` と bottom padding を多めに取る
 
-// After
-Navigator.of(context).push(PillSheetModifiedHistoriesPageRoute.route());
-```
+### 5. 矢印
 
-**calendar_diary**: `ConsumerWidget` → `StatelessWidget`、import変更
-```dart
-// Before
-final tabController = ref.read(homeTabControllerProvider);
-Navigator.of(context).popUntil((r) => r.isFirst);
-tabController?.animateTo(HomePageTabType.calendar.index);
+- `Icons.arrow_downward`（size: 28, color: AppColors.primary）
+- `Icons.keyboard_arrow_down` は使わない（Expandable に見えるため）
 
-// After
-Navigator.of(context).push(DiaryPostPageRoute.route(today(), null));
-```
+### 6. L10n キー命名規則
 
-**future_schedule**: `ConsumerWidget` → `StatelessWidget`、import変更
-```dart
-// Before
-final tabController = ref.read(homeTabControllerProvider);
-Navigator.of(context).popUntil((r) => r.isFirst);
-tabController?.animateTo(HomePageTabType.calendar.index);
-
-// After
-Navigator.of(context).push(SchedulePostPageRoute.route(today().add(const Duration(days: 1))));
-```
-
-**health_care_integration**: `ref` 不要なので `StatelessWidget` に変更するが、遷移先はそのまま維持…と思ったが、タブ切替に `ref.read(homeTabControllerProvider)` が必要。`ConsumerWidget` のまま維持。
-
----
-
-## Step 3: デバッグ残骸のクリーンアップ
-
-- `critical_alert_help_page.dart`: git checkout で HEAD に戻してから Step 1-1 の変更を適用
-- `tmp/` ディレクトリ内のスクリーンショット・デバッグファイルを削除
-
----
-
-## 変更対象ファイル
-
-| ファイル | 変更内容 |
+| キー | 用途 |
 |---|---|
-| `lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart` | デバッグ状態を戻す → `hasValue` ガード除去、`ref.read` に変更 |
-| `lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart` | `hasValue` ガード除去、`ref.read` に変更 |
-| `lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart` | `hasValue` ガード除去、`ref.read` に変更 |
-| `lib/features/feature_appeal/record_pill/record_pill_help_page.dart` | `StatelessWidget` 化、遷移先を `PillSheetModifiedHistoriesPage` に |
-| `lib/features/feature_appeal/calendar_diary/calendar_diary_help_page.dart` | `StatelessWidget` 化、遷移先を `DiaryPostPage` に |
-| `lib/features/feature_appeal/future_schedule/future_schedule_help_page.dart` | `StatelessWidget` 化、遷移先を `SchedulePostPage` に |
-| `lib/features/feature_appeal/menstruation/menstruation_help_page.dart` | ✅ 修正済み (変更なし) |
-| `lib/features/feature_appeal/health_care_integration/health_care_integration_help_page.dart` | 変更なし (専用ページなし) |
+| `{feature}FeatureAppealTitle` | AppBar タイトル |
+| `{feature}FeatureAppealHeadline` | 見出し |
+| `{feature}FeatureAppealBody` | 本文（現在未使用、将来用） |
+| `{feature}FeatureAppealPoint1/2/3` | フィーチャーカードのテキスト |
+| `featureAppealLocationLabel` | 「アプリ内の場所」共通ラベル |
+| `featureAppealTryFeature` | 「実際に試す」共通ボタンテキスト |
 
----
+### 7. AnnouncementBar との関係
+
+- 各機能には AnnouncementBar (`*_announcement_bar.dart`) と HelpPage (`*_help_page.dart`) がセット
+- AnnouncementBar タップで HelpPage に遷移
+- 日次ローテーション: `daysBetween(epoch, today()) % candidates.length`
+- dismiss は SharedPreferences のキーで機能ごとに管理
+
+### 8. Route 定義
+
+```dart
+extension XxxHelpPageRoute on XxxHelpPage {
+  static Route<dynamic> route() => MaterialPageRoute(
+    settings: const RouteSettings(name: 'XxxHelpPage'),
+    builder: (_) => const XxxHelpPage(),
+  );
+}
+```
+
+`RouteSettings.name` は必須（FirebaseAnalyticsObserver の screen_view 送信に使用）
+
+### 9. 開発者オプションへの登録
+
+新しい HelpPage を追加したら `lib/features/settings/components/rows/feature_appeal_help_page_list_page.dart` の `pages` リストにエントリを追加する
+
+## 対象ファイル
+
+| ファイル | 操作 |
+|---|---|
+| `lib/features/feature_appeal/CLAUDE.md` | 新規作成 |
 
 ## 検証
 
-1. `flutter analyze` エラーなし
-2. `flutter test` 全件パス
-3. シミュレータでビルド・インストール
-4. 開発者オプション → HelpPage一覧 → 全8ページでコンテンツ（SVG + 見出し + 本文）が表示されることを確認
-5. 各ページの「実際に試す」が正しい画面に遷移することを確認
-
----
-
-## チェックリスト
-
-### 実装内容
-- [ ] 変更対象ファイルごとに具体的なコード提案をコードブロックで記載している
-- [ ] 既存コードのパターン・構成を確認し、同じパターンで実装している
-- [ ] コード生成: `dart run build_runner build` で生成ファイル更新
-- [ ] 静的解析: `flutter analyze` エラーなし
-- [ ] テスト: `flutter test` 全件パス
-- [ ] iOS ビルド: `flutter build ios` 成功
-- [ ] Android ビルド: `flutter build apk` 成功
-- [ ] 新規・変更機能に対するテストが存在する（なければ新規作成）
-- [ ] 引数: 関数・コンストラクタの引数に `{required}` あり（timestamp等メタデータ除く）
-- [ ] ref使い分け: build内は `ref.watch`、コールバック・操作は `ref.read`
-- [ ] エラーメッセージはそのまま表示（加工・プレフィックス除去なし）
+- CLAUDE.md の内容が既存8ページの実装と矛盾しないこと
+- 新しい HelpPage を追加する手順が CLAUDE.md だけで分かること

--- a/plans/claude-agile-blum.md
+++ b/plans/claude-agile-blum.md
@@ -1,0 +1,554 @@
+# FeatureAppeal HelpPage 5 機能追加
+
+## Context
+
+Pilll の FeatureAppeal は「未認知の既存機能を Bar で訴求 → HelpPage で説明 → 該当タブに遷移」という動線。現在 8 ページ (Premium 3 / Free 5) が揃っているが、以下 5 機能がまだ HelpPage 化されていない。本タスクで 5 機能分の HelpPage + AnnouncementBar + テストを追加する。
+
+| # | 機能 | 区分 | 遷移先タブ | 未作成の理由/訴求価値 |
+|---|---|---|---|---|
+| 1 | クイックレコード | Premium | setting | 通知からワンタップ服用記録。UI 上で便利さが非常に伝わりにくい |
+| 2 | ピルシートグループ自動追加 | Premium | setting | シート終了時の自動切替。説明せずに気づくのが難しい |
+| 3 | AlarmKit (iOS 26+) | Premium | setting | 目覚ましレベルの確実な通知。設定行が L10n 未対応 (範囲外) |
+| 4 | 今日の服用番号変更 | Free | setting | Premium ではないが、ズレ補正手段の認知を上げたい |
+| 5 | 服用おやすみ | Free | record | Premium ではないが、休薬・中断の正しい記録方法として訴求価値あり |
+
+既存 8 ページは本タスクでは変更しない (禁止事項)。設定行の L10n 化 (AlarmKit) や `_mockTabBar` / `_featureCard` の共通化は後続タスクに分離する。
+
+## アプローチ
+
+実装の SSOT は `lib/features/feature_appeal/CLAUDE.md`。これを守り、既存 HelpPage を雛形にしてコピー差替えで進める。
+
+- Premium 3 機能: `critical_alert_help_page.dart` を雛形
+- Free 2 機能: `health_care_integration_help_page.dart` を雛形
+- AnnouncementBar 全 5: `critical_alert_announcement_bar.dart` を雛形
+- テスト全 10 本: `critical_alert_{help_page,announcement_bar}_test.dart` を雛形
+- `_mockTabBar` / `_featureCard` は既存通り各ページにコピペ (既存 8 ページと同流儀)
+- AlarmKit は「Android・iOS 25 以下でも Bar を表示し、FeatureCard Point3 で `iOS 26 以降` と明示」方針で `Platform.isIOS` 等の追加判定は入れない (候補リスト拡張の複雑性を避ける)
+
+候補数は **8 → 13** に増える。`daysBetween(epoch, today()) % candidates.length` のローテ周期が 13 日になる。
+
+## 追加 5 機能仕様
+
+### 共通ルール
+- HelpPage クラス名: `{FeatureName}HelpPage` (PascalCase)。`RouteSettings.name` は同名文字列
+- `AppBar` title = `L.{feature}FeatureAppealTitle`
+- Headline = `L.{feature}FeatureAppealHeadline`
+- FeatureCard 3 点 = `L.{feature}FeatureAppealPoint1/2/3`
+- `feature_key` (analytics) = snake_case のディレクトリ名
+
+### 1. quick_record (Premium, setting)
+
+- ソース機能: `lib/features/settings/components/rows/quick_record.dart`
+- ヘッダー SVG: `images/dots.svg` + `ColorFilter(AppColors.primary, srcIn)`
+- FeatureCard Icons: `Icons.notifications_active`, `Icons.touch_app`, `Icons.settings`
+- **機能デモ gif**: FeatureCard × 3 の後、LocationLabel の前に、プラットフォーム別の gif を大きめに挿入する。既存流用のため**新規アセット追加なし**。
+  - asset: `Platform.isIOS ? 'images/ios-quick-record.gif' : 'images/android-quick-record.gif'`
+  - 初出: `lib/features/initial_setting/premium_trial/page.dart:81` で同じアセットを使用済
+  - ラップ: `ClipRRect(borderRadius: BorderRadius.circular(12), child: Image.asset(...))`
+  - 前後に `const SizedBox(height: 24)` を入れる
+  - `import 'dart:io' show Platform;` を追加
+- `_mockTabBar(selectedIndex: 3)`
+- プレビュー: `critical_alert_help_page.dart` L78-112 と同じ `IgnorePointer` の ListTile + PremiumBadge。title=L.quickRecord / subtitle=L.quickRecordDescription
+
+### 2. creating_new_pillsheet (Premium, setting)
+
+- ソース機能: `lib/features/settings/components/rows/creating_new_pillsheet.dart`
+- ヘッダー SVG: `images/empty_pill_sheet_type.svg` + primary ColorFilter
+- FeatureCard Icons: `Icons.auto_awesome`, `Icons.autorenew`, `Icons.toggle_on`
+- `_mockTabBar(selectedIndex: 3)`
+- プレビュー: `SwitchListTile` モック (title=L.autoAddPillSheetGroup / subtitle=L.autoAddNewSheetAfterCurrentEnds) + PremiumBadge。実ソースと同じ SwitchListTile 形式
+
+### 3. alarm_kit (Premium, setting)
+
+- ソース機能: `lib/features/settings/components/rows/alarm_kit.dart`
+- ヘッダー SVG: `images/alerm.svg` + primary ColorFilter (critical_alert と同 asset だが許容。訴求文言で差別化)
+- FeatureCard Icons: `Icons.alarm`, `Icons.volume_up`, `Icons.phone_iphone`
+- `_mockTabBar(selectedIndex: 3)`
+- プレビュー: ListTile (title='アラーム機能', subtitle='目覚まし同様の通知が鳴ります。サイレント/集中モードでも確実に通知されます') + PremiumBadge + trailing に `Switch(value: false)` モック。**設定行側が L10n ハードコード日本語のため、プレビューも一貫性を取るためハードコード**。L10n 化は別タスクで実施
+
+### 4. today_pill_number (Free, setting)
+
+- ソース機能: `lib/features/settings/components/rows/today_pill_number.dart`
+- ヘッダー SVG: `images/display_number_edit_icon.svg` (colorFilter なし / 必要なら primary)
+- FeatureCard Icons: `Icons.edit`, `Icons.settings`, `Icons.touch_app`
+- `_mockTabBar(selectedIndex: 3)`
+- プレビュー: ListTile (title=L.changePillNumberForToday, trailing=chevron_right)。PremiumBadge なし
+
+### 5. rest_duration (Free, record)
+
+- ソース機能: `lib/features/record/components/setting/components/rest_duration/begin_manual_rest_duration.dart` 他
+- ヘッダー SVG: `images/explain_rest_duration_date.svg` (既存イラストをそのまま流用。80x80 で潰れないか目視確認)
+- FeatureCard Icons: `Icons.dark_mode_outlined`, `Icons.settings`, `Icons.event_repeat`
+- `_mockTabBar(selectedIndex: 0)` — **record タブ**
+- プレビュー: ListTile (title=L.startPauseTaking, leading=`Icon(Icons.settings)`) で「ピルシート設定シートからの導線」を暗示
+
+## L10n キー追加 (7 × 5 = 35 キー)
+
+命名: `{feature}FeatureAppeal{Title|ShortDescription|Headline|Body|Point1|Point2|Point3}`
+
+### 配置
+- `lib/l10n/app_ja.arb`:
+  - `Title` / `ShortDescription` / `Headline` / `Body` を既存 `featureAppealLocationLabel` (L2562) の直前に追加
+  - `Point1/2/3` を既存 `healthCareIntegrationFeatureAppealPoint3` (L2597) の直後に追加
+- `lib/l10n/app_en.arb`: ja と同じ順序で追加
+
+### 文言
+
+#### quickRecord
+| Key | ja | en |
+|---|---|---|
+| `quickRecordFeatureAppealTitle` | 通知からそのまま服用記録 | Record from the notification |
+| `quickRecordFeatureAppealShortDescription` | アプリを開かず通知上で記録 | Log your dose right from the push |
+| `quickRecordFeatureAppealHeadline` | 通知画面でワンタップ服用記録 | Tap the notification to record |
+| `quickRecordFeatureAppealBody` | リマインダー通知を長押しすると「服用した」のアクションが表示され、アプリを開かずに服用を記録できます。 | Long-press the reminder notification to reveal a "Taken" action and log your dose without opening the app. |
+| `quickRecordFeatureAppealPoint1` | 通知のアクションで服用記録 | Mark as taken from the push |
+| `quickRecordFeatureAppealPoint2` | アプリを開かずに完了 | No need to open the app |
+| `quickRecordFeatureAppealPoint3` | 設定タブ > クイックレコードで有効化 | Enable in Settings > Quick Record |
+
+#### creatingNewPillSheet
+| Key | ja | en |
+|---|---|---|
+| `creatingNewPillSheetFeatureAppealTitle` | ピルシートを自動で追加 | Automatically add a new pill sheet |
+| `creatingNewPillSheetFeatureAppealShortDescription` | 次のシートを自動生成 | The next sheet appears automatically |
+| `creatingNewPillSheetFeatureAppealHeadline` | 次のピルシートを自動で作成 | Start your next pill sheet automatically |
+| `creatingNewPillSheetFeatureAppealBody` | 現在のピルシートグループが終わると、新しいピルシートグループが自動で作成されます。手動の切り替え操作が不要で、記録の抜けが起きません。 | When your current pill sheet group ends, a new one is created for you automatically so you never miss a record. |
+| `creatingNewPillSheetFeatureAppealPoint1` | ピルシート終了で自動切り替え | Auto-switches when a sheet ends |
+| `creatingNewPillSheetFeatureAppealPoint2` | 手動の作成操作が不要 | No manual setup between sheets |
+| `creatingNewPillSheetFeatureAppealPoint3` | 設定タブのスイッチで切り替え | Toggle it from the Settings tab |
+
+#### alarmKit
+| Key | ja | en |
+|---|---|---|
+| `alarmKitFeatureAppealTitle` | 目覚ましのように鳴るアラーム | Wake-up style medication alarm |
+| `alarmKitFeatureAppealShortDescription` | サイレントでも確実に鳴る通知 | Rings even on silent or focus mode |
+| `alarmKitFeatureAppealHeadline` | 目覚まし同様の服用アラーム | Medication alarm like your wake-up |
+| `alarmKitFeatureAppealBody` | iOS 26 以降で利用できる AlarmKit を使って、サイレントモードや集中モードでも確実に鳴るアラームでピルの服用を知らせます。 | Powered by AlarmKit on iOS 26+, this alarm rings through silent mode and focus modes so you won't miss a dose. |
+| `alarmKitFeatureAppealPoint1` | サイレント/集中モードでも鳴る | Breaks through silent and focus |
+| `alarmKitFeatureAppealPoint2` | 目覚まし同様のアラーム音 | Classic wake-up alarm sound |
+| `alarmKitFeatureAppealPoint3` | iOS 26 以降・設定タブから有効化 | iOS 26+ only, toggle in Settings |
+
+#### todayPillNumber
+| Key | ja | en |
+|---|---|---|
+| `todayPillNumberFeatureAppealTitle` | 今日の服用番号を合わせる | Align today's pill number |
+| `todayPillNumberFeatureAppealShortDescription` | 番号がずれたら設定で修正 | Fix the number if it drifted |
+| `todayPillNumberFeatureAppealHeadline` | 今日飲むピル番号を変更できる | Change today's pill number |
+| `todayPillNumberFeatureAppealBody` | 飲み忘れや取り違えでピルシート上の番号と実際の服用がずれたときに、今日飲むピル番号を手動で合わせ直せます。ホームのピル数字表示からも同じ画面を開けます。 | If your pill number and what you actually took get out of sync, realign today's number in one tap. You can also open this from the pill number on the home screen. |
+| `todayPillNumberFeatureAppealPoint1` | 無料で使える番号合わせ機能 | Free, no paywall |
+| `todayPillNumberFeatureAppealPoint2` | 設定タブから変更できる | Update it from the Settings tab |
+| `todayPillNumberFeatureAppealPoint3` | ホームの数字タップでも開ける | Also reachable by tapping the number |
+
+#### restDuration
+| Key | ja | en |
+|---|---|---|
+| `restDurationFeatureAppealTitle` | 服用お休み期間を記録 | Log a pause in your medication |
+| `restDurationFeatureAppealShortDescription` | 休薬・中断を正確に管理 | Track breaks and interruptions |
+| `restDurationFeatureAppealHeadline` | ピルの服用をお休みする | Pause your pill schedule |
+| `restDurationFeatureAppealBody` | しばらく服用をやめる期間をピルシートに記録できます。お休み中は服用番号が進まず、再開時にすぐ記録を再開できます。 | Record a pause in your medication. The pill number stops advancing while you're on break and resumes the moment you restart. |
+| `restDurationFeatureAppealPoint1` | 無料で使える休薬記録 | Free, built into every plan |
+| `restDurationFeatureAppealPoint2` | ピルシート右上の歯車から開始 | Start it from the gear on the sheet |
+| `restDurationFeatureAppealPoint3` | 期間の編集・再開もかんたん | Easy to edit the range and resume |
+
+## 新規ファイル (20 本)
+
+各 feature ディレクトリ配下に `{feature}_help_page.dart` と `{feature}_announcement_bar.dart`、test も同様。
+
+```
+lib/features/feature_appeal/quick_record/quick_record_help_page.dart
+lib/features/feature_appeal/quick_record/quick_record_announcement_bar.dart
+lib/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page.dart
+lib/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_announcement_bar.dart
+lib/features/feature_appeal/alarm_kit/alarm_kit_help_page.dart
+lib/features/feature_appeal/alarm_kit/alarm_kit_announcement_bar.dart
+lib/features/feature_appeal/today_pill_number/today_pill_number_help_page.dart
+lib/features/feature_appeal/today_pill_number/today_pill_number_announcement_bar.dart
+lib/features/feature_appeal/rest_duration/rest_duration_help_page.dart
+lib/features/feature_appeal/rest_duration/rest_duration_announcement_bar.dart
+test/features/feature_appeal/quick_record/quick_record_help_page_test.dart
+test/features/feature_appeal/quick_record/quick_record_announcement_bar_test.dart
+test/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page_test.dart
+test/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_announcement_bar_test.dart
+test/features/feature_appeal/alarm_kit/alarm_kit_help_page_test.dart
+test/features/feature_appeal/alarm_kit/alarm_kit_announcement_bar_test.dart
+test/features/feature_appeal/today_pill_number/today_pill_number_help_page_test.dart
+test/features/feature_appeal/today_pill_number/today_pill_number_announcement_bar_test.dart
+test/features/feature_appeal/rest_duration/rest_duration_help_page_test.dart
+test/features/feature_appeal/rest_duration/rest_duration_announcement_bar_test.dart
+```
+
+## 変更ファイル (6 本)
+
+### 1. `lib/utils/shared_preference/keys.dart`
+
+L35 の `}` 直前に以下 5 件を追加 (document コメント必須)。
+
+```dart
+/// クイックレコード (Premium機能: 通知アクションでの服用記録) のアピール Bar を × で閉じたかどうか。
+static const quickRecordFeatureAppealIsClosed = 'quickRecordFeatureAppealIsClosed';
+
+/// ピルシートグループ自動追加 (Premium機能) のアピール Bar を × で閉じたかどうか。
+static const creatingNewPillSheetFeatureAppealIsClosed = 'creatingNewPillSheetFeatureAppealIsClosed';
+
+/// AlarmKit (Premium機能: iOS 26+) のアピール Bar を × で閉じたかどうか。
+static const alarmKitFeatureAppealIsClosed = 'alarmKitFeatureAppealIsClosed';
+
+/// 今日の服用番号変更 (無料機能) のアピール Bar を × で閉じたかどうか。
+static const todayPillNumberFeatureAppealIsClosed = 'todayPillNumberFeatureAppealIsClosed';
+
+/// 服用おやすみ (無料機能) のアピール Bar を × で閉じたかどうか。
+static const restDurationFeatureAppealIsClosed = 'restDurationFeatureAppealIsClosed';
+```
+
+### 2. `lib/features/feature_appeal/feature_appeal_bars_container.dart`
+
+4 箇所を更新:
+
+**(a) import 5 本追加 (L4-11 付近の既存 import と同順で)**
+
+```dart
+import 'package:pilll/features/feature_appeal/alarm_kit/alarm_kit_announcement_bar.dart';
+import 'package:pilll/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_announcement_bar.dart';
+import 'package:pilll/features/feature_appeal/quick_record/quick_record_announcement_bar.dart';
+import 'package:pilll/features/feature_appeal/rest_duration/rest_duration_announcement_bar.dart';
+import 'package:pilll/features/feature_appeal/today_pill_number/today_pill_number_announcement_bar.dart';
+```
+
+**(b) L48 の直後に useState 5 本追加**
+
+```dart
+final quickRecordIsClosed = useState(sharedPreferences.getBool(BoolKey.quickRecordFeatureAppealIsClosed) ?? false);
+final creatingNewPillSheetIsClosed = useState(sharedPreferences.getBool(BoolKey.creatingNewPillSheetFeatureAppealIsClosed) ?? false);
+final alarmKitIsClosed = useState(sharedPreferences.getBool(BoolKey.alarmKitFeatureAppealIsClosed) ?? false);
+final todayPillNumberIsClosed = useState(sharedPreferences.getBool(BoolKey.todayPillNumberFeatureAppealIsClosed) ?? false);
+final restDurationIsClosed = useState(sharedPreferences.getBool(BoolKey.restDurationFeatureAppealIsClosed) ?? false);
+```
+
+**(c) useEffect 内の listener 5 本定義 + addListener/removeListener 5 ペア追加** (L97 (`onHealthCareIntegration`) の直後、L106 の `addListener` 末尾と L115 の `removeListener` 末尾に追加)
+
+```dart
+void onQuickRecord() {
+  sharedPreferences.setBool(BoolKey.quickRecordFeatureAppealIsClosed, quickRecordIsClosed.value);
+  if (quickRecordIsClosed.value) markDismissedToday();
+}
+// creatingNewPillSheet / alarmKit / todayPillNumber / restDuration も同パターン
+```
+
+**(d) candidates リスト末尾に 5 件追加 (L128 直後)**
+
+```dart
+if (!quickRecordIsClosed.value) QuickRecordAnnouncementBar(isClosed: quickRecordIsClosed),
+if (!creatingNewPillSheetIsClosed.value) CreatingNewPillSheetAnnouncementBar(isClosed: creatingNewPillSheetIsClosed),
+if (!alarmKitIsClosed.value) AlarmKitAnnouncementBar(isClosed: alarmKitIsClosed),
+if (!todayPillNumberIsClosed.value) TodayPillNumberAnnouncementBar(isClosed: todayPillNumberIsClosed),
+if (!restDurationIsClosed.value) RestDurationAnnouncementBar(isClosed: restDurationIsClosed),
+```
+
+**(e) `hasAnyCandidate` 内のリスト末尾に 5 件追加 (L162 直後)**
+
+```dart
+!(sharedPreferences.getBool(BoolKey.quickRecordFeatureAppealIsClosed) ?? false),
+!(sharedPreferences.getBool(BoolKey.creatingNewPillSheetFeatureAppealIsClosed) ?? false),
+!(sharedPreferences.getBool(BoolKey.alarmKitFeatureAppealIsClosed) ?? false),
+!(sharedPreferences.getBool(BoolKey.todayPillNumberFeatureAppealIsClosed) ?? false),
+!(sharedPreferences.getBool(BoolKey.restDurationFeatureAppealIsClosed) ?? false),
+```
+
+### 3. `lib/features/settings/components/rows/feature_appeal_help_page_list_page.dart`
+
+import 5 本追加 (alphabetical)、`pages` リスト (L19-28) の末尾に以下 5 エントリ追加。
+
+```dart
+(label: 'クイックレコード', type: 'premium', routeFactory: QuickRecordHelpPageRoute.route),
+(label: 'ピルシート自動追加', type: 'premium', routeFactory: CreatingNewPillSheetHelpPageRoute.route),
+(label: 'AlarmKit (iOS 26+)', type: 'premium', routeFactory: AlarmKitHelpPageRoute.route),
+(label: '今日の服用番号変更', type: 'free', routeFactory: TodayPillNumberHelpPageRoute.route),
+(label: '服用おやすみ', type: 'free', routeFactory: RestDurationHelpPageRoute.route),
+```
+
+### 4. `lib/l10n/app_ja.arb`
+
+前述「L10n キー追加」の通り、Title/ShortDescription/Headline/Body の 4×5=20 キーを L2562 直前、Point1/2/3 の 3×5=15 キーを L2597 直後に追加。各キーに `@` 付き description も併記 (既存パターン通り)。
+
+### 5. `lib/l10n/app_en.arb`
+
+ja と同じキー順・同じ位置に英語文言を追加。
+
+### 6. `test/features/feature_appeal/feature_appeal_bars_container_test.dart`
+
+- import 5 本追加
+- `expectedBarTypeForIndex` の Type リスト末尾に 5 型追加 (8→13)
+- 既存の「全 dismiss → shrink」「hasAnyCandidate の true/false」テストで 13 機能分の setMockInitialValues を更新
+
+## 実装テンプレート (HelpPage Premium / Free)
+
+### Premium 版 雛形 (critical_alert をコピー → 差替え)
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/components/atoms/color.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/components/atoms/premium_badge.dart';
+import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/features/home/page.dart';
+import 'package:pilll/features/premium_introduction/util/premium_and_trial.dart';
+import 'package:pilll/l10n/app_localizations.dart';
+import 'package:pilll/provider/user.dart';
+import 'package:pilll/utils/analytics.dart';
+import 'package:pilll/utils/premium_introduction_sheet.dart';
+
+/// クイックレコード (Premium機能) のアピールページ。
+/// 通知アクションから服用記録できる機能を説明し、設定タブに誘導する。
+class QuickRecordHelpPage extends ConsumerWidget {
+  const QuickRecordHelpPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = L10n.of(context);
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        title: Text(l10n.quickRecordFeatureAppealTitle, style: const TextStyle(fontFamily: FontFamily.japanese, color: TextColor.main)),
+        backgroundColor: AppColors.background,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(24, 24, 24, 40),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Center(
+              child: SvgPicture.asset(
+                'images/dots.svg',
+                width: 80,
+                height: 80,
+                colorFilter: const ColorFilter.mode(AppColors.primary, BlendMode.srcIn),
+              ),
+            ),
+            const SizedBox(height: 20),
+            Center(
+              child: Text(
+                l10n.quickRecordFeatureAppealHeadline,
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 22, fontWeight: FontWeight.w700, fontFamily: FontFamily.japanese, color: TextColor.main),
+              ),
+            ),
+            const SizedBox(height: 24),
+            _featureCard(Icons.notifications_active, l10n.quickRecordFeatureAppealPoint1),
+            const SizedBox(height: 8),
+            _featureCard(Icons.touch_app, l10n.quickRecordFeatureAppealPoint2),
+            const SizedBox(height: 8),
+            _featureCard(Icons.settings, l10n.quickRecordFeatureAppealPoint3),
+            const SizedBox(height: 24),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: Image.asset(
+                Platform.isIOS ? 'images/ios-quick-record.gif' : 'images/android-quick-record.gif',
+              ),
+            ),
+            const SizedBox(height: 32),
+            Text(
+              l10n.featureAppealLocationLabel,
+              style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: TextColor.darkGray),
+            ),
+            const SizedBox(height: 12),
+            _mockTabBar(selectedIndex: 3),
+            const SizedBox(height: 8),
+            const Center(child: Icon(Icons.arrow_downward, size: 28, color: AppColors.primary)),
+            const SizedBox(height: 8),
+            IgnorePointer(
+              child: Container(
+                decoration: BoxDecoration(color: AppColors.white, borderRadius: BorderRadius.circular(10)),
+                child: ListTile(
+                  title: Row(children: [Text(l10n.quickRecord), const SizedBox(width: 8), const PremiumBadge()]),
+                  subtitle: Text(l10n.quickRecordDescription),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: PrimaryButton(
+            text: l10n.featureAppealTryFeature,
+            onPressed: () async {
+              final user = ref.read(userProvider).requireValue;
+              analytics.logEvent(name: 'feature_appeal_try_tapped', parameters: {
+                'feature_key': 'quick_record',
+                'feature_type': 'premium',
+                'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+              });
+              if (!user.premiumOrTrial) {
+                analytics.logEvent(name: 'feature_appeal_paywall_shown', parameters: {'feature_key': 'quick_record'});
+                await showPremiumIntroductionSheet(context);
+                return;
+              }
+              ref.read(homeTabControllerProvider)?.animateTo(HomePageTabType.setting.index);
+              if (context.mounted) Navigator.of(context).popUntil((r) => r.isFirst);
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// _mockTabBar / _featureCard は critical_alert_help_page.dart L149-224 と完全同一の実装をコピー
+
+/// FirebaseAnalyticsObserver が自動で screen_view を送信するため、RouteSettings.name は必ず設定する。
+extension QuickRecordHelpPageRoute on QuickRecordHelpPage {
+  static Route<dynamic> route() => MaterialPageRoute(
+        settings: const RouteSettings(name: 'QuickRecordHelpPage'),
+        builder: (_) => const QuickRecordHelpPage(),
+      );
+}
+```
+
+### Free 版 雛形 (health_care_integration をコピー → 差替え)
+
+`userProvider.requireValue` / ペイウォール分岐を削除し、`feature_type: 'free'`, `is_paywall_shown: 0` で analytics を 1 回だけ送信する形。その他は Premium 版と同じ。
+
+### AnnouncementBar 雛形
+
+`critical_alert_announcement_bar.dart` をコピーし、以下のみ差替え:
+
+- クラス名・コンストラクタ
+- 遷移先 Route: `{Feature}HelpPageRoute.route()`
+- analytics `feature_key` / `feature_type`
+- タイトル / 説明 L10n キー: `L.{feature}FeatureAppeal{Title|ShortDescription}`
+
+## AlarmKit 特有の扱い
+
+- **設定行の L10n 化は本タスク範囲外**: `lib/features/settings/components/rows/alarm_kit.dart` の 'アラーム機能' / 'サイレント/集中モードでも...' はハードコードのまま。HelpPage 用 L10n キーのみ新規追加する
+- **AnnouncementBar は Platform 判定なし**で candidates に積む: Android / iOS 25 以下でも表示されるが、Headline / Point3 で "iOS 26 以降" を明示するため迷子は発生しない
+- **後続タスク候補**: 「alarm_kit.dart の文言 L10n 化」と「Container に `AlarmKitService.isAvailable()` の非同期判定を組み込んで iOS 25 以下で Bar 非表示」
+
+## 実装順序
+
+**各機能の実装直後に必ず「設定タブ > 一番下の debug 画面 (FeatureAppeal HelpPage 一覧)」から新規ページを開き、mobile-mcp または xcodebuildmcp でスクショを撮って UI / 文言 / 遷移を目視確認する**。
+
+1. **インフラ**: `keys.dart` に BoolKey 5 件追加 → `app_ja.arb` / `app_en.arb` に 35 キー追加 → `flutter gen-l10n` → `L.xxx` が解決することを確認
+2. **Free 1 機能 (todayPillNumber)**: HelpPage + AnnouncementBar + テスト 2 本 → **`feature_appeal_help_page_list_page.dart` の `pages` に先に追加** → シミュレータで debug 画面から開き、mobile-mcp でスクショ確認 (ヘッダー SVG / Headline / FeatureCard / プレビュー ListTile / ↓矢印の配置、AppBar・戻るボタン、「確認する」タップで setting タブに遷移)
+3. **Premium 1 機能 (quickRecord)**: 同上 → debug 画面からスクショ確認。追加で `images/ios-quick-record.gif` / `android-quick-record.gif` が正しく再生されるか、「確認する」ボタンで非 Premium ユーザーならペイウォールが開くか、Premium ユーザーなら setting タブに遷移するか確認
+4. **Container 先行登録**: Step 2-3 の 2 機能を `feature_appeal_bars_container.dart` に登録 → container test を 10 件対応に更新 → SharedPreferences 空のフレッシュ起動で AnnouncementBar にローテーション表示されるか mobile-mcp でスクショ確認
+5. **残り 3 機能並列**: creatingNewPillSheet / alarmKit / restDuration を Step 2-3 のテンプレートでコピー展開 → 各機能を debug 画面に追加 → 都度スクショ確認
+   - alarmKit: iOS 26 未満のシミュレータで Point3 "iOS 26 以降" が視認できるか、遷移先 setting タブで設定行が非表示でも違和感ないか
+   - restDuration: record タブに遷移することを確認、歯車 → 服用をお休みする の動線が辿れるか
+   - creatingNewPillSheet: SwitchListTile モックと実機設定行が見た目一致しているか
+6. **最終 test 更新**: `feature_appeal_bars_container_test.dart` を 13 件対応に (expectedBarTypeForIndex / hasAnyCandidate / shrink テスト)
+7. **最終目視**: シミュレータで 5 機能すべての HelpPage を debug 画面から再度開き、スクショを揃えて全機能の UI トーン・文言齟齬がないか総点検
+
+## 検証
+
+### 静的検証
+```bash
+# L10n 生成
+flutter gen-l10n
+
+# 静的解析・フォーマット
+flutter analyze
+dart format lib test
+
+# テスト
+flutter test test/features/feature_appeal/
+flutter test
+
+# ビルド
+flutter build ios --no-codesign
+flutter build apk
+```
+
+### シミュレータ目視 (mobile-mcp / xcodebuildmcp でスクショ撮影しながら)
+
+必ず **設定タブの一番下にある debug 画面** (`FeatureAppealHelpPageListPage` — 「FeatureAppeal HelpPage 一覧」) 経由で各ページを開いて検証する。機能 1 つ実装ごとに都度行う (最後にまとめない)。
+
+```
+手順:
+1. xcodebuildmcp で iOS シミュレータを起動 (iPhone 16 Pro 等)
+2. flutter run で dev ビルドを起動
+3. 設定タブ (index:3) にスワイプ → 一番下までスクロール → 「FeatureAppeal HelpPage 一覧」をタップ
+4. 各機能の行をタップ → HelpPage が開く
+5. mobile-mcp の mobile_take_screenshot で撮影 → スクショを Read で開いて以下を確認
+   - AppBar タイトル / 戻るボタン
+   - ヘッダー SVG (80x80, primary)
+   - Headline (22pt w700, 中央)
+   - FeatureCard × 3 の Icon と文言が実機能と齟齬なし
+   - quickRecord の gif が再生されているか
+   - 「アプリ内の場所」ラベル → _mockTabBar で該当タブが選択色 → ↓ 矢印 → プレビュー の順で表示
+   - プレビューの ListTile 文言と実機の設定行が一致
+   - bottomNavigationBar の「確認する」ボタンが安全領域内に収まり、body 領域が潰れていない
+6. 「確認する」ボタンをタップ → mobile-mcp のタップ操作で動作確認
+   - Premium 3 機能 (非 Premium ユーザー): ペイウォールが開く
+   - Premium 3 機能 (Premium / Trial ユーザー): 設定タブに遷移、HelpPage は pop される
+   - Free 2 機能: 該当タブに遷移
+7. AnnouncementBar 表示確認: SharedPreferences を空にしたフレッシュ起動でホーム画面の AnnouncementBar が 13 機能のいずれかを表示しているか確認 (日付を変えてローテが動くかも検証)
+```
+
+個別に注意する観点:
+- **AlarmKit**: iOS 26 未満のシミュレータで HelpPage を開いて Point3 の "iOS 26 以降" 文言が視認できるか、「確認する」で設定タブに遷移後に設定行が非表示でも違和感が無いか
+- **restDuration**: 「確認する」で record タブに遷移 (setting ではない)。その後ピルシート右上の歯車から「服用をお休みする」にたどり着けるか手動確認
+- **quickRecord の gif**: `Platform.isIOS` で iOS 用 / Android 用が切り替わるので Android シミュレータ (Emulator) でも 1 度目視確認すると良い
+- **Feature Card の文言齟齬**: 過去事例 (未実装の「検索」機能を書いた) の再発防止。実ソースの `quick_record.dart` / `creating_new_pillsheet.dart` / `alarm_kit.dart` / `today_pill_number.dart` / rest_duration 系のサブタイトル / description を必ず読んでから Point の文言を決める
+
+## 残課題 (本タスク範囲外)
+
+- `lib/features/settings/components/rows/alarm_kit.dart` の日本語ハードコード 2 箇所の L10n 化
+- `_mockTabBar` / `_featureCard` の `lib/features/feature_appeal/components/` への共通化 (13 ページ分のリファクタ)
+- iOS 25 以下 / Android で AlarmKit AnnouncementBar を非表示にする判定追加 (必要になれば)
+
+## 重要な規約 (CLAUDE.md / rules より)
+
+- `bottomNavigationBar` 内に `Center` を入れない
+- `hasValue` + `SizedBox.shrink()` のローディングガード禁止
+- ボタン文言は `L.featureAppealTryFeature` = 「確認する」で統一
+- 遷移先はタブ移動のみ (個別ページへの push 禁止)
+- `Icons.arrow_downward` (size: 28, primary) を使う (`keyboard_arrow_down` は NG)
+- FeatureCard の文言は実機能と齟齬がないか必ず確認
+- `ConsumerWidget` を使う (hooks 不要なので `HookConsumerWidget` は避ける)
+- 関数の引数は `{required}` でラベル付与
+- `ref.watch` は状態同期、`ref.read` は操作系のみ
+- analytics イベント名は 40 文字以内、parameters は snake_case
+
+---
+
+## チェックリスト
+
+### 実装内容
+- [ ] 変更対象ファイルごとに具体的なコード提案をコードブロックで記載している
+- [ ] 既存コードのパターン・構成を確認し、同じパターンで実装している
+- [ ] コード生成: `flutter gen-l10n` で L10n 生成ファイル更新
+- [ ] 静的解析: `flutter analyze` エラーなし
+- [ ] テスト: `flutter test` 全件パス
+- [ ] iOS ビルド: `flutter build ios --no-codesign` 成功
+- [ ] Android ビルド: `flutter build apk` 成功
+- [ ] 新規・変更機能に対するテストが存在する (新規 10 ファイル + container test 更新)
+- [ ] Maestro E2E: 該当する maestro flow があれば実行、なければ新規作成
+- [ ] 設定タブの debug 画面 (`FeatureAppealHelpPageListPage`) に 5 機能を追加し、シミュレータから都度開いて mobile-mcp / xcodebuildmcp でスクショ確認
+- [ ] スクショで全ページの AppBar / Headline / FeatureCard / ↓ 矢印 / プレビュー / 「確認する」ボタン領域のレイアウト崩れがないことを目視確認
+- [ ] 「確認する」タップで Premium 3 機能 (非 Premium) ペイウォール表示 / Premium 3 機能 (Premium) タブ遷移 / Free 2 機能 タブ遷移を mobile-mcp のタップ操作で動作確認
+- [ ] quickRecord の gif が iOS シミュレータで再生される / Android シミュレータで Android 用 gif が再生されるのを確認
+- [ ] AlarmKit を iOS 26 未満シミュレータで開いて Point3 "iOS 26 以降" が見えることを確認
+- [ ] AnnouncementBar が 13 機能ローテの 1 つを表示していることをフレッシュ起動で確認
+- [ ] Entity命名: フィールド名が省略されていない
+- [ ] DB操作: 本タスクでは Firestore 操作なし (該当なし)
+- [ ] 引数: 関数・コンストラクタの引数に `{required}` あり (timestamp 等メタデータ除く)
+- [ ] ref使い分け: build内は `ref.watch`、コールバック・操作は `ref.read`
+- [ ] サブコレクションEntityに親ドキュメントIDフィールドあり (該当なし)
+- [ ] エラーメッセージはそのまま表示 (加工・プレフィックス除去なし)
+
+### FeatureAppeal 個別
+- [ ] `bottomNavigationBar` 内に `Center` を入れていない
+- [ ] `hasValue` + `SizedBox.shrink()` のローディングガードを使っていない
+- [ ] ボタン文言が `L.featureAppealTryFeature` で統一
+- [ ] 遷移先はタブ移動のみ (個別ページ push なし)
+- [ ] 矢印は `Icons.arrow_downward` size:28 / primary
+- [ ] FeatureCard の文言が実機能と齟齬なし (AlarmKit の iOS 26+ 条件明記)
+- [ ] ConsumerWidget を使用している (HookConsumerWidget ではない)
+- [ ] SharedPreferences キー `{feature}FeatureAppealIsClosed` を 5 件追加
+- [ ] `feature_appeal_bars_container.dart` の 5 箇所 (import / useState / listener / candidates / hasAnyCandidate) を全て更新
+- [ ] `feature_appeal_help_page_list_page.dart` の pages に 5 エントリ追加
+- [ ] `feature_appeal_bars_container_test.dart` の expectedBarTypeForIndex と setMockInitialValues を 13 機能対応に更新
+- [ ] 既存 8 ページに一切の変更を加えていない

--- a/plans/feature-appeal-expansion-prompt.md
+++ b/plans/feature-appeal-expansion-prompt.md
@@ -1,0 +1,119 @@
+# FeatureAppeal HelpPage 追加タスク プロンプト
+
+このファイルは「別の Claude タスクに HelpPage を追加させるためのプロンプト」です。以下の内容を丸ごとコピーして新しい Claude タスクに渡してください。
+
+---
+
+## タスク内容（Claude にそのまま渡すプロンプト）
+
+Pilll (Flutter) プロジェクトで FeatureAppeal 機能の HelpPage を追加する作業をお願いします。
+
+### 前提・必読ドキュメント
+
+1. **必ず最初に `/Users/bannzai/ghq/github.com/bannzai/pilll/lib/features/feature_appeal/CLAUDE.md` を読んで実装ルールを理解する**
+   - ページ構成、レイアウト禁止事項、タブ移動の統一ルール、L10n命名、touch_app アイコンの配置等が書かれている
+2. 既存 8 ページの実装を参考にする
+   - `lib/features/feature_appeal/{feature}/{feature}_help_page.dart`
+   - `lib/features/feature_appeal/{feature}/{feature}_announcement_bar.dart`
+3. プロジェクト全体のコーディング規約: `.claude/rules/` 配下のファイル
+
+### 既存 HelpPage（参考・重複しないように確認）
+
+1. critical_alert (Premium) - サイレントモードでも通知を受け取る
+2. reminder_notification_customize_word (Premium) - 通知メッセージカスタマイズ
+3. appearance_mode_date (Premium) - ピルシート日付表示
+4. record_pill (Free) - ピル記録・服用履歴
+5. menstruation (Free) - 生理記録
+6. calendar_diary (Free) - カレンダー・日記
+7. future_schedule (Free) - 未来の予定
+8. health_care_integration (Free) - ヘルスケア連携
+
+### 追加候補の機能（優先度順・必要に応じて取捨選択）
+
+以下の機能は HelpPage 未実装。実装前に **本当に HelpPage が必要な機能か判断してから作業する** こと。不要なら追加しない。
+
+1. **クイックレコード (Premium)**
+   - ファイル: `lib/features/settings/components/rows/quick_record.dart`
+   - 内容: 通知画面から直接ピルを服用記録できる
+   - 遷移先タブ: 設定タブ
+
+2. **ピルシートグループの自動追加 (Premium)**
+   - ファイル: `lib/features/settings/components/rows/creating_new_pillsheet.dart`
+   - 内容: ピルシートグループが終了したら自動で新しいシートを追加
+   - 遷移先タブ: 設定タブ
+
+3. **AlarmKit (Premium / iOS のみ)**
+   - ファイル: `lib/features/settings/components/rows/alarm_kit.dart`
+   - 内容: iOS 26+ の AlarmKit を使った通知
+   - 遷移先タブ: 設定タブ
+
+4. **休薬期間通知 / 通知時間カスタマイズ**
+   - 機能説明の価値があるか要判断（基本的な通知設定なので優先度低）
+
+5. **データ移行・アカウント連携**
+   - `lib/features/settings/components/rows/account_link.dart`
+   - 機種変更時のデータ引き継ぎ。ユーザー訴求価値あり
+   - 遷移先タブ: 設定タブ
+
+6. **表示番号カスタマイズ (beginPillNumber/endPillNumber)**
+   - ピルシートの表示開始・終了番号を変えられる。優先度低〜中
+
+### 作業手順（1機能あたり）
+
+1. **既存機能の実装を調査**: 機能のコード・UI・設定行の実装を読む
+2. **HelpPage 追加が妥当か判断**: ユーザー訴求価値があるか。なければスキップ
+3. **ディレクトリ作成**: `lib/features/feature_appeal/{feature_snake_case}/`
+4. **HelpPage 作成**: 既存ページ（例: `critical_alert/critical_alert_help_page.dart`）をコピーして改変
+   - Premium 機能なら Premium チェック付き
+   - `_mockTabBar(selectedIndex: ...)` で該当タブを選択表示
+   - `ref.read(homeTabControllerProvider)` でタブ移動
+5. **AnnouncementBar 作成**: 既存（例: `critical_alert/critical_alert_announcement_bar.dart`）をコピーして改変
+6. **L10n 追加**: `lib/l10n/app_ja.arb` と `lib/l10n/app_en.arb` に以下のキーを追加
+   - `{feature}FeatureAppealTitle`
+   - `{feature}FeatureAppealHeadline`
+   - `{feature}FeatureAppealBody`（将来用）
+   - `{feature}FeatureAppealPoint1/2/3`
+   - AnnouncementBar 用: `{feature}AnnouncementBarTitle`, `{feature}AnnouncementBarDescription`
+7. **L10n 生成**: `flutter gen-l10n`
+8. **FeatureAppealBarsContainer に登録**: `lib/features/feature_appeal/feature_appeal_bars_container.dart` の候補リストに追加
+9. **開発者オプションに登録**: `lib/features/settings/components/rows/feature_appeal_help_page_list_page.dart` の `pages` リストに追加
+10. **テスト作成**: `test/features/feature_appeal/{feature}/{feature}_help_page_test.dart` と `{feature}_announcement_bar_test.dart` を既存に倣って作成
+11. **検証**:
+    - `flutter analyze lib/features/feature_appeal/` で error/warning なし
+    - `flutter test test/features/feature_appeal/` で全パス
+    - シミュレータで HelpPage の表示・タブ移動を確認（開発者オプション経由）
+
+### 重要な規約まとめ（CLAUDE.md より抜粋・必ず遵守）
+
+- **`bottomNavigationBar` 内に `Center` を入れない**（body が 0 高さになる）
+- **`hasValue` + `SizedBox.shrink()` のローディングガード禁止**
+- **ボタン文言は `L.featureAppealTryFeature` =「確認する」**
+- **遷移先はタブ移動のみ**（個別ページへの push は禁止）
+- **`Icons.arrow_downward`（size:28, primary）を使う**（`keyboard_arrow_down` は NG）
+- **touch_app アイコンは対象の下側に配置**
+- **Feature Card の文言は実機能と齟齬がないか必ず確認**（過去の事例: 未実装の「検索」機能が記載されていた）
+
+### 成果物
+
+- 新規 HelpPage 一式（HelpPage + AnnouncementBar + L10n + 登録 + テスト）
+- どの機能を追加したか、なぜその機能を選んだかのサマリ
+- 検証結果（analyze/test/シミュレータ確認）のスクリーンショット
+
+### 禁止事項
+
+- 既存 8 ページを変更しない（このタスクは「追加」のみ）
+- CLAUDE.md のルールを破らない
+- 実機能と齟齬のある説明文を書かない
+
+### 質問・判断に迷ったら
+
+- AskUserQuestion で user に確認
+- 実装前にどの機能を追加対象とするか提案 → 承認を得てから実装
+
+---
+
+## このプロンプトを使う側の注意（bannzai 用メモ）
+
+- 上記の「タスク内容」セクションを新しい Claude Code セッションに貼り付ける
+- 必要に応じて追加したい機能を絞り込んでから渡す（例: 「クイックレコードだけ追加して」）
+- 完了後は `/commit-create-pr` で PR を作成させる

--- a/test/features/feature_appeal/alarm_kit/alarm_kit_announcement_bar_test.dart
+++ b/test/features/feature_appeal/alarm_kit/alarm_kit_announcement_bar_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pilll/features/feature_appeal/alarm_kit/alarm_kit_announcement_bar.dart';
+
+void main() {
+  group('#AlarmKitAnnouncementBar', () {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: AlarmKitAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byType(Text), findsAtLeast(2));
+    });
+
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: AlarmKitAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('isClosed=false の状態で右矢印 SVG が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: AlarmKitAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byType(SvgPicture), findsOneWidget);
+    });
+  });
+}

--- a/test/features/feature_appeal/alarm_kit/alarm_kit_help_page_test.dart
+++ b/test/features/feature_appeal/alarm_kit/alarm_kit_help_page_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/entity/setting.codegen.dart';
+import 'package:pilll/entity/user.codegen.dart';
+import 'package:pilll/features/feature_appeal/alarm_kit/alarm_kit_help_page.dart';
+import 'package:pilll/provider/setting.dart';
+import 'package:pilll/provider/user.dart';
+
+void main() {
+  group('#AlarmKitHelpPage', () {
+    List<Override> helpPageProviderOverrides() {
+      return [
+        userProvider.overrideWith((ref) => Stream.value(const User())),
+        settingProvider.overrideWith(
+          (ref) => Stream.value(
+            const Setting(
+              pillNumberForFromMenstruation: 22,
+              durationMenstruation: 5,
+              isOnReminder: false,
+              timezoneDatabaseName: null,
+            ),
+          ),
+        ),
+      ];
+    }
+
+    testWidgets('見出し・本文の Text Widget が表示される', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: helpPageProviderOverrides(),
+          child: const MaterialApp(home: AlarmKitHelpPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Text), findsAtLeast(2));
+    });
+
+    testWidgets('PrimaryButton が表示される', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: helpPageProviderOverrides(),
+          child: const MaterialApp(home: AlarmKitHelpPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PrimaryButton), findsOneWidget);
+    });
+
+    testWidgets('AppBar と戻るボタンが表示される', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: helpPageProviderOverrides(),
+          child: const MaterialApp(home: AlarmKitHelpPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+    });
+  });
+}

--- a/test/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_announcement_bar_test.dart
+++ b/test/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_announcement_bar_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pilll/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_announcement_bar.dart';
+
+void main() {
+  group('#CreatingNewPillSheetAnnouncementBar', () {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: CreatingNewPillSheetAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byType(Text), findsAtLeast(2));
+    });
+
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: CreatingNewPillSheetAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('isClosed=false の状態で右矢印 SVG が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: CreatingNewPillSheetAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byType(SvgPicture), findsOneWidget);
+    });
+  });
+}

--- a/test/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page_test.dart
+++ b/test/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/entity/setting.codegen.dart';
+import 'package:pilll/entity/user.codegen.dart';
+import 'package:pilll/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page.dart';
+import 'package:pilll/provider/setting.dart';
+import 'package:pilll/provider/user.dart';
+
+void main() {
+  group('#CreatingNewPillSheetHelpPage', () {
+    List<Override> helpPageProviderOverrides() {
+      return [
+        userProvider.overrideWith((ref) => Stream.value(const User())),
+        settingProvider.overrideWith(
+          (ref) => Stream.value(
+            const Setting(
+              pillNumberForFromMenstruation: 22,
+              durationMenstruation: 5,
+              isOnReminder: false,
+              timezoneDatabaseName: null,
+            ),
+          ),
+        ),
+      ];
+    }
+
+    testWidgets('見出し・本文の Text Widget が表示される', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: helpPageProviderOverrides(),
+          child: const MaterialApp(home: CreatingNewPillSheetHelpPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Text), findsAtLeast(2));
+    });
+
+    testWidgets('PrimaryButton が表示される', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: helpPageProviderOverrides(),
+          child: const MaterialApp(home: CreatingNewPillSheetHelpPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PrimaryButton), findsOneWidget);
+    });
+
+    testWidgets('AppBar と戻るボタンが表示される', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: helpPageProviderOverrides(),
+          child: const MaterialApp(home: CreatingNewPillSheetHelpPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+    });
+  });
+}

--- a/test/features/feature_appeal/feature_appeal_bars_container_test.dart
+++ b/test/features/feature_appeal/feature_appeal_bars_container_test.dart
@@ -2,15 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mockito/mockito.dart';
+import 'package:pilll/features/feature_appeal/alarm_kit/alarm_kit_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/appearance_mode_date/appearance_mode_date_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/calendar_diary/calendar_diary_announcement_bar.dart';
+import 'package:pilll/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/critical_alert/critical_alert_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/feature_appeal_bars_container.dart';
 import 'package:pilll/features/feature_appeal/future_schedule/future_schedule_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/health_care_integration/health_care_integration_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/menstruation/menstruation_announcement_bar.dart';
+import 'package:pilll/features/feature_appeal/quick_record/quick_record_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/record_pill/record_pill_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_announcement_bar.dart';
+import 'package:pilll/features/feature_appeal/rest_duration/rest_duration_announcement_bar.dart';
+import 'package:pilll/features/feature_appeal/today_pill_number/today_pill_number_announcement_bar.dart';
 import 'package:pilll/provider/shared_preferences.dart';
 import 'package:pilll/utils/datetime/day.dart';
 import 'package:pilll/utils/shared_preference/keys.dart';
@@ -36,7 +41,7 @@ void main() {
       );
     });
 
-    test('8 機能すべての isClosed key を true にする → false を返す', () async {
+    test('13 機能すべての isClosed key を true にする → false を返す', () async {
       SharedPreferences.setMockInitialValues({
         BoolKey.criticalAlertFeatureAppealIsClosed: true,
         BoolKey.reminderNotificationCustomizeWordFeatureAppealIsClosed: true,
@@ -46,6 +51,11 @@ void main() {
         BoolKey.calendarDiaryFeatureAppealIsClosed: true,
         BoolKey.futureScheduleFeatureAppealIsClosed: true,
         BoolKey.healthCareIntegrationFeatureAppealIsClosed: true,
+        BoolKey.quickRecordFeatureAppealIsClosed: true,
+        BoolKey.creatingNewPillSheetFeatureAppealIsClosed: true,
+        BoolKey.alarmKitFeatureAppealIsClosed: true,
+        BoolKey.todayPillNumberFeatureAppealIsClosed: true,
+        BoolKey.restDurationFeatureAppealIsClosed: true,
       });
       final sharedPreferences = await SharedPreferences.getInstance();
 
@@ -70,6 +80,11 @@ void main() {
         BoolKey.calendarDiaryFeatureAppealIsClosed: true,
         BoolKey.futureScheduleFeatureAppealIsClosed: true,
         BoolKey.healthCareIntegrationFeatureAppealIsClosed: true,
+        BoolKey.quickRecordFeatureAppealIsClosed: true,
+        BoolKey.creatingNewPillSheetFeatureAppealIsClosed: true,
+        BoolKey.alarmKitFeatureAppealIsClosed: true,
+        BoolKey.todayPillNumberFeatureAppealIsClosed: true,
+        BoolKey.restDurationFeatureAppealIsClosed: true,
       });
       final sharedPreferences = await SharedPreferences.getInstance();
 
@@ -94,6 +109,11 @@ void main() {
         BoolKey.calendarDiaryFeatureAppealIsClosed: true,
         BoolKey.futureScheduleFeatureAppealIsClosed: true,
         BoolKey.healthCareIntegrationFeatureAppealIsClosed: true,
+        BoolKey.quickRecordFeatureAppealIsClosed: true,
+        BoolKey.creatingNewPillSheetFeatureAppealIsClosed: true,
+        BoolKey.alarmKitFeatureAppealIsClosed: true,
+        BoolKey.todayPillNumberFeatureAppealIsClosed: true,
+        BoolKey.restDurationFeatureAppealIsClosed: true,
       });
       final sharedPreferences = await SharedPreferences.getInstance();
 
@@ -162,8 +182,8 @@ void main() {
   });
 
   group('#FeatureAppealBarsContainer', () {
-    /// 候補リスト (本実装と同じ並び順) のうち、appIsReleased=true で全 8 件存在する状態を想定。
-    /// テストでは today を任意に固定して daysBetween(epoch, today) % 8 が想定の Bar に一致するかを確認する。
+    /// 候補リスト (本実装と同じ並び順) のうち、appIsReleased=true で全 13 件存在する状態を想定。
+    /// テストでは today を任意に固定して daysBetween(epoch, today) % 13 が想定の Bar に一致するかを確認する。
     Type expectedBarTypeForIndex(int index) {
       return [
         CriticalAlertAnnouncementBar,
@@ -174,6 +194,11 @@ void main() {
         CalendarDiaryAnnouncementBar,
         FutureScheduleAnnouncementBar,
         HealthCareIntegrationAnnouncementBar,
+        QuickRecordAnnouncementBar,
+        CreatingNewPillSheetAnnouncementBar,
+        AlarmKitAnnouncementBar,
+        TodayPillNumberAnnouncementBar,
+        RestDurationAnnouncementBar,
       ][index];
     }
 
@@ -296,7 +321,7 @@ void main() {
       expect(find.byType(RecordPillAnnouncementBar), findsOneWidget);
     });
 
-    testWidgets('8 機能全 dismiss → SizedBox.shrink が表示される', (tester) async {
+    testWidgets('13 機能全 dismiss → SizedBox.shrink が表示される', (tester) async {
       final mockTodayRepository = MockTodayService();
       when(mockTodayRepository.now()).thenReturn(_featureAppealEpoch);
       todayRepository = mockTodayRepository;
@@ -310,6 +335,11 @@ void main() {
         BoolKey.calendarDiaryFeatureAppealIsClosed: true,
         BoolKey.futureScheduleFeatureAppealIsClosed: true,
         BoolKey.healthCareIntegrationFeatureAppealIsClosed: true,
+        BoolKey.quickRecordFeatureAppealIsClosed: true,
+        BoolKey.creatingNewPillSheetFeatureAppealIsClosed: true,
+        BoolKey.alarmKitFeatureAppealIsClosed: true,
+        BoolKey.todayPillNumberFeatureAppealIsClosed: true,
+        BoolKey.restDurationFeatureAppealIsClosed: true,
       });
       final sharedPreferences = await SharedPreferences.getInstance();
 
@@ -327,7 +357,7 @@ void main() {
         ),
       );
 
-      // 全 8 個の Bar が表示されないことを確認
+      // 全 13 個の Bar が表示されないことを確認
       expect(find.byType(CriticalAlertAnnouncementBar), findsNothing);
       expect(find.byType(ReminderNotificationCustomizeWordAnnouncementBar),
           findsNothing);
@@ -337,6 +367,11 @@ void main() {
       expect(find.byType(CalendarDiaryAnnouncementBar), findsNothing);
       expect(find.byType(FutureScheduleAnnouncementBar), findsNothing);
       expect(find.byType(HealthCareIntegrationAnnouncementBar), findsNothing);
+      expect(find.byType(QuickRecordAnnouncementBar), findsNothing);
+      expect(find.byType(CreatingNewPillSheetAnnouncementBar), findsNothing);
+      expect(find.byType(AlarmKitAnnouncementBar), findsNothing);
+      expect(find.byType(TodayPillNumberAnnouncementBar), findsNothing);
+      expect(find.byType(RestDurationAnnouncementBar), findsNothing);
     });
 
     testWidgets('dismissedToday=true → 候補があっても SizedBox.shrink が表示される',

--- a/test/features/feature_appeal/feature_appeal_bars_container_test.dart
+++ b/test/features/feature_appeal/feature_appeal_bars_container_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -182,11 +184,12 @@ void main() {
   });
 
   group('#FeatureAppealBarsContainer', () {
-    /// 候補リスト (本実装と同じ並び順) のうち、appIsReleased=true で全 13 件存在する状態を想定。
-    /// テストでは today を任意に固定して daysBetween(epoch, today) % 13 が想定の Bar に一致するかを確認する。
+    /// 候補リスト (本実装と同じ並び順) のうち、appIsReleased=true で全件存在する状態を想定。
+    /// CriticalAlert / AlarmKit は Platform.isIOS=true の時だけ候補に含まれる。
+    /// テストでは today を任意に固定して daysBetween(epoch, today) % candidates.length が想定の Bar に一致するかを確認する。
     Type expectedBarTypeForIndex(int index) {
       return [
-        CriticalAlertAnnouncementBar,
+        if (Platform.isIOS) CriticalAlertAnnouncementBar,
         ReminderNotificationCustomizeWordAnnouncementBar,
         AppearanceModeDateAnnouncementBar,
         RecordPillAnnouncementBar,
@@ -196,7 +199,7 @@ void main() {
         HealthCareIntegrationAnnouncementBar,
         QuickRecordAnnouncementBar,
         CreatingNewPillSheetAnnouncementBar,
-        AlarmKitAnnouncementBar,
+        if (Platform.isIOS) AlarmKitAnnouncementBar,
         TodayPillNumberAnnouncementBar,
         RestDurationAnnouncementBar,
       ][index];
@@ -258,14 +261,17 @@ void main() {
     });
 
     testWidgets(
-        'criticalAlert を dismiss 済み → 残り 7 候補のうち index 0 (本来は criticalAlert) は表示されない',
+        'ReminderNotificationCustomizeWord を dismiss 済み → 当日 index には別の Bar が表示される',
         (tester) async {
+      // 本テストは macOS/Linux で実行される前提で Platform.isIOS=false となり、
+      // CriticalAlert / AlarmKit は初めから候補に含まれない。そのため dismiss の効果検証は
+      // Reminder を対象にする。
       final mockTodayRepository = MockTodayService();
       when(mockTodayRepository.now()).thenReturn(_featureAppealEpoch);
       todayRepository = mockTodayRepository;
 
       SharedPreferences.setMockInitialValues({
-        BoolKey.criticalAlertFeatureAppealIsClosed: true,
+        BoolKey.reminderNotificationCustomizeWordFeatureAppealIsClosed: true,
       });
       final sharedPreferences = await SharedPreferences.getInstance();
 
@@ -283,17 +289,16 @@ void main() {
         ),
       );
 
-      // criticalAlert は除外。残り 7 候補で daysBetween=0 → index 0 = ReminderNotificationCustomizeWord
-      expect(find.byType(CriticalAlertAnnouncementBar), findsNothing);
+      // Reminder は除外。Platform.isIOS=false の候補先頭は Reminder なので、次は AppearanceModeDate。
       expect(find.byType(ReminderNotificationCustomizeWordAnnouncementBar),
-          findsOneWidget);
+          findsNothing);
+      expect(find.byType(AppearanceModeDateAnnouncementBar), findsOneWidget);
     });
 
     testWidgets(
         'appIsReleased=false → AppearanceModeDateAnnouncementBar が候補から除外される',
         (tester) async {
       final mockTodayRepository = MockTodayService();
-      // 通常 epoch から 2 日後なら index 2 (AppearanceModeDate) になるはず。除外されると 2 番目以降がずれる。
       when(mockTodayRepository.now())
           .thenReturn(_featureAppealEpoch.add(const Duration(days: 2)));
       todayRepository = mockTodayRepository;
@@ -315,10 +320,10 @@ void main() {
         ),
       );
 
-      // appearance_mode_date が除外されているので、その日には別の Bar が表示される
+      // Platform.isIOS=false (macOS/Linux) かつ appIsReleased=false で候補は 10 件。
+      // epoch+2 日 → daysBetween=2 → index 2 = Menstruation (Reminder, RecordPill, Menstruation, ...)。
       expect(find.byType(AppearanceModeDateAnnouncementBar), findsNothing);
-      // 7 候補の中で index 2 = RecordPillAnnouncementBar (本来は AppearanceModeDate がいた位置)
-      expect(find.byType(RecordPillAnnouncementBar), findsOneWidget);
+      expect(find.byType(MenstruationAnnouncementBar), findsOneWidget);
     });
 
     testWidgets('13 機能全 dismiss → SizedBox.shrink が表示される', (tester) async {

--- a/test/features/feature_appeal/quick_record/quick_record_announcement_bar_test.dart
+++ b/test/features/feature_appeal/quick_record/quick_record_announcement_bar_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pilll/features/feature_appeal/quick_record/quick_record_announcement_bar.dart';
+
+void main() {
+  group('#QuickRecordAnnouncementBar', () {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QuickRecordAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byType(Text), findsAtLeast(2));
+    });
+
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QuickRecordAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('isClosed=false の状態で右矢印 SVG が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QuickRecordAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byType(SvgPicture), findsOneWidget);
+    });
+  });
+}

--- a/test/features/feature_appeal/quick_record/quick_record_help_page_test.dart
+++ b/test/features/feature_appeal/quick_record/quick_record_help_page_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/entity/setting.codegen.dart';
+import 'package:pilll/entity/user.codegen.dart';
+import 'package:pilll/features/feature_appeal/quick_record/quick_record_help_page.dart';
+import 'package:pilll/provider/setting.dart';
+import 'package:pilll/provider/user.dart';
+
+void main() {
+  group('#QuickRecordHelpPage', () {
+    List<Override> helpPageProviderOverrides() {
+      return [
+        userProvider.overrideWith((ref) => Stream.value(const User())),
+        settingProvider.overrideWith(
+          (ref) => Stream.value(
+            const Setting(
+              pillNumberForFromMenstruation: 22,
+              durationMenstruation: 5,
+              isOnReminder: false,
+              timezoneDatabaseName: null,
+            ),
+          ),
+        ),
+      ];
+    }
+
+    testWidgets('見出し・本文の Text Widget が表示される', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: helpPageProviderOverrides(),
+          child: const MaterialApp(home: QuickRecordHelpPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Text), findsAtLeast(2));
+    });
+
+    testWidgets('PrimaryButton が表示される', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: helpPageProviderOverrides(),
+          child: const MaterialApp(home: QuickRecordHelpPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PrimaryButton), findsOneWidget);
+    });
+
+    testWidgets('AppBar と戻るボタンが表示される', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: helpPageProviderOverrides(),
+          child: const MaterialApp(home: QuickRecordHelpPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+    });
+  });
+}

--- a/test/features/feature_appeal/rest_duration/rest_duration_announcement_bar_test.dart
+++ b/test/features/feature_appeal/rest_duration/rest_duration_announcement_bar_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pilll/features/feature_appeal/rest_duration/rest_duration_announcement_bar.dart';
+
+void main() {
+  group('#RestDurationAnnouncementBar', () {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: RestDurationAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byType(Text), findsAtLeast(2));
+    });
+
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: RestDurationAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('isClosed=false の状態で右矢印 SVG が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: RestDurationAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byType(SvgPicture), findsOneWidget);
+    });
+  });
+}

--- a/test/features/feature_appeal/rest_duration/rest_duration_help_page_test.dart
+++ b/test/features/feature_appeal/rest_duration/rest_duration_help_page_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/features/feature_appeal/rest_duration/rest_duration_help_page.dart';
+
+void main() {
+  group('#RestDurationHelpPage', () {
+    testWidgets('見出し・本文の Text Widget が表示される', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(home: RestDurationHelpPage()),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(Text), findsAtLeast(2));
+    });
+
+    testWidgets('PrimaryButton が表示される', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(home: RestDurationHelpPage()),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(PrimaryButton), findsOneWidget);
+    });
+
+    testWidgets('AppBar と戻るボタンが表示される', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(home: RestDurationHelpPage()),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+    });
+  });
+}

--- a/test/features/feature_appeal/today_pill_number/today_pill_number_announcement_bar_test.dart
+++ b/test/features/feature_appeal/today_pill_number/today_pill_number_announcement_bar_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pilll/features/feature_appeal/today_pill_number/today_pill_number_announcement_bar.dart';
+
+void main() {
+  group('#TodayPillNumberAnnouncementBar', () {
+    testWidgets('isClosed=false の状態でタイトル・説明文の Text Widget が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TodayPillNumberAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byType(Text), findsAtLeast(2));
+    });
+
+    testWidgets('isClosed=false の状態で × ボタン (Icons.close) が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TodayPillNumberAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('isClosed=false の状態で右矢印 SVG が表示される', (tester) async {
+      final isClosed = ValueNotifier<bool>(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TodayPillNumberAnnouncementBar(isClosed: isClosed),
+          ),
+        ),
+      );
+
+      expect(find.byType(SvgPicture), findsOneWidget);
+    });
+  });
+}

--- a/test/features/feature_appeal/today_pill_number/today_pill_number_help_page_test.dart
+++ b/test/features/feature_appeal/today_pill_number/today_pill_number_help_page_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/features/feature_appeal/today_pill_number/today_pill_number_help_page.dart';
+
+void main() {
+  group('#TodayPillNumberHelpPage', () {
+    testWidgets('見出し・本文の Text Widget が表示される', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(home: TodayPillNumberHelpPage()),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(Text), findsAtLeast(2));
+    });
+
+    testWidgets('PrimaryButton が表示される', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(home: TodayPillNumberHelpPage()),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(PrimaryButton), findsOneWidget);
+    });
+
+    testWidgets('AppBar と戻るボタンが表示される', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(home: TodayPillNumberHelpPage()),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## 変更内容

### 1. Premium系HelpPage の ref.read → ref.watch 修正

コーディング規約に従い、画面描画に必要な Provider は `ref.watch` で取得するように修正。

- `critical_alert_help_page.dart`: `userProvider`, `settingProvider` を build 内で `ref.watch`
- `reminder_notification_customize_word_help_page.dart`: `userProvider` を build 内で `ref.watch`
- `appearance_mode_date_help_page.dart`: `userProvider`, `latestPillSheetGroupProvider` を build 内で `ref.watch`

### 2. FeatureAppeal CLAUDE.md 指示書追加

`lib/features/feature_appeal/CLAUDE.md` を新規作成。新しい HelpPage を量産する際のルール・パターンをまとめた指示書。

記載内容:
- ページ構成（Scaffold レイアウト）
- レイアウト禁止事項（`bottomNavigationBar` 内の `Center`、`SizedBox.shrink()` ガード）
- ステップバイステップガイドのパターン（モックタブバー・矢印・コンポーネントプレビュー）
- `touch_app` アイコンの配置ルール（下側配置・見切れ防止）
- L10n キー命名規則
- AnnouncementBar との関係
- Route 定義・開発者オプション登録手順