### PR TITLE
.vscode ディレクトリを追加

### DIFF
--- a/.vscode/freezed.entity.code-snippets
+++ b/.vscode/freezed.entity.code-snippets
@@ -1,0 +1,18 @@
+{
+	// Place your pilll workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
+	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+	// Placeholders with the same ids are connected.
+	// Example:
+	// "Print to console": {
+	// 	"scope": "javascript,typescript",
+	// 	"prefix": "log",
+	// 	"body": [
+	// 		"console.log('$1');",
+	// 		"$2"
+	// 	],
+	// 	"description": "Log output to console"
+	// }
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Flutter(dev)",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main.dev.dart",
+      "args": [
+        "--debug",
+        "--dart-define-from-file=./environment/dev.json",
+      ]
+    },
+    {
+      // Secret.xcconfigも生成し直す必要がある
+      "name": "Flutter(prod)",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main.prod.dart",
+      "args": [
+        "--debug",
+        "--dart-define-from-file=./environment/prod.json"
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "dart.analysisExcludedFolders": [
+    "test/helper/mock.mocks.dart"
+  ],
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": {
+    "pubspec.yaml": ".flutter-plugins, .packages, .dart_tool, .flutter-plugins-dependencies, .metadata, .packages, pubspec.lock, build.yaml, analysis_options.yaml, all_lint_rules.yaml",
+    ".gitignore": ".gitattributes, .gitmodules, .gitmessage, .mailmap, .git-blame*",
+    "readme.*": "authors, backers.md, changelog*, citation*, code_of_conduct.md, codeowners, contributing.md, contributors, copying, credits, governance.md, history.md, license*, maintainers, readme*, security.md, sponsors.md",
+    "*.dart": "$(capture).g.dart, $(capture).freezed.dart"
+  },
+  "security.workspace.trust.enabled": false
+}


### PR DESCRIPTION
## Abstract

`.vscode/` ディレクトリを追加し、VS Code でのデバッグ実行・エディタ設定・コードスニペットをリポジトリで共有できるようにした。

追加したファイルは以下の3つ。

- `.vscode/launch.json`: Flutter の `dev` / `prod` 起動構成。それぞれ `lib/main.dev.dart` / `lib/main.prod.dart` を `--dart-define-from-file` で対応する `environment/*.json` を読み込んで起動する
- `.vscode/settings.json`: 解析除外フォルダ（生成された mock: `test/helper/mock.mocks.dart`）、ファイルネスティング設定（`*.dart` 配下に `.g.dart` / `.freezed.dart` をまとめる等）、ワークスペース trust 設定
- `.vscode/freezed.entity.code-snippets`: ワークスペース用スニペットの雛形（中身は未定義のテンプレートのみ）

## Why

VS Code のデバッグ構成やエディタ設定をリポジトリで共有し、開発環境のセットアップを揃えるため。`launch.json` があれば dev / prod の起動をエディタからワンクリックで切り替えられ、`settings.json` のファイルネスティングで自動生成ファイルがツリー上で整理される。

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた

> エディタ設定（`.vscode/`）のみの変更で、Flutter のアプリコード・生成ファイル・テストには一切変更がないため、上記チェック項目はいずれも該当なし。アプリ挙動への影響がないため動作確認スクリーンショットも対象外。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * VS Code ワークスペース設定を追加しました。開発環境と本番環境用のデバッグ起動設定、エディタ設定、コードスニペットテンプレートが含まれます。これにより開発環境の初期セットアップが簡素化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->