### PR TITLE
simtunnel セッション用のオンボーディング自動突破 Maestro flow を追加

### DIFF
--- a/.github/workflows/simulator-session.yml
+++ b/.github/workflows/simulator-session.yml
@@ -60,7 +60,7 @@ jobs:
       id-token: write # Tailscale の OIDC (workload identity federation) 認証に必要
       contents: read
     # タグ運用はしないため commit SHA で固定する（更新時は SHA を書き換える）
-    uses: bannzai/simtunnel/.github/workflows/session.yml@65f9b06f35997143d6c8d5794c109b4ebc13a766 # add-maestro-flows（検証用。マージ後に main SHA へ更新する）
+    uses: bannzai/simtunnel/.github/workflows/session.yml@2f2fab7970fd8fe8d5e81ef20ea573b720a72537 # main 2026-07-07
     with:
       session: ${{ inputs.session }}
       device: ${{ inputs.device }}

--- a/.github/workflows/simulator-session.yml
+++ b/.github/workflows/simulator-session.yml
@@ -60,7 +60,7 @@ jobs:
       id-token: write # Tailscale の OIDC (workload identity federation) 認証に必要
       contents: read
     # タグ運用はしないため commit SHA で固定する（更新時は SHA を書き換える）
-    uses: bannzai/simtunnel/.github/workflows/session.yml@c8d92e4858a43de6b61d360d0ec3677306e82957 # add-maestro-flows（検証用。マージ後に main SHA へ更新する）
+    uses: bannzai/simtunnel/.github/workflows/session.yml@65f9b06f35997143d6c8d5794c109b4ebc13a766 # add-maestro-flows（検証用。マージ後に main SHA へ更新する）
     with:
       session: ${{ inputs.session }}
       device: ${{ inputs.device }}

--- a/.github/workflows/simulator-session.yml
+++ b/.github/workflows/simulator-session.yml
@@ -60,7 +60,7 @@ jobs:
       id-token: write # Tailscale の OIDC (workload identity federation) 認証に必要
       contents: read
     # タグ運用はしないため commit SHA で固定する（更新時は SHA を書き換える）
-    uses: bannzai/simtunnel/.github/workflows/session.yml@b220ca01c4a935f1ab023afde22ba7883fc3b963 # main 2026-07-06
+    uses: bannzai/simtunnel/.github/workflows/session.yml@c8d92e4858a43de6b61d360d0ec3677306e82957 # add-maestro-flows（検証用。マージ後に main SHA へ更新する）
     with:
       session: ${{ inputs.session }}
       device: ${{ inputs.device }}

--- a/.maestro/flows/simtunnel/setup.yml
+++ b/.maestro/flows/simtunnel/setup.yml
@@ -1,1 +1,12 @@
-../feature_appeal/subflows/initial_setup.yaml
+appId: com.mizuki.Ohashi.Pilll.dev
+---
+# simtunnel セッション起動時にオンボーディングを自動突破してホーム画面まで進める。
+# runner の Simulator は英語ロケールでシステムダイアログの文言タップが通らないため、
+# permissions で通知を事前許可し、ダイアログ自体を出さずに launch し直す
+- launchApp:
+    clearState: true
+    clearKeychain: true
+    permissions:
+      notifications: allow
+- waitForAnimationToEnd
+- runFlow: ../feature_appeal/subflows/initial_setup.yaml

--- a/.maestro/flows/simtunnel/setup.yml
+++ b/.maestro/flows/simtunnel/setup.yml
@@ -1,0 +1,1 @@
+../feature_appeal/subflows/initial_setup.yaml


### PR DESCRIPTION
## 概要

simtunnel セッション起動時にオンボーディングを自動突破する Maestro flow を追加する。

- `.maestro/flows/simtunnel/setup.yml`（新規）: simtunnel の session workflow が自動検出して、アプリ install / launch 後・WebDriverAgent 起動前に runner 上で実行する（bannzai/simtunnel#19）。これによりセッション開始時点でホーム画面まで到達済みになり、以降の操作（WDA / MCP）をオンボーディング突破なしで始められる
- `.github/workflows/simulator-session.yml`: simtunnel session.yml の参照 SHA を Maestro flow 自動実行対応版の main SHA に更新

## setup.yml の設計

既存の `.maestro/flows/feature_appeal/subflows/initial_setup.yaml` を `runFlow` で再利用する薄いラッパー。symlink ではなくラッパー flow にしたのは、CI runner の Simulator が英語ロケールのため:

- 通知許可ダイアログが "Allow" 表記になり、subflow 内の `tapOn: "許可"`（条件タップ）では突破できない
- そこで `launchApp` の `permissions: notifications: allow` で事前許可し、ダイアログ自体を出さない（`clearState` で初期状態から launch し直す）

## 検証（実 run）

- flow 失敗時の挙動も含め、実 run 2 回で検証済み。詳細な記録（ログ抜粋・スクリーンショット・所要時間の実測）: https://github.com/bannzai/simtunnel/pull/19#issuecomment-4899956638
- flow がオンボーディングを完走してホーム画面に到達し、直後の WDA 操作（tap → モーダル表示）に干渉が無いことを確認
- flow が失敗した場合もセッション自体は通常どおり開く（simtunnel 側の設計。run summary に警告が出る）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * シミュレーター環境で、起動時の初期設定と通知許可を自動で進めるフローを追加しました。これにより、ホーム画面までのセットアップがスムーズになります。

* **Bug Fixes**
  * 英語ロケールのシミュレーターで、システムダイアログの操作が通りにくい問題への対応を行いました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->