### PR TITLE
ホームの月1回Paywall自動表示機能を削除

### DIFF
--- a/lib/features/home/page.dart
+++ b/lib/features/home/page.dart
@@ -8,8 +8,6 @@ import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/features/error/error_alert.dart';
 import 'package:pilll/features/error/page.dart';
 import 'package:pilll/features/localizations/l.dart';
-import 'package:pilll/features/premium_introduction/paywall_source.dart';
-import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
 import 'package:pilll/features/settings/components/churn/churn_survey_complete_dialog.dart';
 import 'package:pilll/features/store_review/pre_store_review_modal.dart';
 import 'package:pilll/provider/locale.dart';
@@ -23,7 +21,6 @@ import 'package:pilll/features/record/page.dart';
 import 'package:pilll/features/settings/page.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/text_color.dart';
-import 'package:pilll/utils/datetime/day.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:pilll/utils/error_log.dart';
@@ -110,19 +107,6 @@ class HomePageBody extends HookConsumerWidget {
       disableShouldAskCancelReasonProvider,
     );
     final shouldAskCancelReason = user.shouldAskCancelReason;
-    final monthlyPremiumIntroductionSheetPresentedDateMilliSeconds = sharedPreferences.getInt(
-          IntKey.monthlyPremiumIntroductionSheetPresentedDateMilliSeconds,
-        ) ??
-        0;
-    final isOneMonthPassedSinceLastDisplayedMonthlyPremiumIntroductionSheet =
-        now().millisecondsSinceEpoch - monthlyPremiumIntroductionSheetPresentedDateMilliSeconds > 1000 * 60 * 60 * 24 * 30;
-    final bool isOneMonthPassedTrialDeadline;
-    final trialDeadlineDate = user.trialDeadlineDate;
-    if (trialDeadlineDate != null) {
-      isOneMonthPassedTrialDeadline = now().millisecondsSinceEpoch - trialDeadlineDate.millisecondsSinceEpoch > 1000 * 60 * 60 * 24 * 30;
-    } else {
-      isOneMonthPassedTrialDeadline = false;
-    }
     final error = useState<String?>(null);
 
     useEffect(() {
@@ -150,14 +134,6 @@ class HomePageBody extends HookConsumerWidget {
             BoolKey.isAlreadyAnsweredPreStoreReviewModal,
             true,
           );
-        } else if (isOneMonthPassedTrialDeadline && isOneMonthPassedSinceLastDisplayedMonthlyPremiumIntroductionSheet && !user.premiumOrTrial) {
-          if (!user.premiumOrTrial) {
-            showPremiumIntroductionSheet(context, source: PaywallSource.homeMonthly);
-            sharedPreferences.setInt(
-              IntKey.monthlyPremiumIntroductionSheetPresentedDateMilliSeconds,
-              now().millisecondsSinceEpoch,
-            );
-          }
         }
       });
 

--- a/lib/utils/shared_preference/keys.dart
+++ b/lib/utils/shared_preference/keys.dart
@@ -87,5 +87,4 @@ extension ReleaseNoteKey on String {
 
 extension IntKey on String {
   static const String totalCountOfActionForTakenPill = 'totalPillCount';
-  static const String monthlyPremiumIntroductionSheetPresentedDateMilliSeconds = 'monthlyPremiumIntroductionSheetPresentedDateMilliSeconds';
 }


### PR DESCRIPTION
## Abstract

ホーム画面で月1回 PremiumIntroductionSheet（Paywall）を自動表示していた機能を削除しました。

## Why

この月1回表示経由での購入がほとんど発生しておらず、効果が薄いため削除します。

### 削除した挙動

`HomePageBody` の `useEffect` 内で、以下の条件をすべて満たすときに `showPremiumIntroductionSheet(source: PaywallSource.homeMonthly)` を自動表示していました。

- トライアル期限（`user.trialDeadlineDate`）から30日以上経過している
- 前回の月次 Paywall 表示から30日以上経過している
- プレミアム / トライアル中ではない

この分岐ごと削除しました。

### 変更内容

- `lib/features/home/page.dart`
  - 月次 Paywall 表示の `else if` 分岐を削除
  - 月次判定用のローカル変数（トライアル期限経過判定・前回表示からの経過判定）を削除
  - 未使用になった import 3件を削除（`paywall_source.dart` / `premium_introduction_sheet.dart` / `utils/datetime/day.dart`）
- `lib/utils/shared_preference/keys.dart`
  - 参照されなくなった `IntKey.monthlyPremiumIntroductionSheetPresentedDateMilliSeconds` を削除

### 残したもの

- `PaywallSource.homeMonthly`（`value: 'home_monthly'`）enum は **残置**。Firebase Analytics / BigQuery の過去データ・集計クエリとの整合のため削除しません。

## Links

なし

## 動作確認

- `flutter analyze`（変更2ファイル）: 既存の `info` レベル `use_build_context_synchronously`（churn survey の未変更コード）1件のみで、本変更起因の指摘なし
- `flutter test`（全体）: **+1419 All tests passed!**
- 削除した機能に対応する既存テストは無く（`test/` 内に該当参照なし）、テスト追加・修正は不要
- iOS Simulator での動作確認は未実施。削除対象は「トライアル期限超過 + 30日経過 + 前回表示から30日経過」という時間条件下でのみ発火する機能であり、スクリーンショットでの「非表示確認」が有意でないため、ユニットテスト・静的解析での確認に留めています

## Checked

- [ ] Analyticsのログを入れたか（該当なし: 表示トリガーの削除でありログ追加なし。`PaywallSource.homeMonthly` enum は残置）
- [ ] 境界値に対してのUnitTestを書いた（該当なし: 機能削除。既存テスト全件 +1419 パス）
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた（該当なし: 分岐の削除）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * プレミアム機能の表示ロジックを最適化しました。
  * 服用記録のトラッキング機能を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->