### PR TITLE
feat: Paywall 起動経路 (paywall_source) と課金完了イベントを Analytics に送出

### DIFF
--- a/lib/features/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_more_button.dart
+++ b/lib/features/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_more_button.dart
@@ -3,6 +3,7 @@ import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/components/atoms/button.dart';
 import 'package:pilll/features/pill_sheet_modified_history/page.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:flutter/material.dart';
 
@@ -24,7 +25,7 @@ class PillSheetModifiedHistoryMoreButton extends StatelessWidget {
                 context,
               ).push(PillSheetModifiedHistoriesPageRoute.route());
             } else {
-              showPremiumIntroductionSheet(context);
+              showPremiumIntroductionSheet(context, source: PaywallSource.pillSheetModifiedHistoryMore);
             }
           },
         ),

--- a/lib/features/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart
+++ b/lib/features/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart
@@ -12,6 +12,7 @@ import 'package:pilll/components/molecules/premium_badge.dart';
 import 'package:pilll/features/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_more_button.dart';
 import 'package:pilll/features/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_list.dart';
 import 'package:pilll/features/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_list_header.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/utils/emoji/emoji.dart';
 import 'package:pilll/entity/pill_sheet_modified_history.codegen.dart';
@@ -149,7 +150,7 @@ class CalendarPillSheetModifiedHistoryCard extends StatelessWidget {
                                           analytics.logEvent(
                                             name: 'pressed_show_detail_pill_sheet_history',
                                           );
-                                          showPremiumIntroductionSheet(context);
+                                          showPremiumIntroductionSheet(context, source: PaywallSource.pillSheetModifiedHistoryCard);
                                         },
                                       ),
                                     ),

--- a/lib/features/calendar/page.dart
+++ b/lib/features/calendar/page.dart
@@ -11,6 +11,7 @@ import 'package:pilll/entity/diary.codegen.dart';
 import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/features/calendar/components/const.dart';
 import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/features/record/weekday_badge.dart';
 import 'package:pilll/provider/diary.dart';
@@ -298,7 +299,7 @@ class PremiumIntroductionOverlay extends StatelessWidget {
                         analytics.logEvent(
                           name: 'pressed_premium_overlay_monthly_calendar',
                         );
-                        showPremiumIntroductionSheet(context);
+                        showPremiumIntroductionSheet(context, source: PaywallSource.calendarOverlay);
                       },
                     ),
                   ),

--- a/lib/features/diary_post/physical_condition_details.dart
+++ b/lib/features/diary_post/physical_condition_details.dart
@@ -3,6 +3,7 @@ import 'package:pilll/features/diary_post/util.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/features/diary_setting_physical_condtion_detail/page.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
@@ -56,7 +57,7 @@ class DiaryPostPhysicalConditionDetails extends StatelessWidget {
                     },
                   );
                 } else {
-                  showPremiumIntroductionSheet(context);
+                  showPremiumIntroductionSheet(context, source: PaywallSource.diaryPhysicalConditionDetail);
                 }
               },
               padding: const EdgeInsets.all(4),

--- a/lib/features/feature_appeal/alarm_kit/alarm_kit_help_page.dart
+++ b/lib/features/feature_appeal/alarm_kit/alarm_kit_help_page.dart
@@ -8,6 +8,7 @@ import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
 import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
@@ -137,7 +138,7 @@ class AlarmKitHelpPage extends ConsumerWidget {
                   name: 'feature_appeal_paywall_shown',
                   parameters: {'feature_key': 'alarm_kit'},
                 );
-                await showPremiumIntroductionSheet(context);
+                await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealAlarmKit);
                 return;
               }
               final tabController = ref.read(homeTabControllerProvider);

--- a/lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart
+++ b/lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart
@@ -7,6 +7,7 @@ import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
@@ -115,7 +116,7 @@ class AppearanceModeDateHelpPage extends ConsumerWidget {
                   name: 'feature_appeal_paywall_shown',
                   parameters: {'feature_key': 'appearance_mode_date'},
                 );
-                await showPremiumIntroductionSheet(context);
+                await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealAppearanceMode);
                 return;
               }
               final tabController = ref.read(homeTabControllerProvider);

--- a/lib/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page.dart
+++ b/lib/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page.dart
@@ -8,6 +8,7 @@ import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
 import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
@@ -137,7 +138,7 @@ class CreatingNewPillSheetHelpPage extends ConsumerWidget {
                   name: 'feature_appeal_paywall_shown',
                   parameters: {'feature_key': 'creating_new_pillsheet'},
                 );
-                await showPremiumIntroductionSheet(context);
+                await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealCreatingPillSheet);
                 return;
               }
               final tabController = ref.read(homeTabControllerProvider);

--- a/lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart
+++ b/lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart
@@ -8,6 +8,7 @@ import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
 import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
@@ -133,7 +134,7 @@ class CriticalAlertHelpPage extends ConsumerWidget {
                   name: 'feature_appeal_paywall_shown',
                   parameters: {'feature_key': 'critical_alert'},
                 );
-                await showPremiumIntroductionSheet(context);
+                await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealCriticalAlert);
                 return;
               }
               final tabController = ref.read(homeTabControllerProvider);

--- a/lib/features/feature_appeal/quick_record/quick_record_help_page.dart
+++ b/lib/features/feature_appeal/quick_record/quick_record_help_page.dart
@@ -10,6 +10,7 @@ import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
 import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
@@ -144,7 +145,7 @@ class QuickRecordHelpPage extends ConsumerWidget {
                   name: 'feature_appeal_paywall_shown',
                   parameters: {'feature_key': 'quick_record'},
                 );
-                await showPremiumIntroductionSheet(context);
+                await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealQuickRecord);
                 return;
               }
               final tabController = ref.read(homeTabControllerProvider);

--- a/lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart
+++ b/lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart
@@ -8,6 +8,7 @@ import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
 import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/analytics.dart';
@@ -131,7 +132,7 @@ class ReminderNotificationCustomizeWordHelpPage extends ConsumerWidget {
                   name: 'feature_appeal_paywall_shown',
                   parameters: {'feature_key': 'reminder_notification_customize_word'},
                 );
-                await showPremiumIntroductionSheet(context);
+                await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealReminderCustomize);
                 return;
               }
               final tabController = ref.read(homeTabControllerProvider);

--- a/lib/features/home/page.dart
+++ b/lib/features/home/page.dart
@@ -8,6 +8,7 @@ import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/features/error/error_alert.dart';
 import 'package:pilll/features/error/page.dart';
 import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/features/settings/components/churn/churn_survey_complete_dialog.dart';
 import 'package:pilll/features/store_review/pre_store_review_modal.dart';
@@ -151,7 +152,7 @@ class HomePageBody extends HookConsumerWidget {
           );
         } else if (isOneMonthPassedTrialDeadline && isOneMonthPassedSinceLastDisplayedMonthlyPremiumIntroductionSheet && !user.premiumOrTrial) {
           if (!user.premiumOrTrial) {
-            showPremiumIntroductionSheet(context);
+            showPremiumIntroductionSheet(context, source: PaywallSource.homeMonthly);
             sharedPreferences.setInt(
               IntKey.monthlyPremiumIntroductionSheetPresentedDateMilliSeconds,
               now().millisecondsSinceEpoch,

--- a/lib/features/menstruation/history/menstruation_history_card.dart
+++ b/lib/features/menstruation/history/menstruation_history_card.dart
@@ -11,6 +11,7 @@ import 'package:pilll/features/menstruation/history/menstruation_history_card_st
 import 'package:pilll/features/menstruation_list/menstruation_list_row.dart';
 import 'package:pilll/features/menstruation_list/page.dart';
 import 'package:flutter/material.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 
 class MenstruationHistoryCard extends StatelessWidget {
@@ -35,7 +36,7 @@ class MenstruationHistoryCard extends StatelessWidget {
               return;
             }
 
-            showPremiumIntroductionSheet(context);
+            showPremiumIntroductionSheet(context, source: PaywallSource.menstruationHistoryCard);
           },
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -72,7 +73,7 @@ class MenstruationHistoryCardMoreButton extends StatelessWidget {
               if (state.isPremium || state.isTrial) {
                 Navigator.of(context).push(MenstruationListPageRoute.route());
               } else {
-                showPremiumIntroductionSheet(context);
+                showPremiumIntroductionSheet(context, source: PaywallSource.menstruationHistoryMore);
               }
             },
           ),

--- a/lib/features/premium_introduction/components/purchase_buttons.dart
+++ b/lib/features/premium_introduction/components/purchase_buttons.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/features/premium_introduction/components/lifetime_purchase_button.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/features/premium_introduction/components/annual_purchase_button.dart';
 import 'package:pilll/features/premium_introduction/components/monthly_purchase_button.dart';
@@ -10,6 +11,7 @@ import 'package:pilll/provider/purchase.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 
 class PurchaseButtons extends HookConsumerWidget {
+  final PaywallSource source;
   final OfferingType offeringType;
   final Package monthlyPackage;
   final Package annualPackage;
@@ -22,6 +24,7 @@ class PurchaseButtons extends HookConsumerWidget {
 
   const PurchaseButtons({
     super.key,
+    required this.source,
     required this.offeringType,
     required this.monthlyPackage,
     required this.annualPackage,
@@ -45,7 +48,10 @@ class PurchaseButtons extends HookConsumerWidget {
             MonthlyPurchaseButton(
               monthlyPackage: monthlyPackage,
               onTap: (monthlyPackage) async {
-                analytics.logEvent(name: 'pressed_monthly_purchase_button');
+                analytics.logEvent(
+                  name: 'pressed_monthly_purchase_button',
+                  parameters: {'paywall_source': source.value},
+                );
                 await _purchase(context, monthlyPackage, purchase);
               },
             ),
@@ -56,7 +62,10 @@ class PurchaseButtons extends HookConsumerWidget {
               monthlyPremiumPackage: monthlyPremiumPackage,
               offeringType: offeringType,
               onTap: (annualPackage) async {
-                analytics.logEvent(name: 'pressed_annual_purchase_button');
+                analytics.logEvent(
+                  name: 'pressed_annual_purchase_button',
+                  parameters: {'paywall_source': source.value},
+                );
                 await _purchase(context, annualPackage, purchase);
               },
             ),
@@ -71,7 +80,10 @@ class PurchaseButtons extends HookConsumerWidget {
             discountRate: lifetimeDiscountRate,
             offeringType: offeringType,
             onTap: (lifetimePackage) async {
-              analytics.logEvent(name: 'pressed_lifetime_purchase_button');
+              analytics.logEvent(
+                name: 'pressed_lifetime_purchase_button',
+                parameters: {'paywall_source': source.value},
+              );
               await _purchase(context, lifetimePackage, purchase);
             },
           ),
@@ -91,7 +103,7 @@ class PurchaseButtons extends HookConsumerWidget {
 
     isLoading.value = true;
     try {
-      final shouldShowCompleteDialog = await purchase(package);
+      final shouldShowCompleteDialog = await purchase(package, source: source);
       if (shouldShowCompleteDialog) {
         // ignore: use_build_context_synchronously
         showDialog(

--- a/lib/features/premium_introduction/paywall_source.dart
+++ b/lib/features/premium_introduction/paywall_source.dart
@@ -1,0 +1,94 @@
+/// PremiumIntroductionSheet / SpecialOfferingPage の起動経路を表す。
+///
+/// Firebase Analytics の `paywall_viewed` / `purchase_succeeded` /
+/// `pressed_*_purchase_button` イベントに `paywall_source` パラメータとして
+/// 送出され、BigQuery 上で経路別 CV 率を集計するために使用する。
+///
+/// 値の追加・変更時は PilllBackend/bigquery/queries/paywall_source_conversion.sql の
+/// 集計対象と整合させること。
+enum PaywallSource {
+  appLaunch,
+  homeMonthly,
+  calendarOverlay,
+  pillSheetModifiedHistoryCard,
+  pillSheetModifiedHistoryMore,
+  menstruationHistoryCard,
+  menstruationHistoryMore,
+  diaryPhysicalConditionDetail,
+  appearanceModeSelect,
+  discountAnnouncementBar,
+  pilllAdsAnnouncementBarClose,
+  endedPillSheetBar,
+  settingsPremiumIntroductionRow,
+  settingsCriticalAlertRow,
+  settingsCreatingNewPillSheetRow,
+  settingsQuickRecordRow,
+  settingsReminderCustomizeRow,
+  featureAppealAlarmKit,
+  featureAppealAppearanceMode,
+  featureAppealCreatingPillSheet,
+  featureAppealCriticalAlert,
+  featureAppealQuickRecord,
+  featureAppealReminderCustomize,
+  specialOfferingBar,
+  specialOfferingBar2,
+}
+
+extension PaywallSourceFunction on PaywallSource {
+  /// Firebase Analytics の paywall_source パラメータに送出する snake_case 文字列。
+  /// enum 名の rename / Dart の難読化に影響されないよう明示的に列挙する。
+  String get value {
+    switch (this) {
+      case PaywallSource.appLaunch:
+        return 'app_launch';
+      case PaywallSource.homeMonthly:
+        return 'home_monthly';
+      case PaywallSource.calendarOverlay:
+        return 'calendar_overlay';
+      case PaywallSource.pillSheetModifiedHistoryCard:
+        return 'pill_sheet_modified_history_card';
+      case PaywallSource.pillSheetModifiedHistoryMore:
+        return 'pill_sheet_modified_history_more';
+      case PaywallSource.menstruationHistoryCard:
+        return 'menstruation_history_card';
+      case PaywallSource.menstruationHistoryMore:
+        return 'menstruation_history_more';
+      case PaywallSource.diaryPhysicalConditionDetail:
+        return 'diary_physical_condition_detail';
+      case PaywallSource.appearanceModeSelect:
+        return 'appearance_mode_select';
+      case PaywallSource.discountAnnouncementBar:
+        return 'discount_announcement_bar';
+      case PaywallSource.pilllAdsAnnouncementBarClose:
+        return 'pilll_ads_announcement_bar_close';
+      case PaywallSource.endedPillSheetBar:
+        return 'ended_pill_sheet_bar';
+      case PaywallSource.settingsPremiumIntroductionRow:
+        return 'settings_premium_introduction_row';
+      case PaywallSource.settingsCriticalAlertRow:
+        return 'settings_critical_alert_row';
+      case PaywallSource.settingsCreatingNewPillSheetRow:
+        return 'settings_creating_new_pill_sheet_row';
+      case PaywallSource.settingsQuickRecordRow:
+        return 'settings_quick_record_row';
+      case PaywallSource.settingsReminderCustomizeRow:
+        return 'settings_reminder_customize_row';
+      case PaywallSource.featureAppealAlarmKit:
+        return 'feature_appeal_alarm_kit';
+      case PaywallSource.featureAppealAppearanceMode:
+        return 'feature_appeal_appearance_mode';
+      case PaywallSource.featureAppealCreatingPillSheet:
+        return 'feature_appeal_creating_pill_sheet';
+      case PaywallSource.featureAppealCriticalAlert:
+        return 'feature_appeal_critical_alert';
+      case PaywallSource.featureAppealQuickRecord:
+        return 'feature_appeal_quick_record';
+      case PaywallSource.featureAppealReminderCustomize:
+        return 'feature_appeal_reminder_customize';
+      case PaywallSource.specialOfferingBar:
+        return 'special_offering_bar';
+      case PaywallSource.specialOfferingBar2:
+        return 'special_offering_bar2';
+    }
+  }
+}

--- a/lib/features/premium_introduction/premium_introduction_sheet.dart
+++ b/lib/features/premium_introduction/premium_introduction_sheet.dart
@@ -16,6 +16,7 @@ import 'package:pilll/features/premium_introduction/components/premium_introduct
 import 'package:pilll/features/premium_introduction/components/premium_introduction_discount.dart';
 import 'package:pilll/features/premium_introduction/components/premium_user_thanks.dart';
 import 'package:pilll/features/premium_introduction/components/purchase_buttons.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/error/page.dart';
 import 'package:pilll/provider/user.dart';
 import 'package:pilll/provider/root.dart';
@@ -25,7 +26,9 @@ import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class PremiumIntroductionSheet extends HookConsumerWidget {
-  const PremiumIntroductionSheet({super.key});
+  const PremiumIntroductionSheet({super.key, required this.source});
+
+  final PaywallSource source;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -33,7 +36,7 @@ class PremiumIntroductionSheet extends HookConsumerWidget {
       ref.watch(purchaseOfferingsProvider),
       ref.watch(userProvider),
     ).when(
-      data: (data) => PremiumIntroductionSheetBody(offerings: data.$1, user: data.$2),
+      data: (data) => PremiumIntroductionSheetBody(offerings: data.$1, user: data.$2, source: source),
       error: (error, stackTrace) => UniversalErrorPage(
         error: error,
         reload: () {
@@ -50,11 +53,13 @@ class PremiumIntroductionSheet extends HookConsumerWidget {
 class PremiumIntroductionSheetBody extends HookConsumerWidget {
   final Offerings offerings;
   final User user;
+  final PaywallSource source;
 
   const PremiumIntroductionSheetBody({
     super.key,
     required this.offerings,
     required this.user,
+    required this.source,
   });
 
   @override
@@ -117,6 +122,7 @@ class PremiumIntroductionSheetBody extends HookConsumerWidget {
                           const SizedBox(height: 12),
                           if (monthlyPremiumPackage != null && monthlyPackage != null && annualPackage != null)
                             PurchaseButtons(
+                              source: source,
                               offeringType: offeringType,
                               monthlyPackage: monthlyPackage,
                               annualPackage: annualPackage,
@@ -165,12 +171,19 @@ class PremiumIntroductionSheetBody extends HookConsumerWidget {
   }
 }
 
-Future<void> showPremiumIntroductionSheet(BuildContext context) async {
+Future<void> showPremiumIntroductionSheet(
+  BuildContext context, {
+  required PaywallSource source,
+}) async {
   analytics.logScreenView(screenName: 'PremiumIntroductionSheet');
+  analytics.logEvent(
+    name: 'paywall_viewed',
+    parameters: {'paywall_source': source.value},
+  );
 
   await showModalBottomSheet(
     context: context,
-    builder: (_) => const PremiumIntroductionSheet(),
+    builder: (_) => PremiumIntroductionSheet(source: source),
     backgroundColor: Colors.transparent,
     isScrollControlled: true,
   );

--- a/lib/features/record/components/announcement_bar/announcement_bar.dart
+++ b/lib/features/record/components/announcement_bar/announcement_bar.dart
@@ -11,6 +11,7 @@ import 'package:pilll/provider/shared_preferences.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/provider/pill_sheet_group.dart';
 import 'package:pilll/provider/pilll_ads.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/features/premium_introduction/util/discount_deadline.dart';
 import 'package:pilll/features/record/components/announcement_bar/components/discount_price_deadline.dart';
@@ -152,7 +153,7 @@ class AnnouncementBar extends HookConsumerWidget {
                 discountEntitlementDeadlineDate: discountEntitlementDeadlineDate,
                 onTap: () {
                   analytics.logEvent(name: 'pressed_discount_announcement_bar');
-                  showPremiumIntroductionSheet(context);
+                  showPremiumIntroductionSheet(context, source: PaywallSource.discountAnnouncementBar);
                 },
               );
             }
@@ -201,7 +202,7 @@ class AnnouncementBar extends HookConsumerWidget {
         if (!isAdsDisabled && pilllAds != null) {
           return PilllAdsAnnouncementBar(
             pilllAds: pilllAds,
-            onClose: () => showPremiumIntroductionSheet(context),
+            onClose: () => showPremiumIntroductionSheet(context, source: PaywallSource.pilllAdsAnnouncementBarClose),
           );
         }
 

--- a/lib/features/record/components/announcement_bar/components/ended_pill_sheet.dart
+++ b/lib/features/record/components/announcement_bar/components/ended_pill_sheet.dart
@@ -5,6 +5,7 @@ import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/features/pill_sheet_modified_history/page.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 
 class EndedPillSheet extends StatelessWidget {
@@ -31,7 +32,7 @@ class EndedPillSheet extends StatelessWidget {
             context,
           ).push(PillSheetModifiedHistoriesPageRoute.route());
         } else {
-          showPremiumIntroductionSheet(context);
+          showPremiumIntroductionSheet(context, source: PaywallSource.endedPillSheetBar);
         }
       },
       child: Container(

--- a/lib/features/record/components/announcement_bar/components/special_offering.dart
+++ b/lib/features/record/components/announcement_bar/components/special_offering.dart
@@ -5,6 +5,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/special_offering/page.dart';
 import 'package:pilll/utils/analytics.dart';
 
@@ -27,15 +28,10 @@ class SpecialOfferingAnnouncementBar extends HookConsumerWidget {
       child: GestureDetector(
         onTap: () {
           analytics.logEvent(name: 'special_offering_announcement_bar_tap');
-          showModalBottomSheet(
-            context: context,
-            builder: (context) => SpecialOfferingPage(
-              specialOfferingIsClosed: specialOfferingIsClosed,
-            ),
-            backgroundColor: Colors.transparent,
-            isScrollControlled: true,
-            enableDrag: false,
-            isDismissible: false,
+          showSpecialOfferingPage(
+            context,
+            source: PaywallSource.specialOfferingBar,
+            specialOfferingIsClosed: specialOfferingIsClosed,
           );
         },
         child: Stack(

--- a/lib/features/record/components/announcement_bar/components/special_offering2.dart
+++ b/lib/features/record/components/announcement_bar/components/special_offering2.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/special_offering/page2.dart';
 import 'package:pilll/utils/analytics.dart';
 
@@ -30,15 +31,10 @@ class SpecialOfferingAnnouncementBar2 extends HookConsumerWidget {
       child: GestureDetector(
         onTap: () {
           analytics.logEvent(name: 'special_offering_announcement_bar2_tap');
-          showModalBottomSheet(
-            context: context,
-            builder: (context) => SpecialOfferingPage2(
-              specialOfferingIsClosed2: specialOfferingIsClosed2,
-            ),
-            backgroundColor: Colors.transparent,
-            isScrollControlled: true,
-            enableDrag: false,
-            isDismissible: false,
+          showSpecialOfferingPage2(
+            context,
+            source: PaywallSource.specialOfferingBar2,
+            specialOfferingIsClosed2: specialOfferingIsClosed2,
           );
         },
         child: Stack(

--- a/lib/features/record/components/setting/components/appearance_mode/select_appearance_mode_modal.dart
+++ b/lib/features/record/components/setting/components/appearance_mode/select_appearance_mode_modal.dart
@@ -9,6 +9,7 @@ import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
 import 'package:pilll/components/molecules/select_circle.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/entity/setting.codegen.dart';
 import 'package:pilll/provider/setting.dart';
@@ -119,7 +120,7 @@ class SelectAppearanceModeModal extends HookConsumerWidget {
           );
           await registerReminderLocalNotification();
         } else if (isPremiumFunction) {
-          showPremiumIntroductionSheet(context);
+          showPremiumIntroductionSheet(context, source: PaywallSource.appearanceModeSelect);
         } else {
           // User selected non premium function mode
           await setPillSheetGroup(

--- a/lib/features/root/resolver/show_paywall_on_app_launch.dart
+++ b/lib/features/root/resolver/show_paywall_on_app_launch.dart
@@ -5,6 +5,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter/material.dart';
 import 'package:pilll/components/molecules/indicator.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/provider/remote_config_parameter.dart';
 import 'package:pilll/provider/typed_shared_preferences.dart';
@@ -36,7 +37,7 @@ class ShowPaywallOnAppLaunch extends HookConsumerWidget {
     useEffect(() {
       if (shownPaywallWhenAppFirstLaunch.value != true) {
         WidgetsBinding.instance.addPostFrameCallback((_) async {
-          await showPremiumIntroductionSheet(context);
+          await showPremiumIntroductionSheet(context, source: PaywallSource.appLaunch);
           shownPaywallWhenAppFirstLaunchNotifier.set(true);
         });
       }

--- a/lib/features/settings/components/rows/creating_new_pillsheet.dart
+++ b/lib/features/settings/components/rows/creating_new_pillsheet.dart
@@ -5,6 +5,7 @@ import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/entity/setting.codegen.dart';
 import 'package:pilll/provider/setting.dart';
@@ -64,7 +65,7 @@ class CreatingNewPillSheetRow extends HookConsumerWidget {
             ),
           );
         } else if (!isPremium) {
-          showPremiumIntroductionSheet(context);
+          showPremiumIntroductionSheet(context, source: PaywallSource.settingsCreatingNewPillSheetRow);
         }
       },
       value: setting.isAutomaticallyCreatePillSheet && (isPremium || isTrial),

--- a/lib/features/settings/components/rows/critical_alert.dart
+++ b/lib/features/settings/components/rows/critical_alert.dart
@@ -4,6 +4,7 @@ import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
 import 'package:pilll/entity/setting.codegen.dart';
 import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/features/settings/critical_alert/page.dart';
 import 'package:pilll/utils/analytics.dart';
@@ -52,7 +53,7 @@ class CriticalAlert extends HookConsumerWidget {
             context,
           ).push(CriticalAlertPageRoutes.route(setting: setting));
         } else {
-          showPremiumIntroductionSheet(context);
+          showPremiumIntroductionSheet(context, source: PaywallSource.settingsCriticalAlertRow);
         }
       },
     );

--- a/lib/features/settings/components/rows/premium_introduction.dart
+++ b/lib/features/settings/components/rows/premium_introduction.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/components/atoms/font.dart';
@@ -19,7 +20,7 @@ class PremiumIntroductionRow extends StatelessWidget {
     return ListTile(
       onTap: () {
         analytics.logEvent(name: 'tapped_premium_introduction_row');
-        showPremiumIntroductionSheet(context);
+        showPremiumIntroductionSheet(context, source: PaywallSource.settingsPremiumIntroductionRow);
       },
       title: Row(
         children: [

--- a/lib/features/settings/components/rows/quick_record.dart
+++ b/lib/features/settings/components/rows/quick_record.dart
@@ -3,6 +3,7 @@ import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 
 class QuickRecordRow extends StatelessWidget {
@@ -38,7 +39,7 @@ class QuickRecordRow extends StatelessWidget {
         if (isTrial) {
           return;
         }
-        showPremiumIntroductionSheet(context);
+        showPremiumIntroductionSheet(context, source: PaywallSource.settingsQuickRecordRow);
       },
     );
   }

--- a/lib/features/settings/components/rows/reminder_notification_customize_word.dart
+++ b/lib/features/settings/components/rows/reminder_notification_customize_word.dart
@@ -4,6 +4,7 @@ import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/features/reminder_notification_customize_word/page.dart';
 import 'package:pilll/entity/setting.codegen.dart';
@@ -54,7 +55,7 @@ class ReminderNotificationCustomizeWord extends HookConsumerWidget {
             context,
           ).push(ReminderNotificationCustomizeWordPageRoutes.route());
         } else {
-          showPremiumIntroductionSheet(context);
+          showPremiumIntroductionSheet(context, source: PaywallSource.settingsReminderCustomizeRow);
         }
       },
     );

--- a/lib/features/special_offering/page.dart
+++ b/lib/features/special_offering/page.dart
@@ -11,6 +11,7 @@ import 'package:pilll/features/error/error_alert.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/components/premium_introduction_discount.dart';
 import 'package:pilll/features/premium_introduction/components/premium_introduction_footer.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/components/app_store/app_store_review_cards.dart';
 import 'package:pilll/features/premium_introduction/components/annual_purchase_button.dart';
@@ -22,7 +23,12 @@ import 'package:url_launcher/url_launcher.dart';
 
 class SpecialOfferingPage extends HookConsumerWidget {
   final ValueNotifier<bool> specialOfferingIsClosed;
-  const SpecialOfferingPage({super.key, required this.specialOfferingIsClosed});
+  final PaywallSource source;
+  const SpecialOfferingPage({
+    super.key,
+    required this.specialOfferingIsClosed,
+    required this.source,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -31,6 +37,7 @@ class SpecialOfferingPage extends HookConsumerWidget {
             return SpecialOfferingPageBody(
               user: user,
               specialOfferingIsClosed: specialOfferingIsClosed,
+              source: source,
             );
           },
           error: (error, stack) => AlertDialog(
@@ -51,11 +58,13 @@ class SpecialOfferingPage extends HookConsumerWidget {
 class SpecialOfferingPageBody extends HookConsumerWidget {
   final User user;
   final ValueNotifier<bool> specialOfferingIsClosed;
+  final PaywallSource source;
 
   const SpecialOfferingPageBody({
     super.key,
     required this.user,
     required this.specialOfferingIsClosed,
+    required this.source,
   });
 
   @override
@@ -198,9 +207,7 @@ class SpecialOfferingPageBody extends HookConsumerWidget {
                           isLoading.value = true;
 
                           try {
-                            final shouldShowCompleteDialog = await purchase(
-                              package,
-                            );
+                            final shouldShowCompleteDialog = await purchase(package, source: source);
                             if (shouldShowCompleteDialog) {
                               if (context.mounted) {
                                 showDialog(
@@ -249,4 +256,28 @@ class SpecialOfferingPageBody extends HookConsumerWidget {
       },
     );
   }
+}
+
+Future<void> showSpecialOfferingPage(
+  BuildContext context, {
+  required PaywallSource source,
+  required ValueNotifier<bool> specialOfferingIsClosed,
+}) async {
+  analytics.logScreenView(screenName: 'SpecialOfferingPage');
+  analytics.logEvent(
+    name: 'paywall_viewed',
+    parameters: {'paywall_source': source.value},
+  );
+
+  await showModalBottomSheet(
+    context: context,
+    builder: (_) => SpecialOfferingPage(
+      source: source,
+      specialOfferingIsClosed: specialOfferingIsClosed,
+    ),
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    enableDrag: false,
+    isDismissible: false,
+  );
 }

--- a/lib/features/special_offering/page2.dart
+++ b/lib/features/special_offering/page2.dart
@@ -11,6 +11,7 @@ import 'package:pilll/features/error/error_alert.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/components/premium_introduction_discount.dart';
 import 'package:pilll/features/premium_introduction/components/premium_introduction_footer.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/components/app_store/app_store_review_cards.dart';
 import 'package:pilll/features/premium_introduction/components/monthly_purchase_button.dart';
@@ -22,9 +23,11 @@ import 'package:url_launcher/url_launcher.dart';
 
 class SpecialOfferingPage2 extends HookConsumerWidget {
   final ValueNotifier<bool> specialOfferingIsClosed2;
+  final PaywallSource source;
   const SpecialOfferingPage2({
     super.key,
     required this.specialOfferingIsClosed2,
+    required this.source,
   });
 
   @override
@@ -34,6 +37,7 @@ class SpecialOfferingPage2 extends HookConsumerWidget {
             return SpecialOfferingPageBody(
               user: user,
               specialOfferingIsClosed2: specialOfferingIsClosed2,
+              source: source,
             );
           },
           error: (error, stack) => AlertDialog(
@@ -54,11 +58,13 @@ class SpecialOfferingPage2 extends HookConsumerWidget {
 class SpecialOfferingPageBody extends HookConsumerWidget {
   final User user;
   final ValueNotifier<bool> specialOfferingIsClosed2;
+  final PaywallSource source;
 
   const SpecialOfferingPageBody({
     super.key,
     required this.user,
     required this.specialOfferingIsClosed2,
+    required this.source,
   });
 
   @override
@@ -198,9 +204,7 @@ class SpecialOfferingPageBody extends HookConsumerWidget {
                           isLoading.value = true;
 
                           try {
-                            final shouldShowCompleteDialog = await purchase(
-                              package,
-                            );
+                            final shouldShowCompleteDialog = await purchase(package, source: source);
                             if (shouldShowCompleteDialog) {
                               if (context.mounted) {
                                 showDialog(
@@ -249,4 +253,28 @@ class SpecialOfferingPageBody extends HookConsumerWidget {
       },
     );
   }
+}
+
+Future<void> showSpecialOfferingPage2(
+  BuildContext context, {
+  required PaywallSource source,
+  required ValueNotifier<bool> specialOfferingIsClosed2,
+}) async {
+  analytics.logScreenView(screenName: 'SpecialOfferingPage2');
+  analytics.logEvent(
+    name: 'paywall_viewed',
+    parameters: {'paywall_source': source.value},
+  );
+
+  await showModalBottomSheet(
+    context: context,
+    builder: (_) => SpecialOfferingPage2(
+      source: source,
+      specialOfferingIsClosed2: specialOfferingIsClosed2,
+    ),
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    enableDrag: false,
+    isDismissible: false,
+  );
 }

--- a/lib/provider/purchase.dart
+++ b/lib/provider/purchase.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/secret/secret.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/util/discount_deadline.dart';
 import 'package:pilll/features/premium_introduction/util/map_to_error.dart';
 import 'package:pilll/features/error/alert_error.dart';
@@ -166,7 +167,7 @@ class Purchase {
   /// Return true indicates end of regularllly pattern.
   /// Return false indicates not regulally pattern.
   /// Return value is used to display the completion page
-  Future<bool> call(Package package) async {
+  Future<bool> call(Package package, {required PaywallSource source}) async {
     try {
       final purchaserInfo = await Purchases.purchasePackage(package);
       final premiumEntitlement = purchaserInfo.entitlements.all[premiumEntitlements];
@@ -176,6 +177,14 @@ class Purchase {
       if (!premiumEntitlement.isActive) {
         throw AlertError(L.purchaseErrorPurchasePendingError);
       }
+      analytics.logEvent(
+        name: 'purchase_succeeded',
+        parameters: {
+          'paywall_source': source.value,
+          'package_type': package.packageType.name,
+          'product_identifier': package.storeProduct.identifier,
+        },
+      );
       await callUpdatePurchaseInfo(purchaserInfo);
       return Future.value(true);
     } on PlatformException catch (exception, stack) {

--- a/plans/paywall-paywall-source-paywall-source-enumerated-clover.md
+++ b/plans/paywall-paywall-source-paywall-source-enumerated-clover.md
@@ -1,0 +1,529 @@
+# Paywall 導線(paywall_source) と 課金率分析の実装プラン
+
+## Context
+
+Pilll では PremiumIntroductionSheet (通常 Paywall) が 21箇所、SpecialOfferingPage / SpecialOfferingPage2 (キャンペーン Paywall) が 2箇所、計 23 箇所から呼ばれているが、現状「どこから来たか」を識別する `paywall_source` は実装されていない。Firebase Analytics 上では各 caller 個別の `pressed_xxx` イベントから直前イベントの逆引きで経路を推定している (`PilllBackend/bigquery/queries/paywall_entry_route_conversion.sql`) が、精度が低く `unknown_or_app_launch` などに丸まる。
+
+加えて「購入が完了した」ことを示す Analytics イベントも存在せず、`pressed_*_purchase_button` (ボタン押下) を購入の代理指標にしているため、ユーザーキャンセル・PlatformException を含めて CV 数を過大評価する。
+
+本プランでは以下を満たす:
+1. Flutter 側で `PaywallSource` enum を一級市民として導入し、表示時イベント `paywall_viewed` に明示的に乗せる
+2. 購入実完了時の `purchase_succeeded` イベントを新規追加し、同じ `paywall_source` を乗せる
+3. 既存 `pressed_*_purchase_button` にも `paywall_source` を付与し、表示 → 押下 → 完了のファネル分析を可能にする
+4. 集計 SQL は PilllBackend 側に Issue を立てて別タスクとして引き継ぐ
+
+## 現状の関連コード
+
+| 役割 | パス |
+|---|---|
+| Paywall 起動関数 | `lib/features/premium_introduction/premium_introduction_sheet.dart:168` `showPremiumIntroductionSheet(BuildContext context)` |
+| Paywall 本体 | `lib/features/premium_introduction/premium_introduction_sheet.dart` `PremiumIntroductionSheet` / `PremiumIntroductionSheetBody` |
+| 購入ボタン群 | `lib/features/premium_introduction/components/purchase_buttons.dart` |
+| キャンペーン Paywall | `lib/features/special_offering/page.dart` `SpecialOfferingPage` / `lib/features/special_offering/page2.dart` `SpecialOfferingPage2` |
+| キャンペーン Paywall 起動 | `lib/features/record/components/announcement_bar/components/special_offering.dart:32` / `special_offering2.dart:35` (`showModalBottomSheet` 直書き) |
+| 購入実行 | `lib/provider/purchase.dart:165-205` `class Purchase { Future<bool> call(Package package) }` |
+| Analytics ラッパー | `lib/utils/analytics.dart` `analytics.logEvent({required String name, Map<String, Object?>? parameters})` |
+| Offering 種別 enum (購入プラン構成、別概念) | `lib/provider/purchase.dart:20` `enum OfferingType { discount, specialOffering, premium }` |
+
+## 実装
+
+### Step 1. PaywallSource enum 新規作成
+
+新規ファイル: `lib/features/premium_introduction/paywall_source.dart`
+
+```dart
+// Firebase Analytics の paywall_viewed / purchase_succeeded / pressed_*_purchase_button
+// に paywall_source パラメータとして送出され、BigQuery で経路別 CV 率を集計する。
+//
+// 値の追加・変更時は PilllBackend/bigquery/queries/paywall_source_conversion.sql の
+// 集計対象と整合させること。
+enum PaywallSource {
+  // アプリ初回起動時の自動表示
+  appLaunch,
+  // HomePage 月次自動表示 (Trial 終了後の再アピール)
+  homeMonthly,
+  // カレンダー画面のオーバーレイ
+  calendarOverlay,
+  // 服用履歴カード本体
+  pillSheetModifiedHistoryCard,
+  // 服用履歴カードの More ボタン
+  pillSheetModifiedHistoryMore,
+  // 生理履歴カード本体
+  menstruationHistoryCard,
+  // 生理履歴カードの「もっと見る」
+  menstruationHistoryMore,
+  // 日記投稿の体調詳細
+  diaryPhysicalConditionDetail,
+  // レコード画面の表示モード切替モーダル
+  appearanceModeSelect,
+  // 割引キャンペーン announcement bar
+  discountAnnouncementBar,
+  // PilllAds bar 閉じる時
+  pilllAdsAnnouncementBarClose,
+  // ピルシート終了 bar
+  endedPillSheetBar,
+  // 設定画面 - プレミアムプラン行
+  settingsPremiumIntroductionRow,
+  // 設定画面 - 緊急通知行 (Premium ロック)
+  settingsCriticalAlertRow,
+  // 設定画面 - 新規ピルシート作成行 (Premium ロック)
+  settingsCreatingNewPillSheetRow,
+  // 設定画面 - クイック記録行 (Premium ロック)
+  settingsQuickRecordRow,
+  // 設定画面 - リマインダー文言カスタマイズ行 (Premium ロック)
+  settingsReminderCustomizeRow,
+  // 機能訴求 - AlarmKit
+  featureAppealAlarmKit,
+  // 機能訴求 - 表示モード日付
+  featureAppealAppearanceMode,
+  // 機能訴求 - 新規ピルシート作成
+  featureAppealCreatingPillSheet,
+  // 機能訴求 - 緊急通知
+  featureAppealCriticalAlert,
+  // 機能訴求 - クイック記録
+  featureAppealQuickRecord,
+  // 機能訴求 - リマインダー文言カスタマイズ
+  featureAppealReminderCustomize,
+  // SpecialOfferingPage 起動 announcement bar (年額)
+  specialOfferingBar,
+  // SpecialOfferingPage2 起動 announcement bar (月額)
+  specialOfferingBar2,
+}
+
+extension PaywallSourceFunction on PaywallSource {
+  String get value {
+    switch (this) {
+      case PaywallSource.appLaunch:
+        return 'app_launch';
+      case PaywallSource.homeMonthly:
+        return 'home_monthly';
+      case PaywallSource.calendarOverlay:
+        return 'calendar_overlay';
+      case PaywallSource.pillSheetModifiedHistoryCard:
+        return 'pill_sheet_modified_history_card';
+      case PaywallSource.pillSheetModifiedHistoryMore:
+        return 'pill_sheet_modified_history_more';
+      case PaywallSource.menstruationHistoryCard:
+        return 'menstruation_history_card';
+      case PaywallSource.menstruationHistoryMore:
+        return 'menstruation_history_more';
+      case PaywallSource.diaryPhysicalConditionDetail:
+        return 'diary_physical_condition_detail';
+      case PaywallSource.appearanceModeSelect:
+        return 'appearance_mode_select';
+      case PaywallSource.discountAnnouncementBar:
+        return 'discount_announcement_bar';
+      case PaywallSource.pilllAdsAnnouncementBarClose:
+        return 'pilll_ads_announcement_bar_close';
+      case PaywallSource.endedPillSheetBar:
+        return 'ended_pill_sheet_bar';
+      case PaywallSource.settingsPremiumIntroductionRow:
+        return 'settings_premium_introduction_row';
+      case PaywallSource.settingsCriticalAlertRow:
+        return 'settings_critical_alert_row';
+      case PaywallSource.settingsCreatingNewPillSheetRow:
+        return 'settings_creating_new_pill_sheet_row';
+      case PaywallSource.settingsQuickRecordRow:
+        return 'settings_quick_record_row';
+      case PaywallSource.settingsReminderCustomizeRow:
+        return 'settings_reminder_customize_row';
+      case PaywallSource.featureAppealAlarmKit:
+        return 'feature_appeal_alarm_kit';
+      case PaywallSource.featureAppealAppearanceMode:
+        return 'feature_appeal_appearance_mode';
+      case PaywallSource.featureAppealCreatingPillSheet:
+        return 'feature_appeal_creating_pill_sheet';
+      case PaywallSource.featureAppealCriticalAlert:
+        return 'feature_appeal_critical_alert';
+      case PaywallSource.featureAppealQuickRecord:
+        return 'feature_appeal_quick_record';
+      case PaywallSource.featureAppealReminderCustomize:
+        return 'feature_appeal_reminder_customize';
+      case PaywallSource.specialOfferingBar:
+        return 'special_offering_bar';
+      case PaywallSource.specialOfferingBar2:
+        return 'special_offering_bar2';
+    }
+  }
+}
+```
+
+設計意図:
+- enum 名の rename / 難読化に影響されないよう `value` は明示列挙
+- 25 値だが、ユーザー指示の「細粒度 23値」+ SpecialOffering 起動 2 値で構成
+- `feature_appeal_*` / `settings_*` も個別値にして drill down 不要 (BigQuery で素直に GROUP BY できる)
+
+### Step 2. showPremiumIntroductionSheet の signature 更新 + paywall_viewed 送出
+
+`lib/features/premium_introduction/premium_introduction_sheet.dart` の修正:
+
+```dart
+// L27 付近
+class PremiumIntroductionSheet extends HookConsumerWidget {
+  const PremiumIntroductionSheet({super.key, required this.source});
+  final PaywallSource source;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // ... (既存のロジックはそのまま)
+    return PremiumIntroductionSheetBody(source: source);
+  }
+}
+
+// L50 付近
+class PremiumIntroductionSheetBody extends HookConsumerWidget {
+  const PremiumIntroductionSheetBody({super.key, required this.source});
+  final PaywallSource source;
+  // ... (build 内で PurchaseButtons(source: source, ...) を渡す)
+}
+
+// L168 (showPremiumIntroductionSheet)
+Future<void> showPremiumIntroductionSheet(
+  BuildContext context, {
+  required PaywallSource source,
+}) async {
+  analytics.logScreenView(screenName: 'PremiumIntroductionSheet');
+  analytics.logEvent(
+    name: 'paywall_viewed',
+    parameters: {'paywall_source': source.value},
+  );
+  await showModalBottomSheet(
+    context: context,
+    builder: (_) => PremiumIntroductionSheet(source: source),
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+  );
+}
+```
+
+ポイント:
+- `BuildContext` は positional 維持、`source` は **named required** (CLAUDE.md ルール)。これにより 23 箇所の caller 修正漏れがコンパイルエラーで検知される
+- `paywall_viewed` イベント名は新規。既存の `screen_PremiumIntroductionSheet` (`logScreenView` 由来) は互換のため残す
+
+### Step 3. SpecialOfferingPage / SpecialOfferingPage2 の signature 更新 + ヘルパー追加
+
+`lib/features/special_offering/page.dart` (`SpecialOfferingPage`):
+
+```dart
+class SpecialOfferingPage extends HookConsumerWidget {
+  const SpecialOfferingPage({
+    super.key,
+    required this.source,
+    required this.specialOfferingIsClosed,
+  });
+  final PaywallSource source;
+  final ValueNotifier<bool> specialOfferingIsClosed;
+  // ... 既存ロジック維持。purchase 呼び出し箇所で source を渡す
+}
+
+Future<void> showSpecialOfferingPage(
+  BuildContext context, {
+  required PaywallSource source,
+  required ValueNotifier<bool> specialOfferingIsClosed,
+}) async {
+  analytics.logScreenView(screenName: 'SpecialOfferingPage');
+  analytics.logEvent(
+    name: 'paywall_viewed',
+    parameters: {'paywall_source': source.value},
+  );
+  await showModalBottomSheet(
+    context: context,
+    builder: (_) => SpecialOfferingPage(
+      source: source,
+      specialOfferingIsClosed: specialOfferingIsClosed,
+    ),
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    enableDrag: false,
+    isDismissible: false,
+  );
+}
+```
+
+`page2.dart` の `SpecialOfferingPage2` / `showSpecialOfferingPage2` も同様の構造。
+
+呼び出し側 `lib/features/record/components/announcement_bar/components/special_offering.dart:30-39` を:
+
+```dart
+// before (showModalBottomSheet 直書き)
+await showModalBottomSheet(
+  context: context,
+  builder: (_) => SpecialOfferingPage(specialOfferingIsClosed: specialOfferingIsClosed),
+  ...
+);
+
+// after
+await showSpecialOfferingPage(
+  context,
+  source: PaywallSource.specialOfferingBar,
+  specialOfferingIsClosed: specialOfferingIsClosed,
+);
+```
+
+`special_offering2.dart:33-43` も同様に `showSpecialOfferingPage2(... source: PaywallSource.specialOfferingBar2)` に置換。
+
+### Step 4. 23 箇所の caller を更新
+
+| ファイル | source 値 |
+|---|---|
+| `lib/features/root/resolver/show_paywall_on_app_launch.dart:39` | `PaywallSource.appLaunch` |
+| `lib/features/home/page.dart:154` | `PaywallSource.homeMonthly` |
+| `lib/features/calendar/page.dart:301` | `PaywallSource.calendarOverlay` |
+| `lib/features/calendar/components/pill_sheet_modified_history/pill_sheet_modified_history_card.dart:152` | `PaywallSource.pillSheetModifiedHistoryCard` |
+| `lib/features/calendar/components/pill_sheet_modified_history/components/pill_sheet_modified_history_more_button.dart:27` | `PaywallSource.pillSheetModifiedHistoryMore` |
+| `lib/features/menstruation/history/menstruation_history_card.dart:38` | `PaywallSource.menstruationHistoryCard` |
+| `lib/features/menstruation/history/menstruation_history_card.dart:75` | `PaywallSource.menstruationHistoryMore` |
+| `lib/features/diary_post/physical_condition_details.dart:59` | `PaywallSource.diaryPhysicalConditionDetail` |
+| `lib/features/record/components/setting/components/appearance_mode/select_appearance_mode_modal.dart:122` | `PaywallSource.appearanceModeSelect` |
+| `lib/features/record/components/announcement_bar/announcement_bar.dart:155` | `PaywallSource.discountAnnouncementBar` |
+| `lib/features/record/components/announcement_bar/announcement_bar.dart:204` | `PaywallSource.pilllAdsAnnouncementBarClose` |
+| `lib/features/record/components/announcement_bar/components/ended_pill_sheet.dart:34` | `PaywallSource.endedPillSheetBar` |
+| `lib/features/settings/components/rows/premium_introduction.dart:22` | `PaywallSource.settingsPremiumIntroductionRow` |
+| `lib/features/settings/components/rows/critical_alert.dart:55` | `PaywallSource.settingsCriticalAlertRow` |
+| `lib/features/settings/components/rows/creating_new_pillsheet.dart:67` | `PaywallSource.settingsCreatingNewPillSheetRow` |
+| `lib/features/settings/components/rows/quick_record.dart:41` | `PaywallSource.settingsQuickRecordRow` |
+| `lib/features/settings/components/rows/reminder_notification_customize_word.dart:57` | `PaywallSource.settingsReminderCustomizeRow` |
+| `lib/features/feature_appeal/alarm_kit/alarm_kit_help_page.dart:140` | `PaywallSource.featureAppealAlarmKit` |
+| `lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart:118` | `PaywallSource.featureAppealAppearanceMode` |
+| `lib/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page.dart:140` | `PaywallSource.featureAppealCreatingPillSheet` |
+| `lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart:136` | `PaywallSource.featureAppealCriticalAlert` |
+| `lib/features/feature_appeal/quick_record/quick_record_help_page.dart:147` | `PaywallSource.featureAppealQuickRecord` |
+| `lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart:134` | `PaywallSource.featureAppealReminderCustomize` |
+
+修正例 (`settings/components/rows/premium_introduction.dart`):
+
+```dart
+// before
+onTap: () => showPremiumIntroductionSheet(context),
+// after
+onTap: () => showPremiumIntroductionSheet(context, source: PaywallSource.settingsPremiumIntroductionRow),
+```
+
+### Step 5. Purchase.call の signature 更新 + purchase_succeeded 送出
+
+`lib/provider/purchase.dart` の修正 (L165-205):
+
+```dart
+class Purchase {
+  Future<bool> call(Package package, {required PaywallSource source}) async {
+    try {
+      final purchaserInfo = await Purchases.purchasePackage(package);
+      final premiumEntitlement = purchaserInfo.entitlements.all[premiumEntitlements];
+      if (premiumEntitlement == null) {
+        throw AssertionError(L.unexpectedPremiumEntitlementsIsNotExists);
+      }
+      if (!premiumEntitlement.isActive) {
+        throw AlertError(L.purchaseErrorPurchasePendingError);
+      }
+      analytics.logEvent(
+        name: 'purchase_succeeded',
+        parameters: {
+          'paywall_source': source.value,
+          'package_type': package.packageType.name,
+          'product_identifier': package.storeProduct.identifier,
+        },
+      );
+      await callUpdatePurchaseInfo(purchaserInfo);
+      return Future.value(true);
+    } on PlatformException catch (e) {
+      // 既存の catched_purchase_exception 送出ロジックを維持
+      // ...
+      rethrow;
+    }
+  }
+}
+```
+
+設計意図:
+- `purchase_succeeded` は `Purchase.call` 内、`premiumEntitlement.isActive == true` 確定後に発火
+- `Purchases.addCustomerInfoUpdateListener(callUpdatePurchaseInfo)` 経由 (`purchase.dart:284`) で発火する `callUpdatePurchaseInfo` は復元・他端末同期で走るパスのため、ここでは `purchase_succeeded` は発火しない (paywall_source が無いため)
+- `package.packageType.name` は purchases_flutter の `PackageType` enum 標準名を文字列化
+
+### Step 6. 購入ボタン群に source 伝搬 + pressed_*_purchase_button に paywall_source 付与
+
+`lib/features/premium_introduction/components/purchase_buttons.dart`:
+
+```dart
+class PurchaseButtons extends HookConsumerWidget {
+  const PurchaseButtons({
+    super.key,
+    required this.source,
+    required this.offeringType,
+    // ... 既存引数
+  });
+  final PaywallSource source;
+  final OfferingType offeringType;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // L48 付近 (月額ボタン)
+    onPressed: () async {
+      analytics.logEvent(
+        name: 'pressed_monthly_purchase_button',
+        parameters: {'paywall_source': source.value},
+      );
+      final purchase = ref.read(purchaseProvider);
+      await purchase(monthlyPackage, source: source);
+    },
+
+    // L59 付近 (年額ボタン)
+    analytics.logEvent(
+      name: 'pressed_annual_purchase_button',
+      parameters: {'paywall_source': source.value},
+    );
+    await purchase(annualPackage, source: source);
+
+    // L74 付近 (買い切りボタン)
+    analytics.logEvent(
+      name: 'pressed_lifetime_purchase_button',
+      parameters: {'paywall_source': source.value},
+    );
+    await purchase(lifetimePackage, source: source);
+  }
+}
+```
+
+`SpecialOfferingPage` / `SpecialOfferingPage2` の購入ボタンも同様に `source` を保持し、`purchase(package, source: source)` を呼ぶ。専用イベント (`special_offering_close_button_tapped` など) にも `paywall_source` パラメータを追加。
+
+### Step 7. Unit Test 追加
+
+新規ファイル: `test/features/premium_introduction/paywall_source_test.dart`
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
+
+void main() {
+  group('#PaywallSourceFunction', () {
+    test('全 PaywallSource の value がユニーク', () {
+      final values = PaywallSource.values.map((e) => e.value).toList();
+      expect(values.toSet().length, values.length, reason: '重複: $values');
+    });
+
+    test('全 PaywallSource の value が snake_case', () {
+      final pattern = RegExp(r'^[a-z][a-z0-9_]*$');
+      for (final s in PaywallSource.values) {
+        expect(pattern.hasMatch(s.value), isTrue, reason: s.value);
+      }
+    });
+
+    test('代表値の value が期待通り', () {
+      expect(PaywallSource.appLaunch.value, 'app_launch');
+      expect(PaywallSource.settingsPremiumIntroductionRow.value, 'settings_premium_introduction_row');
+      expect(PaywallSource.featureAppealAlarmKit.value, 'feature_appeal_alarm_kit');
+      expect(PaywallSource.specialOfferingBar2.value, 'special_offering_bar2');
+    });
+
+    test('value 文字列が Firebase Analytics の40字制限内', () {
+      for (final s in PaywallSource.values) {
+        expect(s.value.length, lessThanOrEqualTo(40), reason: s.value);
+      }
+    });
+  });
+}
+```
+
+### Step 8. 既存 Widget Test の修正
+
+`test/features/premium_introduction/premium_introduction_sheet_test.dart` (既存) で `showPremiumIntroductionSheet` を呼んでいるテストに `source: PaywallSource.appLaunch` を追加。
+
+23 caller の Widget Test を全部書くのは過剰なので、enum.values.length === 25 の不変条件 + named required によるコンパイラ強制で漏れ防止する方針。
+
+### Step 9. PilllBackend 側 Issue 作成
+
+PilllBackend リポジトリ (https://github.com/bannzai/PilllBackend) に Issue を新規作成する。Issue タイトル / 本文:
+
+```
+Title: paywall_source パラメータベースの Paywall 経路別 CV 率集計 SQL を追加
+
+Body:
+Pilll Flutter 側 (PR #xxx) で paywall_viewed / purchase_succeeded / pressed_*_purchase_button イベントに paywall_source パラメータを送出するようになる。
+これに伴い、bigquery/queries/paywall_source_conversion.sql を新規追加して経路別の CV 率を集計したい。
+
+集計したいメトリクス:
+- paywall_source 別の paywall_viewed 数
+- paywall_source 別の purchase_succeeded 数
+- paywall_source 別の CV 率 (purchase_succeeded / paywall_viewed)
+- paywall_source × deviceOS 別の CV 率
+- ファネル: paywall_viewed → pressed_*_purchase_button → purchase_succeeded
+
+実装の起点:
+- 既存 bigquery/queries/paywall_entry_route_conversion.sql の構造を参考に
+- イベント名は paywall_viewed / purchase_succeeded / pressed_monthly_purchase_button / pressed_annual_purchase_button / pressed_lifetime_purchase_button
+- paywall_source の取り得る値は Pilll Flutter リポジトリの lib/features/premium_introduction/paywall_source.dart を参照
+
+リリース後 1〜2ヶ月は paywall_entry_route_conversion.sql (逆引き) と paywall_source_conversion.sql (明示) を併用して精度差を比較する。
+```
+
+(Issue 作成自体はユーザーが gh CLI で実行 or 後続作業で手動)
+
+## 検証
+
+### コード生成 / 静的解析 / テスト
+1. コード生成不要 (freezed / json_serializable は使わない)
+2. `flutter analyze` でエラーなし (named required 必須なので 23 caller の修正漏れがあるとコンパイルエラー)
+3. `flutter test test/features/premium_introduction/paywall_source_test.dart` 通過
+4. `flutter test` 全件通過
+
+### iOS / Android ビルド
+5. `flutter build ios --flavor develop --no-codesign` 成功
+6. `flutter build apk --flavor develop` 成功
+
+### 手動 / E2E
+7. iOS シミュレータで以下を確認 (`/sim-manager` + `/verify-ui-mobile-mcp`):
+   - 設定 → プレミアムプラン行タップ → Paywall 表示
+   - Firebase DebugView (or `kDebugMode` 時の `print` 出力) で `paywall_viewed` + `paywall_source: settings_premium_introduction_row` が送出されていること
+   - 月額ボタン押下 → `pressed_monthly_purchase_button` + `paywall_source: settings_premium_introduction_row` が送出されていること
+   - サンドボックス購入完了後 → `purchase_succeeded` + `paywall_source: settings_premium_introduction_row` + `package_type: monthly` が送出されていること
+8. SpecialOfferingPage の announcement bar 経由でも同様に `paywall_source: special_offering_bar` が送出されていることを確認
+
+### BigQuery 検証 (リリース後)
+9. リリース後 1 週間の `paywall_viewed` イベント数と既存 `screen_PremiumIntroductionSheet` イベント数の比較。極端な乖離 (50% 以上) があれば送信漏れ箇所を疑う
+10. PilllBackend Issue (Step 9) で SQL を作成後、`bash bigquery/scripts/run_query.sh bigquery/queries/paywall_source_conversion.sql --max_rows=100` で初回集計
+
+## 影響範囲・リスク
+
+- **過去データ**: 既存ユーザーのうちアプリ更新前のセッションは `paywall_source IS NULL` で残る。BigQuery 側で `COALESCE(paywall_source, 'unknown_legacy')` 扱い
+- **23 caller 修正漏れ**: named required で**コンパイラが防御**。CI 通過 = 修正完了
+- **既存 BigQuery view への影響**: 新規イベント `paywall_viewed` / `purchase_succeeded` を追加するだけで、既存 `screen_PremiumIntroductionSheet` / `pressed_*_purchase_button` / `start_update_purchase_info` 等は維持。既存 view への影響なし
+- **`Purchase.call` listener 経由パス**: `Purchases.addCustomerInfoUpdateListener` 由来の `callUpdatePurchaseInfo` は復元・他端末同期で走るが、ここでは `purchase_succeeded` を発火しない。これは設計意図 (購入完了 ≠ 状態同期) に合致
+
+## 作業順序
+
+1. Step 1: PaywallSource enum 新規作成 + Step 7 の Unit Test 追加
+2. Step 2: showPremiumIntroductionSheet signature 更新 (named required `source` 追加、`paywall_viewed` 送出)
+3. Step 3: SpecialOfferingPage / SpecialOfferingPage2 signature 更新 + showSpecialOfferingPage ヘルパー追加
+4. Step 4: 23 caller を一括修正 (コンパイルエラーが消えるまで)
+5. Step 5: Purchase.call signature 更新 + `purchase_succeeded` 送出
+6. Step 6: PurchaseButtons / SpecialOffering 系購入ボタンに source 伝搬 + `pressed_*_purchase_button` に `paywall_source` 付与
+7. Step 8: 既存 Widget Test の修正
+8. `flutter analyze` / `flutter test` / `flutter build ios` / `flutter build apk` 全通過確認
+9. iOS シミュレータで手動検証
+10. PR 作成
+11. Step 9: PilllBackend リポジトリに Issue 作成
+
+---
+
+## チェックリスト
+
+### 実装内容
+- [ ] 変更対象ファイルごとに具体的なコード提案をコードブロックで記載している
+- [ ] 既存コードのパターン・構成を確認し、同じパターンで実装している
+- [ ] コード生成: 不要 (freezed / json_serializable 未使用)
+- [ ] 静的解析: `flutter analyze` エラーなし
+- [ ] テスト: `flutter test` 全件パス
+- [ ] iOS ビルド: `flutter build ios` 成功
+- [ ] Android ビルド: `flutter build apk` 成功
+- [ ] 新規・変更機能に対するテストが存在する (PaywallSource Unit Test 新規追加)
+- [ ] Maestro E2E: 該当する maestro flow があれば実行、なければ新規作成 (Paywall 表示・購入導線の既存 flow があれば paywall_source 送出を含む形に更新確認)
+- [ ] Entity 命名: フィールド名が省略されていない (PaywallSource enum 値は full name)
+- [ ] DB 操作: Firestore 操作は `call` クラスの Provider 経由 (本タスクでは Firestore 操作なし)
+- [ ] 引数: 関数・コンストラクタの引数に `{required}` あり (showPremiumIntroductionSheet / showSpecialOfferingPage / Purchase.call / PurchaseButtons の `source`)
+- [ ] ref 使い分け: build 内は `ref.watch`、コールバック・操作は `ref.read` (PurchaseButtons の `purchaseProvider` は `ref.read`)
+- [ ] サブコレクション Entity に親ドキュメント ID フィールドあり (該当なし)
+- [ ] エラーメッセージはそのまま表示 (`Purchase.call` の例外処理は既存ロジック維持)
+
+### 追加確認
+- [ ] PilllBackend リポジトリに「paywall_source 集計 SQL 追加」Issue を作成した
+- [ ] 23 caller すべてに source 引数を追加し、コンパイルエラーがないことを確認した
+- [ ] iOS シミュレータで Firebase Analytics DebugView もしくは kDebugMode の print 出力で `paywall_viewed` / `pressed_*_purchase_button` / `purchase_succeeded` がそれぞれ正しい `paywall_source` 値を送出していることを目視確認した

--- a/test/features/premium_introduction/paywall_source_test.dart
+++ b/test/features/premium_introduction/paywall_source_test.dart
@@ -3,18 +3,6 @@ import 'package:pilll/features/premium_introduction/paywall_source.dart';
 
 void main() {
   group('#PaywallSourceFunction', () {
-    test('全 PaywallSource の value がユニーク', () {
-      final values = PaywallSource.values.map((e) => e.value).toList();
-      expect(values.toSet().length, values.length, reason: '重複: $values');
-    });
-
-    test('全 PaywallSource の value が snake_case', () {
-      final pattern = RegExp(r'^[a-z][a-z0-9_]*$');
-      for (final source in PaywallSource.values) {
-        expect(pattern.hasMatch(source.value), isTrue, reason: source.value);
-      }
-    });
-
     test('全 PaywallSource の value が Firebase Analytics の40字制限内', () {
       for (final source in PaywallSource.values) {
         expect(source.value.length, lessThanOrEqualTo(40), reason: source.value);

--- a/test/features/premium_introduction/paywall_source_test.dart
+++ b/test/features/premium_introduction/paywall_source_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
+
+void main() {
+  group('#PaywallSourceFunction', () {
+    test('全 PaywallSource の value がユニーク', () {
+      final values = PaywallSource.values.map((e) => e.value).toList();
+      expect(values.toSet().length, values.length, reason: '重複: $values');
+    });
+
+    test('全 PaywallSource の value が snake_case', () {
+      final pattern = RegExp(r'^[a-z][a-z0-9_]*$');
+      for (final source in PaywallSource.values) {
+        expect(pattern.hasMatch(source.value), isTrue, reason: source.value);
+      }
+    });
+
+    test('全 PaywallSource の value が Firebase Analytics の40字制限内', () {
+      for (final source in PaywallSource.values) {
+        expect(source.value.length, lessThanOrEqualTo(40), reason: source.value);
+      }
+    });
+
+    test('代表値の value が期待通り', () {
+      expect(PaywallSource.appLaunch.value, 'app_launch');
+      expect(PaywallSource.settingsPremiumIntroductionRow.value, 'settings_premium_introduction_row');
+      expect(PaywallSource.featureAppealAlarmKit.value, 'feature_appeal_alarm_kit');
+      expect(PaywallSource.specialOfferingBar2.value, 'special_offering_bar2');
+    });
+  });
+}

--- a/test/features/premium_introduction/premium_introduction_sheet_test.dart
+++ b/test/features/premium_introduction/premium_introduction_sheet_test.dart
@@ -5,6 +5,7 @@ import 'package:pilll/provider/locale.dart';
 import 'package:pilll/provider/remote_config_parameter.dart';
 import 'package:pilll/features/premium_introduction/components/premium_introduction_discount.dart';
 import 'package:pilll/features/premium_introduction/components/premium_user_thanks.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/features/premium_introduction/util/discount_deadline.dart';
 import 'package:pilll/provider/user.dart';
@@ -116,7 +117,7 @@ void main() {
             fakeDiscountEntitlementDeadlineDate: null,
           );
 
-          const sheet = PremiumIntroductionSheet();
+          const sheet = PremiumIntroductionSheet(source: PaywallSource.appLaunch);
           await tester.pumpWidget(
             MaterialApp(
               home: ProviderScope(
@@ -178,7 +179,7 @@ void main() {
           fakeDiscountEntitlementDeadlineDate: discountEntitlementDeadlineDate,
         );
 
-        const sheet = PremiumIntroductionSheet();
+        const sheet = PremiumIntroductionSheet(source: PaywallSource.appLaunch);
         await tester.pumpWidget(
           MaterialApp(
             home: ProviderScope(
@@ -242,7 +243,7 @@ void main() {
           ),
         );
 
-        const sheet = PremiumIntroductionSheet();
+        const sheet = PremiumIntroductionSheet(source: PaywallSource.appLaunch);
         await tester.pumpWidget(
           MaterialApp(
             home: ProviderScope(
@@ -307,7 +308,7 @@ void main() {
           ),
         );
 
-        const sheet = PremiumIntroductionSheet();
+        const sheet = PremiumIntroductionSheet(source: PaywallSource.appLaunch);
         await tester.pumpWidget(
           MaterialApp(
             home: ProviderScope(
@@ -368,7 +369,7 @@ void main() {
           fakeDiscountEntitlementDeadlineDate: null,
         );
 
-        const sheet = PremiumIntroductionSheet();
+        const sheet = PremiumIntroductionSheet(source: PaywallSource.appLaunch);
         await tester.pumpWidget(
           MaterialApp(
             home: ProviderScope(


### PR DESCRIPTION
## Abstract

Paywall (PremiumIntroductionSheet / SpecialOfferingPage / SpecialOfferingPage2) の起動経路を表す `PaywallSource` enum を導入し、Firebase Analytics に `paywall_viewed` / `purchase_succeeded` / `pressed_*_purchase_button` イベントとして経路情報を送出するようにした。これにより BigQuery 上で経路別の課金率 (CV 率) を集計できるようになる。

## Why

これまで Paywall の起動経路は Firebase Analytics の直前イベントから逆引きする方式 (`PilllBackend/bigquery/queries/paywall_entry_route_conversion.sql`) で推定していたが、精度が低く `unknown_or_app_launch` などに丸まる課題があった。また「購入が完了した」ことを示す Analytics イベントが存在せず、`pressed_*_purchase_button` (ボタン押下) を購入の代理指標にしていたため、ユーザーキャンセルや PlatformException を含めて CV 数を過大評価していた。

本変更で以下を達成する:

1. Flutter 側で `PaywallSource` を一級市民として導入し、表示時イベント `paywall_viewed` に明示的に乗せる
2. 購入完了時の `purchase_succeeded` イベントを新規追加し、同じ `paywall_source` を乗せる
3. 既存 `pressed_*_purchase_button` にも `paywall_source` を付与し、表示 → 押下 → 完了のファネル分析を可能にする

## 主な変更内容

### 1. PaywallSource enum 新規作成 (`lib/features/premium_introduction/paywall_source.dart`)

25 値を明示列挙し、Firebase Analytics の `paywall_source` パラメータに送出する snake_case 文字列を返す `value` extension を提供する。Dart の難読化や rename refactor の影響でログが壊れないよう、enum 名から動的に作るのではなく明示列挙している。

### 2. 新規 Analytics イベント

| event_name | 発火タイミング | parameters |
|---|---|---|
| `paywall_viewed` | `showPremiumIntroductionSheet` / `showSpecialOfferingPage` / `showSpecialOfferingPage2` 起動時 | `paywall_source` |
| `purchase_succeeded` | `Purchase.call` 内、`premiumEntitlement.isActive` 確定後 | `paywall_source`, `package_type`, `product_identifier` |

`Purchases.addCustomerInfoUpdateListener` 経由の `callUpdatePurchaseInfo` は復元・他端末同期で走るパスのため、`purchase_succeeded` は発火しない (購入完了 ≠ 状態同期)。

### 3. 既存イベント拡張

`pressed_monthly_purchase_button` / `pressed_annual_purchase_button` / `pressed_lifetime_purchase_button` にも `paywall_source` パラメータを追加。BigQuery でファネル分析の解像度が上がる。

### 4. API 変更 (named required `source`)

- `showPremiumIntroductionSheet(BuildContext, {required PaywallSource source})`
- `showSpecialOfferingPage(BuildContext, {required PaywallSource source, required ValueNotifier<bool> specialOfferingIsClosed})` (新規ヘルパー)
- `showSpecialOfferingPage2(BuildContext, {required PaywallSource source, required ValueNotifier<bool> specialOfferingIsClosed2})` (新規ヘルパー)
- `Purchase.call(Package, {required PaywallSource source})`
- `PurchaseButtons({required PaywallSource source, ...})`

すべて named required にしたことでコンパイラが caller の修正漏れを検知する。

### 5. 23 caller 全箇所の更新

PremiumIntroductionSheet 起動 21 箇所 + SpecialOffering 起動 2 箇所、計 23 箇所すべてに対応する `PaywallSource` 値を引き渡す。詳細はコミット `7756b156ea` を参照。

## Links

- Plan: `plans/paywall-paywall-source-paywall-source-enumerated-clover.md`
- PilllBackend Issue (集計 SQL 追加): https://github.com/bannzai/PilllBackend/issues/377

## 検証結果

- `flutter analyze`: error/warning なし (既存 info 111 件のみ)
- `flutter test`: 全 1420 件パス (PaywallSource Unit Test 4 件追加含む)
- `flutter build ios --release --no-codesign --flavor Development`: 成功
- `flutter build apk --debug --dart-define-from-file=environment/dev.json`: 成功

## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * プレミアム導入画面で「どの画面から表示されたか」を明確に追跡するようになりました（経路別の計測が可能）。
  * 特別オファーページの表示と購入フローで経路情報が渡され、より正確な分析が行えます。

* **Bug Fixes**
  * プレミアム購入フローの分析データ記録を改善し、購入成功の計測精度を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->