### PR TITLE
simtunnel の参照 SHA を simulators=1 regression 修正後の main に更新

### DIFF
--- a/.github/workflows/simulator-session.yml
+++ b/.github/workflows/simulator-session.yml
@@ -60,7 +60,7 @@ jobs:
       id-token: write # Tailscale の OIDC (workload identity federation) 認証に必要
       contents: read
     # タグ運用はしないため commit SHA で固定する（更新時は SHA を書き換える）
-    uses: bannzai/simtunnel/.github/workflows/session.yml@2f2fab7970fd8fe8d5e81ef20ea573b720a72537 # main 2026-07-07
+    uses: bannzai/simtunnel/.github/workflows/session.yml@7c449372c5d5da31fd15357e414fdb2281d06b11 # main 2026-07-07
     with:
       session: ${{ inputs.session }}
       device: ${{ inputs.device }}


### PR DESCRIPTION
simtunnel 側の regression（`simulators` 未指定でも Simulator が 3 台 boot され、多重 install で simctl がハングして session job が timeout する。BSD seq の逆順カウントが原因）の修正を取り込む。

- 検知した run: https://github.com/bannzai/Pilll/actions/runs/28843309251
- 修正: https://github.com/bannzai/simtunnel/pull/22
- 変更は `uses:` の SHA 差し替えのみ（他の内容は保持）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * シミュレーターセッションの実行基盤を最新の参照先に更新しました。
  * 既存の入力設定や権限はそのままで、実行の安定性と互換性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->