### PR TITLE
再インストール後の「ログインしました」誤表示を修正し、サインイン完了で初期設定スキップ

### DIFF
--- a/lib/features/initial_setting/pill_sheet_group/page.dart
+++ b/lib/features/initial_setting/pill_sheet_group/page.dart
@@ -20,7 +20,11 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/entity/pill_sheet_type.dart';
 import 'package:pilll/entity/link_account_type.dart';
+import 'package:pilll/features/error/error_alert.dart';
 import 'package:pilll/features/sign_in/sign_in_sheet.dart';
+import 'package:pilll/provider/typed_shared_preferences.dart';
+import 'package:pilll/utils/router.dart';
+import 'package:pilll/utils/shared_preference/keys.dart';
 
 class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
   const InitialSettingPillSheetGroupPage({super.key});
@@ -31,6 +35,15 @@ class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
     final state = ref.watch(initialSettingStateNotifierProvider);
     final isAppleLinked = ref.watch(isAppleLinkedProvider);
     final isGoogleLinked = ref.watch(isGoogleLinkedProvider);
+    final didEndInitialSettingNotifier = ref.watch(
+      boolSharedPreferencesProvider(BoolKey.didEndInitialSetting).notifier,
+    );
+
+    // この画面で実際にユーザーがサインイン操作を完了したかどうか。
+    // Firebase Auth は iOS Keychain でセッションを保持するため、アプリ再インストール直後でも
+    // providerData が残ったまま isAppleLinked / isGoogleLinked が true になり得る。
+    // ユーザー操作によるサインイン完了と、Keychain 復元による自動ログイン状態を区別するために必要。
+    final didSignInThisSession = useState(false);
 
     // [Pill:TwoTaken] 2錠飲み機能 - 現在一部ユーザーにテスト解放中。初期設定では非表示
     // final pillTakenCount = useState<int>(state.pillTakenCount);
@@ -50,15 +63,11 @@ class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
         parameters: {'uid': FirebaseAuth.instance.currentUser?.uid},
       );
 
-      final LinkAccountType? accountType = () {
-        if (isAppleLinked) {
-          return LinkAccountType.apple;
-        } else if (isGoogleLinked) {
-          return LinkAccountType.google;
-        } else {
-          return null;
-        }
-      }();
+      final accountType = snackbarAccountTypeForLinkedUser(
+        didSignInThisSession: didSignInThisSession.value,
+        isAppleLinked: isAppleLinked,
+        isGoogleLinked: isGoogleLinked,
+      );
       if (accountType != null) {
         Future.microtask(() {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -71,7 +80,7 @@ class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
       }
 
       return null;
-    }, [isAppleLinked, isGoogleLinked]);
+    }, [isAppleLinked, isGoogleLinked, didSignInThisSession.value]);
 
     return HUD(
       shown: state.isLoading,
@@ -142,11 +151,26 @@ class InitialSettingPillSheetGroupPage extends HookConsumerWidget {
                             analytics.logEvent(
                               name: 'pressed_initial_setting_signin',
                             );
+                            final navigator = Navigator.of(context);
                             showSignInSheet(
                               context,
                               SignInSheetStateContext.initialSetting,
                               (accountType) async {
+                                analytics.logEvent(
+                                  name: 'initial_setting_skip_after_signin',
+                                  parameters: {'account_type': accountType.providerName},
+                                );
+                                didSignInThisSession.value = true;
                                 store.showHUD();
+                                try {
+                                  // サインイン完了 → 初期設定オンボーディングをスキップしてホームへ。
+                                  // 再インストール時に既存ユーザーが PillSheetGroup の入力からやり直す必要を解消する。
+                                  await AppRouter.endInitialSetting(navigator, didEndInitialSettingNotifier);
+                                } catch (error) {
+                                  if (context.mounted) showErrorAlert(context, error.toString());
+                                } finally {
+                                  store.hideHUD();
+                                }
                               },
                             );
                           },
@@ -222,4 +246,25 @@ extension InitialSettingPillSheetGroupPageRoute on InitialSettingPillSheetGroupP
     analytics.logScreenView(screenName: 'InitialSettingPillSheetGroupPage');
     return const InitialSettingPillSheetGroupPage();
   }
+}
+
+/// 「{accountType}でログインしました」snackbar を表示すべき LinkAccountType を返す。
+/// この画面でユーザーがサインイン操作を完了していない場合 (didSignInThisSession=false) は null を返す。
+/// Firebase Auth の iOS Keychain による自動セッション復元のみの状態では発火させないことが目的。
+@visibleForTesting
+LinkAccountType? snackbarAccountTypeForLinkedUser({
+  required bool didSignInThisSession,
+  required bool isAppleLinked,
+  required bool isGoogleLinked,
+}) {
+  if (!didSignInThisSession) {
+    return null;
+  }
+  if (isAppleLinked) {
+    return LinkAccountType.apple;
+  }
+  if (isGoogleLinked) {
+    return LinkAccountType.google;
+  }
+  return null;
 }

--- a/test/features/initial_setting/pill_sheet_group/page_test.dart
+++ b/test/features/initial_setting/pill_sheet_group/page_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pilll/entity/link_account_type.dart';
+import 'package:pilll/features/initial_setting/pill_sheet_group/page.dart';
+
+void main() {
+  group('#snackbarAccountTypeForLinkedUser', () {
+    test('この画面でサインイン未完了かつ Apple link 済み (iOS Keychain による自動復元のみ) のとき、null を返す',
+        () {
+      expect(
+        snackbarAccountTypeForLinkedUser(
+          didSignInThisSession: false,
+          isAppleLinked: true,
+          isGoogleLinked: false,
+        ),
+        null,
+      );
+    });
+
+    test('この画面でサインイン未完了かつ Google link 済み (iOS Keychain による自動復元のみ) のとき、null を返す',
+        () {
+      expect(
+        snackbarAccountTypeForLinkedUser(
+          didSignInThisSession: false,
+          isAppleLinked: false,
+          isGoogleLinked: true,
+        ),
+        null,
+      );
+    });
+
+    test('この画面でサインイン未完了かつ両方 link されているとき、null を返す', () {
+      expect(
+        snackbarAccountTypeForLinkedUser(
+          didSignInThisSession: false,
+          isAppleLinked: true,
+          isGoogleLinked: true,
+        ),
+        null,
+      );
+    });
+
+    test('この画面でサインイン完了かつ Apple link 済みのとき、apple を返す', () {
+      expect(
+        snackbarAccountTypeForLinkedUser(
+          didSignInThisSession: true,
+          isAppleLinked: true,
+          isGoogleLinked: false,
+        ),
+        LinkAccountType.apple,
+      );
+    });
+
+    test('この画面でサインイン完了かつ Google link 済みのとき、google を返す', () {
+      expect(
+        snackbarAccountTypeForLinkedUser(
+          didSignInThisSession: true,
+          isAppleLinked: false,
+          isGoogleLinked: true,
+        ),
+        LinkAccountType.google,
+      );
+    });
+
+    test('この画面でサインイン完了かつ両方 link されているとき、apple を優先して返す', () {
+      expect(
+        snackbarAccountTypeForLinkedUser(
+          didSignInThisSession: true,
+          isAppleLinked: true,
+          isGoogleLinked: true,
+        ),
+        LinkAccountType.apple,
+      );
+    });
+
+    test('この画面でサインイン完了でも両方 link されていないとき、null を返す', () {
+      expect(
+        snackbarAccountTypeForLinkedUser(
+          didSignInThisSession: true,
+          isAppleLinked: false,
+          isGoogleLinked: false,
+        ),
+        null,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Abstract

iOS アプリ再インストール後に「ログインしました」のスナックバーが誤表示される問題を修正し、既存アカウントでサインイン完了したら初期設定オンボーディングをスキップしてホーム画面へ遷移するように変更。

## Why

問い合わせ:
> スマホ本体のアップデートの為に一度アプリを削除し、またログインをしようと再インストールしたのですが、ログイン出来てないのに「ログインしました」とだけ画面に出てきてログインが今現在も出来ていない状況です

### 原因

1. **iOS Keychain による Firebase Auth セッション永続化**: アプリ削除では Keychain は消えず、`FirebaseAuth.instance.currentUser` が前回の Apple/Google リンク済みユーザーを保持する。
2. **SharedPreferences は再インストールでクリアされる**: `didEndInitialSetting` が null になり、`retrieveScreenType` が `initialSetting` を返して `InitialSettingPillSheetGroupPage` に遷移する。
3. **画面マウントで snackbar が無条件発火**: コミット `fd9f11d6ff` (2025-05-26 "Remove unnecessary userIsAnonymous check") で `userIsAnonymous` ガードが外され、`isAppleLinked` / `isGoogleLinked` だけを条件に snackbar を表示するロジックになっていた。
4. **「既存アカウントの方」ボタンを押してサインインしても初期設定をやり直す必要があった**: 既存ユーザーが同じ Apple/Google アカウントでサインインしても、PillSheetGroup の入力からやり直す必要があった。

### 修正内容

#### `lib/features/initial_setting/pill_sheet_group/page.dart`

1. `useState<bool>` の `didSignInThisSession` フラグを追加し、「この画面で実際にユーザーがサインイン操作を完了したか」を管理する
2. snackbar 発火ロジックを純粋関数 `snackbarAccountTypeForLinkedUser` に切り出し、`@visibleForTesting` でテストから呼べるようにする
3. 「既存アカウントの方」ボタンの `onSignIn` コールバックで:
    - フラグを true にセット
    - `AppRouter.endInitialSetting` を呼んで `didEndInitialSetting = true` にし、初期設定スキップでホームへ遷移
    - エラー時は `showErrorAlert` で表示し、`store.hideHUD()` で HUD を必ず閉じる

`AppRouter.endInitialSetting` のドキュメントコメント (`lib/utils/router.dart:6-8`) には「user signed with 3rd party provider」とあり、設計時点でサインイン完了をオンボーディング終了 trigger にすることが想定されていた挙動を実装で活かしている。

#### `test/features/initial_setting/pill_sheet_group/page_test.dart` (新規)

`snackbarAccountTypeForLinkedUser` の挙動を 7 ケースで網羅:
- `didSignInThisSession=false` のとき、`isAppleLinked` / `isGoogleLinked` が true でも null を返す (iOS Keychain による自動復元のみの状態を除外)
- `didSignInThisSession=true` のとき、Apple/Google それぞれの link 状態で適切な `LinkAccountType` を返す
- 両方 link されている場合は Apple を優先

### 影響範囲

#### 修正後のフロー (シナリオ別)

| シナリオ | 修正前 | 修正後 |
|---|---|---|
| 既存 Apple リンク済みユーザーが再インストール | 初期設定画面に来ただけで「Appleでログインしました」が出る (ユーザー操作なし) | snackbar は出ない。「既存アカウントの方」タップ → サインイン完了 → snackbar 表示 → ホームへ |
| 新規ユーザーの初期設定 | 通常通り | 通常通り (変化なし) |
| ホームに進んだ後の挙動 | 変化なし | 変化なし (今回スコープ外) |

#### 検証結果

- `flutter analyze`: 今回の修正範囲で新規警告なし (残存は既存の `use_build_context_synchronously` 1件のみ)
- `flutter test`: 全 1426 件パス
- iOS ビルド: 成功 (`com.mizuki.Ohashi.Pilll.dev` for device)
- Android ビルド: 成功 (`com.mizuki.Ohashi.Pilll.development` debug)

#### 手動 E2E 想定シナリオ (マージ前に確認推奨)

1. **既存 Apple リンク済みユーザーが再インストール**: 削除 → 再インストール後、初期設定画面が表示される。スナックバーは出ない。「既存アカウントの方」をタップして同じ Apple ID でサインイン → 「Appleでログインしました」snackbar → ホーム画面へ、既存の PillSheetGroup が表示される。
2. **新規ユーザーの初期設定**: 通常通り PillSheetGroup 選択 → 当日番号 → リマインダー → トライアル開始 → ホーム。
3. **新規ユーザーが「既存アカウントの方」を誤タップ**: 別 Apple ID でサインイン → snackbar 表示後にホーム画面へ (PillSheetGroup は未登録の状態)。

## Links

- 関連コミット (誤表示の原因): `fd9f11d6ff` "Remove unnecessary userIsAnonymous check" (2025-05-26)
- プランファイル: `.plans/sign-in-jiggly-neumann.md`

## Checked
- [x] Analyticsのログを入れたか (新規イベント: `initial_setting_skip_after_signin`)
- [x] 境界値に対してのUnitTestを書いた (`snackbarAccountTypeForLinkedUser` で 7 ケース網羅)
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた (Provider 依存が多く現実的でなかったため、ロジックを純粋関数に切り出してユニットテストでカバー)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 初期設定画面でのサインイン後のメッセージ表示ロジックを改善しました。

* **テスト**
  * 初期設定画面のサインイン関連機能に対するテストカバレッジを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bannzai/Pilll/pull/1803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->