### PR TITLE
simulator-session の参照 SHA 更新（keepalive 強化）と serve_sim 入力の追加

### DIFF
--- a/.github/workflows/simulator-session.yml
+++ b/.github/workflows/simulator-session.yml
@@ -19,6 +19,10 @@ on:
         description: "セッション維持時間（分）"
         required: true
         default: "60"
+      serve_sim:
+        description: "serve-sim (ブラウザ preview) を起動する。runner のメモリに余裕を持たせたい時は false"
+        required: false
+        default: "true"
 
 jobs:
   # dev 環境の Simulator 用 .app をビルドして artifact に上げる（ci.yml の build-ios-debug と同じ手順の --simulator 版）
@@ -56,11 +60,12 @@ jobs:
       id-token: write # Tailscale の OIDC (workload identity federation) 認証に必要
       contents: read
     # タグ運用はしないため commit SHA で固定する（更新時は SHA を書き換える）
-    uses: bannzai/simtunnel/.github/workflows/session.yml@2350cbd49b5ddc2359e7e393606f08b00db2b5d4 # main 2026-07-06
+    uses: bannzai/simtunnel/.github/workflows/session.yml@b220ca01c4a935f1ab023afde22ba7883fc3b963 # main 2026-07-06
     with:
       session: ${{ inputs.session }}
       device: ${{ inputs.device }}
       duration_minutes: ${{ inputs.duration_minutes }}
+      serve_sim: ${{ inputs.serve_sim }}
       app_artifact: simulator-app
     secrets:
       TS_OIDC_CLIENT_ID: ${{ secrets.TS_OIDC_CLIENT_ID }}


### PR DESCRIPTION
セッションが keepalive の死活チェック 1 回失敗で早期終了する事象への対応（simtunnel 側 PR #16 の取り込み）。

- `session.yml` の参照 SHA を keepalive 強化（連続 4 回失敗時のみ終了 + 終了時に wda.log 出力）込みの simtunnel main に更新
- runner のメモリ切り分け用に `serve_sim` を workflow_dispatch の input として公開（既定 true）

マージ後に実 run で検証し、結果を #1812 にコメントする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 手動実行できるシミュレーターセッションで、ブラウザのプレビュー起動を切り替える新しいオプションを追加しました。デフォルトは有効です。
* **Chores**
  * セッション起動時の呼び出し設定を更新し、最新の連携先に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->