### PR TITLE
3年以上の無料ユーザーへ月額300円オファーを追加

### DIFF
--- a/lib/features/lifetime_offer/lifetime_offer_plan.dart
+++ b/lib/features/lifetime_offer/lifetime_offer_plan.dart
@@ -1,0 +1,9 @@
+/// 長期利用者向けオファーで提示するプラン。
+enum LifetimeOfferPlan {
+  lifetime('lifetime'),
+  monthly300('monthly_300');
+
+  const LifetimeOfferPlan(this.analyticsValue);
+
+  final String analyticsValue;
+}

--- a/lib/features/lifetime_offer/page.dart
+++ b/lib/features/lifetime_offer/page.dart
@@ -10,6 +10,7 @@ import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/features/error/error_alert.dart';
 import 'package:pilll/features/error/page.dart';
 import 'package:pilll/features/lifetime_offer/lifetime_offer_copy_variant.dart';
+import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/features/lifetime_offer/provider.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/components/premium_introduction_footer.dart';
@@ -28,10 +29,12 @@ import 'package:url_launcher/url_launcher.dart';
 class LifetimeOfferPage extends HookConsumerWidget {
   final PaywallSource source;
   final LifetimeOfferCopyVariant copyVariant;
+  final LifetimeOfferPlan offerPlan;
   const LifetimeOfferPage({
     super.key,
     required this.source,
     required this.copyVariant,
+    required this.offerPlan,
   });
 
   @override
@@ -42,6 +45,7 @@ class LifetimeOfferPage extends HookConsumerWidget {
               user: user,
               source: source,
               copyVariant: copyVariant,
+              offerPlan: offerPlan,
             );
           },
           error: (error, stackTrace) => UniversalErrorPage(
@@ -60,12 +64,14 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
   final User user;
   final PaywallSource source;
   final LifetimeOfferCopyVariant copyVariant;
+  final LifetimeOfferPlan offerPlan;
 
   const LifetimeOfferPageBody({
     super.key,
     required this.user,
     required this.source,
     required this.copyVariant,
+    required this.offerPlan,
   });
 
   @override
@@ -74,6 +80,7 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
 
     final purchase = ref.watch(purchaseProvider);
     final lifetimeDiscountPackage = ref.watch(lifetimeDiscountPackageProvider);
+    final monthlyDiscountPackage = ref.watch(monthlyDiscountPackageProvider);
     final lifetimePremiumPackage = ref.watch(lifetimePremiumPackageProvider);
     final lifetimeDiscountRate = ref.watch(lifetimeDiscountRateProvider);
     final usageDays = ref.watch(lifetimeOfferUsageDaysProvider);
@@ -83,7 +90,11 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
     // ページを開いたまま表示期限を迎えた場合に購入導線を無効化するための判定。false→trueの変化時のみ再ビルドされる
     final isOverLifetimeOfferDeadline = ref.watch(isOverLifetimeOfferDeadlineProvider);
 
-    if (lifetimeDiscountPackage == null) {
+    final offerPackage = switch (offerPlan) {
+      LifetimeOfferPlan.lifetime => lifetimeDiscountPackage,
+      LifetimeOfferPlan.monthly300 => monthlyDiscountPackage,
+    };
+    if (offerPackage == null) {
       return const ScaffoldIndicator();
     }
 
@@ -167,9 +178,12 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
                 ],
                 const SizedBox(height: 12),
                 Text(
-                  switch (copyVariant) {
-                    LifetimeOfferCopyVariant.defaultVariant => '長く使ってくださっている方へ\n買い切りプランのご案内です',
-                    LifetimeOfferCopyVariant.ownership => '一度の購入で、ずっとプレミアム。\n月々のお支払いは不要です',
+                  switch (offerPlan) {
+                    LifetimeOfferPlan.monthly300 => '3年以上使ってくださっている方へ\n月額プランのご案内です',
+                    LifetimeOfferPlan.lifetime => switch (copyVariant) {
+                        LifetimeOfferCopyVariant.defaultVariant => '長く使ってくださっている方へ\n買い切りプランのご案内です',
+                        LifetimeOfferCopyVariant.ownership => '一度の購入で、ずっとプレミアム。\n月々のお支払いは不要です',
+                      },
                   },
                   textAlign: TextAlign.center,
                   style: const TextStyle(
@@ -193,15 +207,18 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
                 const SizedBox(height: 8),
                 const LifetimeOfferCountdownText(),
                 const SizedBox(height: 28),
-                if (isActiveSubscriber) ...[
+                if (offerPlan == LifetimeOfferPlan.lifetime && isActiveSubscriber) ...[
                   const LifetimeOfferSubscriptionCancelNotice(),
                   const SizedBox(height: 16),
                 ],
-                LifetimeOfferPriceCard(
-                  lifetimeDiscountPackage: lifetimeDiscountPackage,
-                  lifetimePremiumPackage: lifetimePremiumPackage,
-                  lifetimeDiscountRate: lifetimeDiscountRate,
-                ),
+                if (offerPlan == LifetimeOfferPlan.lifetime)
+                  LifetimeOfferPriceCard(
+                    lifetimeDiscountPackage: offerPackage,
+                    lifetimePremiumPackage: lifetimePremiumPackage,
+                    lifetimeDiscountRate: lifetimeDiscountRate,
+                  )
+                else
+                  Monthly300OfferPriceCard(monthlyDiscountPackage: offerPackage),
                 const SizedBox(height: 24),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 24),
@@ -215,13 +232,13 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
                           : () async {
                               analytics.logEvent(
                                 name: 'pressed_lifetime_purchase_button',
-                                parameters: {'paywall_source': source.value, 'copy_variant': copyVariant.value},
+                                parameters: {'paywall_source': source.value, 'copy_variant': copyVariant.value, 'offer_plan': offerPlan.analyticsValue},
                               );
                               if (isLoading.value) return;
                               isLoading.value = true;
 
                               try {
-                                final shouldShowCompleteDialog = await purchase.call(lifetimeDiscountPackage, source: source);
+                                final shouldShowCompleteDialog = await purchase.call(offerPackage, source: source);
                                 if (shouldShowCompleteDialog) {
                                   // isLifetimePurchasedProviderは一発取得でwatch中はキャッシュが残り続けるため、
                                   // 購入完了を反映してオファーバーの非表示・解約警告バーの表示を再起動なしで切り替える
@@ -412,6 +429,36 @@ class LifetimeOfferPriceCard extends StatelessWidget {
   }
 }
 
+/// 3年以上利用している無料ユーザー向けの月額プラン価格カード。
+class Monthly300OfferPriceCard extends StatelessWidget {
+  final Package monthlyDiscountPackage;
+  const Monthly300OfferPriceCard({super.key, required this.monthlyDiscountPackage});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.symmetric(horizontal: 24),
+      padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 20),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: const BorderRadius.all(Radius.circular(16)),
+        border: Border.all(width: 2, color: AppColors.primary),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text('月額プラン', style: TextStyle(color: TextColor.main, fontFamily: FontFamily.japanese, fontWeight: FontWeight.w700, fontSize: 16)),
+          const SizedBox(height: 12),
+          Text(monthlyDiscountPackage.storeProduct.priceString, style: const TextStyle(color: TextColor.main, fontFamily: FontFamily.number, fontWeight: FontWeight.w800, fontSize: 40)),
+          const SizedBox(height: 8),
+          const Text('1ヶ月ごとの自動更新', style: TextStyle(color: TextColor.gray, fontFamily: FontFamily.japanese, fontWeight: FontWeight.w400, fontSize: 13)),
+        ],
+      ),
+    );
+  }
+}
+
 /// 月額・年額プランで課金中のユーザーへ、買い切り購入前にサブスクリプションの解約を促す注意文言
 class LifetimeOfferSubscriptionCancelNotice extends StatelessWidget {
   const LifetimeOfferSubscriptionCancelNotice({super.key});
@@ -443,11 +490,12 @@ Future<void> showLifetimeOfferPage(
   BuildContext context, {
   required PaywallSource source,
   required LifetimeOfferCopyVariant copyVariant,
+  required LifetimeOfferPlan offerPlan,
 }) async {
   analytics.logScreenView(screenName: 'LifetimeOfferPage');
   analytics.logEvent(
     name: 'paywall_viewed',
-    parameters: {'paywall_source': source.value, 'copy_variant': copyVariant.value},
+    parameters: {'paywall_source': source.value, 'copy_variant': copyVariant.value, 'offer_plan': offerPlan.analyticsValue},
   );
   analytics.setUserProperties('lifetime_offer_variant', copyVariant.value);
 
@@ -457,6 +505,7 @@ Future<void> showLifetimeOfferPage(
       builder: (_) => LifetimeOfferPage(
         source: source,
         copyVariant: copyVariant,
+        offerPlan: offerPlan,
       ),
     ),
   );

--- a/lib/features/lifetime_offer/page.dart
+++ b/lib/features/lifetime_offer/page.dart
@@ -179,7 +179,7 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
                 const SizedBox(height: 12),
                 Text(
                   switch (offerPlan) {
-                    LifetimeOfferPlan.monthly300 => '3年以上使ってくださっている方へ\n月額プランのご案内です',
+                    LifetimeOfferPlan.monthly300 => '長くご愛顧いただいている皆様へ\n月額プランのご案内です',
                     LifetimeOfferPlan.lifetime => switch (copyVariant) {
                         LifetimeOfferCopyVariant.defaultVariant => '長く使ってくださっている方へ\n買い切りプランのご案内です',
                         LifetimeOfferCopyVariant.ownership => '一度の購入で、ずっとプレミアム。\n月々のお支払いは不要です',
@@ -232,7 +232,11 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
                           : () async {
                               analytics.logEvent(
                                 name: 'pressed_lifetime_purchase_button',
-                                parameters: {'paywall_source': source.value, 'copy_variant': copyVariant.value, 'offer_plan': offerPlan.analyticsValue},
+                                parameters: {
+                                  'paywall_source': source.value,
+                                  'copy_variant': copyVariant.value,
+                                  'offer_plan': offerPlan.analyticsValue
+                                },
                               );
                               if (isLoading.value) return;
                               isLoading.value = true;
@@ -450,9 +454,11 @@ class Monthly300OfferPriceCard extends StatelessWidget {
         children: [
           const Text('月額プラン', style: TextStyle(color: TextColor.main, fontFamily: FontFamily.japanese, fontWeight: FontWeight.w700, fontSize: 16)),
           const SizedBox(height: 12),
-          Text(monthlyDiscountPackage.storeProduct.priceString, style: const TextStyle(color: TextColor.main, fontFamily: FontFamily.number, fontWeight: FontWeight.w800, fontSize: 40)),
+          Text(monthlyDiscountPackage.storeProduct.priceString,
+              style: const TextStyle(color: TextColor.main, fontFamily: FontFamily.number, fontWeight: FontWeight.w800, fontSize: 40)),
           const SizedBox(height: 8),
-          const Text('1ヶ月ごとの自動更新', style: TextStyle(color: TextColor.gray, fontFamily: FontFamily.japanese, fontWeight: FontWeight.w400, fontSize: 13)),
+          const Text('1ヶ月ごとの自動更新',
+              style: TextStyle(color: TextColor.gray, fontFamily: FontFamily.japanese, fontWeight: FontWeight.w400, fontSize: 13)),
         ],
       ),
     );

--- a/lib/features/lifetime_offer/provider.dart
+++ b/lib/features/lifetime_offer/provider.dart
@@ -39,10 +39,7 @@ final lifetimeOfferPlanProvider = Provider.autoDispose<LifetimeOfferPlan?>((ref)
   if (usageDays >= monthly300OfferUsageDaysSince && user == null) {
     return null;
   }
-  if (user != null &&
-      !user.isPremium &&
-      usageDays >= monthly300OfferUsageDaysSince &&
-      ref.watch(monthlyDiscountPackageProvider) != null) {
+  if (user != null && !user.isPremium && usageDays >= monthly300OfferUsageDaysSince && ref.watch(monthlyDiscountPackageProvider) != null) {
     return LifetimeOfferPlan.monthly300;
   }
   return LifetimeOfferPlan.lifetime;

--- a/lib/features/lifetime_offer/provider.dart
+++ b/lib/features/lifetime_offer/provider.dart
@@ -1,9 +1,11 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/provider/auth.dart';
 import 'package:pilll/provider/purchase.dart';
 import 'package:pilll/provider/remote_config_parameter.dart';
 import 'package:pilll/provider/tick.dart';
 import 'package:pilll/provider/typed_shared_preferences.dart';
+import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/datetime/day.dart';
 import 'package:pilll/utils/formatter/date_time_formatter.dart';
 import 'package:pilll/utils/shared_preference/keys.dart';
@@ -22,6 +24,29 @@ final lifetimeOfferUsageDaysProvider = Provider.autoDispose<int?>((ref) {
 
 /// 買い切りオファーの表示周期の日数。1年ごとに同じ時期へオファーを出すための固定値（うるう年による1日程度のずれは許容する）
 const _lifetimeOfferCycleDays = 365;
+
+/// 月額300円オファーを優先する利用日数。3年を365日/年として判定する。
+const monthly300OfferUsageDaysSince = _lifetimeOfferCycleDays * 3;
+
+/// 無料かつ3年以上の利用者にはDiscount offeringの月額プランを優先する。
+final lifetimeOfferPlanProvider = Provider.autoDispose<LifetimeOfferPlan?>((ref) {
+  final user = ref.watch(userProvider).valueOrNull;
+  final usageDays = ref.watch(lifetimeOfferUsageDaysProvider);
+  if (usageDays == null) {
+    return null;
+  }
+  // 3年以上はユーザーの課金状態が確定するまで待ち、月額オファーより先に買い切りを表示しない。
+  if (usageDays >= monthly300OfferUsageDaysSince && user == null) {
+    return null;
+  }
+  if (user != null &&
+      !user.isPremium &&
+      usageDays >= monthly300OfferUsageDaysSince &&
+      ref.watch(monthlyDiscountPackageProvider) != null) {
+    return LifetimeOfferPlan.monthly300;
+  }
+  return LifetimeOfferPlan.lifetime;
+});
 
 /// 買い切りオファーの周期番号（利用開始からの経過年数, 0始まり）を返すProvider
 ///
@@ -62,7 +87,13 @@ final shouldShowLifetimeOfferProvider = Provider.autoDispose<bool>((ref) {
   if (ref.watch(isLifetimePurchasedProvider).valueOrNull != false) {
     return false;
   }
-  if (ref.watch(lifetimeDiscountPackageProvider) == null) {
+  final offerPlan = ref.watch(lifetimeOfferPlanProvider);
+  final offerPackageExists = switch (offerPlan) {
+    LifetimeOfferPlan.lifetime => ref.watch(lifetimeDiscountPackageProvider) != null,
+    LifetimeOfferPlan.monthly300 => ref.watch(monthlyDiscountPackageProvider) != null,
+    null => false,
+  };
+  if (!offerPackageExists) {
     return false;
   }
   final usageDays = ref.watch(lifetimeOfferUsageDaysProvider);

--- a/lib/features/record/components/announcement_bar/announcement_bar.dart
+++ b/lib/features/record/components/announcement_bar/announcement_bar.dart
@@ -85,6 +85,7 @@ class AnnouncementBar extends HookConsumerWidget {
     );
     final lifetimePurchaseStatus = ref.watch(isLifetimePurchasedProvider);
     final shouldShowLifetimeOffer = ref.watch(shouldShowLifetimeOfferProvider);
+    final lifetimeOfferPlan = ref.watch(lifetimeOfferPlanProvider);
 
     final historiesAsync = ref.watch(
       pillSheetModifiedHistoriesWithRangeProvider(
@@ -211,6 +212,7 @@ class AnnouncementBar extends HookConsumerWidget {
         if (shouldShowLifetimeOffer) {
           return LifetimeOfferAnnouncementBar(
             copyVariant: LifetimeOfferCopyVariant.fromString(remoteConfigParameter.lifetimeOfferCopyVariant),
+            offerPlan: lifetimeOfferPlan!,
           );
         }
 
@@ -251,6 +253,7 @@ class AnnouncementBar extends HookConsumerWidget {
       if (shouldShowLifetimeOffer) {
         return LifetimeOfferAnnouncementBar(
           copyVariant: LifetimeOfferCopyVariant.fromString(remoteConfigParameter.lifetimeOfferCopyVariant),
+          offerPlan: lifetimeOfferPlan!,
         );
       }
 

--- a/lib/features/record/components/announcement_bar/components/lifetime_offer.dart
+++ b/lib/features/record/components/announcement_bar/components/lifetime_offer.dart
@@ -23,7 +23,8 @@ class LifetimeOfferAnnouncementBar extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     useEffect(() {
-      analytics.logEvent(name: 'lifetime_offer_announcement_bar_viewed', parameters: {'copy_variant': copyVariant.value, 'offer_plan': offerPlan.analyticsValue});
+      analytics.logEvent(
+          name: 'lifetime_offer_announcement_bar_viewed', parameters: {'copy_variant': copyVariant.value, 'offer_plan': offerPlan.analyticsValue});
       analytics.setUserProperties('lifetime_offer_variant', copyVariant.value);
       // 表示期限の起点となる初回表示時刻を記録する
       setLifetimeOfferFirstDisplayedDateTimeIfAbsent(ref);
@@ -42,7 +43,8 @@ class LifetimeOfferAnnouncementBar extends HookConsumerWidget {
         // 子のヒットテスト結果に依存せず、矢印や余白を含むバー全域をタップ可能にする
         behavior: HitTestBehavior.opaque,
         onTap: () {
-          analytics.logEvent(name: 'lifetime_offer_announcement_bar_tap', parameters: {'copy_variant': copyVariant.value, 'offer_plan': offerPlan.analyticsValue});
+          analytics.logEvent(
+              name: 'lifetime_offer_announcement_bar_tap', parameters: {'copy_variant': copyVariant.value, 'offer_plan': offerPlan.analyticsValue});
           showLifetimeOfferPage(
             context,
             source: PaywallSource.lifetimeOfferBar,
@@ -56,9 +58,10 @@ class LifetimeOfferAnnouncementBar extends HookConsumerWidget {
               alignment: Alignment.center,
               child: Text(
                 switch (offerPlan) {
-                  LifetimeOfferPlan.monthly300 => '3年以上ご利用の方へ、月額300円！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
+                  LifetimeOfferPlan.monthly300 => '長くご愛顧いただいている皆様へ！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
                   LifetimeOfferPlan.lifetime => switch (copyVariant) {
-                      LifetimeOfferCopyVariant.defaultVariant => 'Pilllのご利用ありがとうございます！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
+                      LifetimeOfferCopyVariant.defaultVariant =>
+                        'Pilllのご利用ありがとうございます！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
                       LifetimeOfferCopyVariant.ownership => '一度の購入でずっとプレミアム！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
                     },
                 },

--- a/lib/features/record/components/announcement_bar/components/lifetime_offer.dart
+++ b/lib/features/record/components/announcement_bar/components/lifetime_offer.dart
@@ -6,6 +6,7 @@ import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/features/lifetime_offer/lifetime_offer_copy_variant.dart';
+import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/features/lifetime_offer/page.dart';
 import 'package:pilll/features/lifetime_offer/provider.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
@@ -16,12 +17,13 @@ import 'package:pilll/utils/analytics.dart';
 /// 初回表示から表示期限までの残り時間を毎秒更新でカウントダウン表示し、期限を過ぎると自動で消える。
 class LifetimeOfferAnnouncementBar extends HookConsumerWidget {
   final LifetimeOfferCopyVariant copyVariant;
-  const LifetimeOfferAnnouncementBar({super.key, required this.copyVariant});
+  final LifetimeOfferPlan offerPlan;
+  const LifetimeOfferAnnouncementBar({super.key, required this.copyVariant, required this.offerPlan});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     useEffect(() {
-      analytics.logEvent(name: 'lifetime_offer_announcement_bar_viewed', parameters: {'copy_variant': copyVariant.value});
+      analytics.logEvent(name: 'lifetime_offer_announcement_bar_viewed', parameters: {'copy_variant': copyVariant.value, 'offer_plan': offerPlan.analyticsValue});
       analytics.setUserProperties('lifetime_offer_variant', copyVariant.value);
       // 表示期限の起点となる初回表示時刻を記録する
       setLifetimeOfferFirstDisplayedDateTimeIfAbsent(ref);
@@ -40,11 +42,12 @@ class LifetimeOfferAnnouncementBar extends HookConsumerWidget {
         // 子のヒットテスト結果に依存せず、矢印や余白を含むバー全域をタップ可能にする
         behavior: HitTestBehavior.opaque,
         onTap: () {
-          analytics.logEvent(name: 'lifetime_offer_announcement_bar_tap', parameters: {'copy_variant': copyVariant.value});
+          analytics.logEvent(name: 'lifetime_offer_announcement_bar_tap', parameters: {'copy_variant': copyVariant.value, 'offer_plan': offerPlan.analyticsValue});
           showLifetimeOfferPage(
             context,
             source: PaywallSource.lifetimeOfferBar,
             copyVariant: copyVariant,
+            offerPlan: offerPlan,
           );
         },
         child: Stack(
@@ -52,9 +55,12 @@ class LifetimeOfferAnnouncementBar extends HookConsumerWidget {
             Align(
               alignment: Alignment.center,
               child: Text(
-                switch (copyVariant) {
-                  LifetimeOfferCopyVariant.defaultVariant => 'Pilllのご利用ありがとうございます！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
-                  LifetimeOfferCopyVariant.ownership => '一度の購入でずっとプレミアム！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
+                switch (offerPlan) {
+                  LifetimeOfferPlan.monthly300 => '3年以上ご利用の方へ、月額300円！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
+                  LifetimeOfferPlan.lifetime => switch (copyVariant) {
+                      LifetimeOfferCopyVariant.defaultVariant => 'Pilllのご利用ありがとうございます！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
+                      LifetimeOfferCopyVariant.ownership => '一度の購入でずっとプレミアム！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
+                    },
                 },
                 style: const TextStyle(
                   fontFamily: FontFamily.japanese,

--- a/lib/features/root/resolver/show_lifetime_offer_on_app_launch.dart
+++ b/lib/features/root/resolver/show_lifetime_offer_on_app_launch.dart
@@ -20,6 +20,7 @@ class ShowLifetimeOfferOnAppLaunch extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final shouldShowLifetimeOffer = ref.watch(shouldShowLifetimeOfferProvider);
+    final lifetimeOfferPlan = ref.watch(lifetimeOfferPlanProvider);
     // 周期番号が確定するまで（null）はshouldShowLifetimeOfferがfalseのため、仮のキー(cycle: 0)が使われることはない
     final lifetimeOfferCycle = ref.watch(lifetimeOfferCycleProvider);
     final lifetimeOfferAutoModalShown = ref.watch(
@@ -52,6 +53,7 @@ class ShowLifetimeOfferOnAppLaunch extends HookConsumerWidget {
               context,
               source: PaywallSource.lifetimeOfferAppLaunch,
               copyVariant: LifetimeOfferCopyVariant.fromString(ref.read(remoteConfigParameterProvider).lifetimeOfferCopyVariant),
+              offerPlan: lifetimeOfferPlan!,
             );
           }
         });

--- a/lib/features/settings/components/rows/lifetime_offer_paywall_row.dart
+++ b/lib/features/settings/components/rows/lifetime_offer_paywall_row.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/features/lifetime_offer/lifetime_offer_copy_variant.dart';
+import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/features/lifetime_offer/page.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/provider/purchase.dart';
@@ -41,6 +42,10 @@ class LifetimeOfferPaywallRow extends StatelessWidget {
         if (copyVariant == null || !context.mounted) {
           return;
         }
+        final offerPlan = await _selectLifetimeOfferPlan(context);
+        if (offerPlan == null || !context.mounted) {
+          return;
+        }
         Navigator.of(context).push(
           MaterialPageRoute(
             fullscreenDialog: true,
@@ -63,6 +68,7 @@ class LifetimeOfferPaywallRow extends StatelessWidget {
               child: LifetimeOfferPage(
                 source: PaywallSource.lifetimeOfferBar,
                 copyVariant: copyVariant,
+                offerPlan: offerPlan,
               ),
             ),
           ),
@@ -86,6 +92,26 @@ Future<LifetimeOfferCopyVariant?> _selectLifetimeOfferCopyVariant(BuildContext c
         SimpleDialogOption(
           onPressed: () => Navigator.of(context).pop(LifetimeOfferCopyVariant.ownership),
           child: const Text('ownership（所有価値訴求）'),
+        ),
+      ],
+    ),
+  );
+}
+
+/// 表示するオファープランを選択するダイアログを表示する。キャンセル時はnullを返す。
+Future<LifetimeOfferPlan?> _selectLifetimeOfferPlan(BuildContext context) {
+  return showDialog<LifetimeOfferPlan>(
+    context: context,
+    builder: (context) => SimpleDialog(
+      title: const Text('オファープランを選択'),
+      children: [
+        SimpleDialogOption(
+          onPressed: () => Navigator.of(context).pop(LifetimeOfferPlan.lifetime),
+          child: const Text('買い切りプラン'),
+        ),
+        SimpleDialogOption(
+          onPressed: () => Navigator.of(context).pop(LifetimeOfferPlan.monthly300),
+          child: const Text('月額300円プラン'),
         ),
       ],
     ),

--- a/lib/provider/purchase.dart
+++ b/lib/provider/purchase.dart
@@ -117,6 +117,16 @@ final monthlySpecialOfferingPackageProvider = Provider.autoDispose((ref) {
     (element) => element.packageType == PackageType.monthly,
   );
 });
+final monthlyDiscountPackageProvider = Provider.autoDispose((ref) {
+  const discountOfferingType = OfferingType.discount;
+  final offering = ref.watch(purchaseOfferingsProvider).valueOrNull?.all[discountOfferingType.identifier];
+  if (offering == null) {
+    return null;
+  }
+  return offering.availablePackages.firstWhereOrNull(
+    (element) => element.packageType == PackageType.monthly,
+  );
+});
 final lifetimeDiscountPackageProvider = Provider.autoDispose((ref) {
   const limitedPackageOfferingType = OfferingType.discount;
   final offering = ref.watch(purchaseOfferingsProvider).valueOrNull?.all[limitedPackageOfferingType.identifier];

--- a/test/features/lifetime_offer/page_test.dart
+++ b/test/features/lifetime_offer/page_test.dart
@@ -166,7 +166,7 @@ void main() {
         offerPlan: LifetimeOfferPlan.monthly300,
       );
 
-      expect(find.text('3年以上使ってくださっている方へ\n月額プランのご案内です'), findsOneWidget);
+      expect(find.text('長くご愛顧いただいている皆様へ\n月額プランのご案内です'), findsOneWidget);
       expect(find.byType(Monthly300OfferPriceCard), findsOneWidget);
       expect(find.byType(LifetimeOfferPriceCard), findsNothing);
     });

--- a/test/features/lifetime_offer/page_test.dart
+++ b/test/features/lifetime_offer/page_test.dart
@@ -9,6 +9,7 @@ import 'package:pilll/components/molecules/indicator.dart';
 import 'package:pilll/entity/remote_config_parameter.codegen.dart';
 import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/features/lifetime_offer/lifetime_offer_copy_variant.dart';
+import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/features/lifetime_offer/page.dart';
 import 'package:pilll/features/lifetime_offer/provider.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
@@ -64,6 +65,7 @@ void main() {
       Map<String, Object> initialSharedPreferencesValues = const {},
       LifetimeOfferCopyVariant copyVariant =
           LifetimeOfferCopyVariant.defaultVariant,
+      LifetimeOfferPlan offerPlan = LifetimeOfferPlan.lifetime,
     }) async {
       final mockTodayRepository = MockTodayService();
       when(mockTodayRepository.now()).thenReturn(DateTime(2026, 7, 3));
@@ -84,6 +86,9 @@ void main() {
             lifetimeDiscountPackageProvider.overrideWith(
               (ref) =>
                   hasLifetimeDiscountPackage ? _LifetimeFakePackage() : null,
+            ),
+            monthlyDiscountPackageProvider.overrideWith(
+              (ref) => _LifetimeFakePackage(),
             ),
             lifetimePremiumPackageProvider.overrideWith(
               (ref) => _LifetimeFakePackage(),
@@ -107,6 +112,7 @@ void main() {
                 user: user,
                 source: PaywallSource.lifetimeOfferAppLaunch,
                 copyVariant: copyVariant,
+                offerPlan: offerPlan,
               ),
             ),
           ),
@@ -151,6 +157,18 @@ void main() {
         expect(find.text('一度の購入で、ずっとプレミアム。\n月々のお支払いは不要です'), findsOneWidget);
         expect(find.text('長く使ってくださっている方へ\n買い切りプランのご案内です'), findsNothing);
       });
+    });
+
+    testWidgets('月額300円プランでは月額向け訴求と価格カードが表示される', (WidgetTester tester) async {
+      await pumpLifetimeOfferPageBody(
+        tester,
+        user: const User(isPremium: false),
+        offerPlan: LifetimeOfferPlan.monthly300,
+      );
+
+      expect(find.text('3年以上使ってくださっている方へ\n月額プランのご案内です'), findsOneWidget);
+      expect(find.byType(Monthly300OfferPriceCard), findsOneWidget);
+      expect(find.byType(LifetimeOfferPriceCard), findsNothing);
     });
 
     group('#LifetimeOfferSubscriptionCancelNotice', () {

--- a/test/features/lifetime_offer/provider_test.dart
+++ b/test/features/lifetime_offer/provider_test.dart
@@ -4,12 +4,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mockito/mockito.dart';
 import 'package:pilll/entity/remote_config_parameter.codegen.dart';
+import 'package:pilll/entity/user.codegen.dart';
+import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/features/lifetime_offer/provider.dart';
 import 'package:pilll/provider/auth.dart';
 import 'package:pilll/provider/purchase.dart';
 import 'package:pilll/provider/remote_config_parameter.dart';
 import 'package:pilll/provider/shared_preferences.dart';
 import 'package:pilll/provider/tick.dart';
+import 'package:pilll/provider/user.dart';
 import 'package:pilll/utils/datetime/day.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -19,6 +22,34 @@ import '../../helper/mock.mocks.dart';
 void main() {
   setUp(() {
     TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  group('#lifetimeOfferPlanProvider', () {
+    Future<LifetimeOfferPlan> readPlan({required int usageDays, required bool isPremium, bool hasMonthlyPackage = true}) async {
+      final container = ProviderContainer(
+        overrides: [
+          userProvider.overrideWith((ref) => Stream.value(User(isPremium: isPremium))),
+          lifetimeOfferUsageDaysProvider.overrideWith((ref) => usageDays),
+          monthlyDiscountPackageProvider.overrideWith((ref) => hasMonthlyPackage ? FakeRevenueCatPackage() : null),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(userProvider.future);
+      return container.read(lifetimeOfferPlanProvider)!;
+    }
+
+    test('無料ユーザーは利用1095日から月額300円プランを優先する', () async {
+      expect(await readPlan(usageDays: 1094, isPremium: false), LifetimeOfferPlan.lifetime);
+      expect(await readPlan(usageDays: 1095, isPremium: false), LifetimeOfferPlan.monthly300);
+    });
+
+    test('3年以上でもプレミアムユーザーには買い切りプランを提示する', () async {
+      expect(await readPlan(usageDays: 1095, isPremium: true), LifetimeOfferPlan.lifetime);
+    });
+
+    test('月額300円Packageを取得できない場合は買い切りプランへフォールバックする', () async {
+      expect(await readPlan(usageDays: 1095, isPremium: false, hasMonthlyPackage: false), LifetimeOfferPlan.lifetime);
+    });
   });
 
   group('#shouldShowLifetimeOfferProvider', () {

--- a/test/features/lifetime_offer/provider_test.dart
+++ b/test/features/lifetime_offer/provider_test.dart
@@ -25,12 +25,17 @@ void main() {
   });
 
   group('#lifetimeOfferPlanProvider', () {
-    Future<LifetimeOfferPlan> readPlan({required int usageDays, required bool isPremium, bool hasMonthlyPackage = true}) async {
+    Future<LifetimeOfferPlan> readPlan(
+        {required int usageDays,
+        required bool isPremium,
+        bool hasMonthlyPackage = true}) async {
       final container = ProviderContainer(
         overrides: [
-          userProvider.overrideWith((ref) => Stream.value(User(isPremium: isPremium))),
+          userProvider
+              .overrideWith((ref) => Stream.value(User(isPremium: isPremium))),
           lifetimeOfferUsageDaysProvider.overrideWith((ref) => usageDays),
-          monthlyDiscountPackageProvider.overrideWith((ref) => hasMonthlyPackage ? FakeRevenueCatPackage() : null),
+          monthlyDiscountPackageProvider.overrideWith(
+              (ref) => hasMonthlyPackage ? FakeRevenueCatPackage() : null),
         ],
       );
       addTearDown(container.dispose);
@@ -39,16 +44,22 @@ void main() {
     }
 
     test('無料ユーザーは利用1095日から月額300円プランを優先する', () async {
-      expect(await readPlan(usageDays: 1094, isPremium: false), LifetimeOfferPlan.lifetime);
-      expect(await readPlan(usageDays: 1095, isPremium: false), LifetimeOfferPlan.monthly300);
+      expect(await readPlan(usageDays: 1094, isPremium: false),
+          LifetimeOfferPlan.lifetime);
+      expect(await readPlan(usageDays: 1095, isPremium: false),
+          LifetimeOfferPlan.monthly300);
     });
 
     test('3年以上でもプレミアムユーザーには買い切りプランを提示する', () async {
-      expect(await readPlan(usageDays: 1095, isPremium: true), LifetimeOfferPlan.lifetime);
+      expect(await readPlan(usageDays: 1095, isPremium: true),
+          LifetimeOfferPlan.lifetime);
     });
 
     test('月額300円Packageを取得できない場合は買い切りプランへフォールバックする', () async {
-      expect(await readPlan(usageDays: 1095, isPremium: false, hasMonthlyPackage: false), LifetimeOfferPlan.lifetime);
+      expect(
+          await readPlan(
+              usageDays: 1095, isPremium: false, hasMonthlyPackage: false),
+          LifetimeOfferPlan.lifetime);
     });
   });
 

--- a/test/features/record/announcement_bar/components/lifetime_offer_test.dart
+++ b/test/features/record/announcement_bar/components/lifetime_offer_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/features/lifetime_offer/lifetime_offer_copy_variant.dart';
+import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/features/lifetime_offer/provider.dart';
 import 'package:pilll/features/record/components/announcement_bar/components/lifetime_offer.dart';
 import 'package:pilll/utils/analytics.dart';
@@ -18,6 +19,7 @@ void main() {
     Future<void> pumpBar(
       WidgetTester tester, {
       required LifetimeOfferCopyVariant copyVariant,
+      LifetimeOfferPlan offerPlan = LifetimeOfferPlan.lifetime,
     }) async {
       await tester.pumpWidget(
         ProviderScope(
@@ -30,7 +32,7 @@ void main() {
           ],
           child: MaterialApp(
             home: Material(
-              child: LifetimeOfferAnnouncementBar(copyVariant: copyVariant),
+              child: LifetimeOfferAnnouncementBar(copyVariant: copyVariant, offerPlan: offerPlan),
             ),
           ),
         ),
@@ -51,6 +53,16 @@ void main() {
 
       expect(find.textContaining('一度の購入でずっとプレミアム！'), findsOneWidget);
       expect(find.textContaining('Pilllのご利用ありがとうございます！'), findsNothing);
+    });
+
+    testWidgets('月額300円プランで3年以上利用者向けの文言が表示される', (WidgetTester tester) async {
+      await pumpBar(
+        tester,
+        copyVariant: LifetimeOfferCopyVariant.defaultVariant,
+        offerPlan: LifetimeOfferPlan.monthly300,
+      );
+
+      expect(find.textContaining('3年以上ご利用の方へ、月額300円！'), findsOneWidget);
     });
   });
 }

--- a/test/features/record/announcement_bar/components/lifetime_offer_test.dart
+++ b/test/features/record/announcement_bar/components/lifetime_offer_test.dart
@@ -32,7 +32,8 @@ void main() {
           ],
           child: MaterialApp(
             home: Material(
-              child: LifetimeOfferAnnouncementBar(copyVariant: copyVariant, offerPlan: offerPlan),
+              child: LifetimeOfferAnnouncementBar(
+                  copyVariant: copyVariant, offerPlan: offerPlan),
             ),
           ),
         ),
@@ -62,7 +63,7 @@ void main() {
         offerPlan: LifetimeOfferPlan.monthly300,
       );
 
-      expect(find.textContaining('3年以上ご利用の方へ、月額300円！'), findsOneWidget);
+      expect(find.textContaining('長くご愛顧いただいている皆様へ！'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Abstract

3年以上利用している無料ユーザーに、従来の買い切りオファーより優先して月額300円プランを提示する。

PR #1818で導入した1年ごとの対象期間、24時間の表示期限、アナウンスバー、起動時モーダル、Paywallを共用し、対象ユーザーだけ購入対象をRevenueCatの`Discount` offeringの月額Packageへ切り替える。

## Why

買い切りプランのオファーは無料ユーザーに響きにくい可能性があるため、長期間継続利用している無料ユーザーには購入ハードルの低い月額300円プランを優先して提示したい。

## 主な変更点

- 無料かつ利用1095日以上のユーザーへ月額300円プランを優先する判定を追加
- ユーザーの課金状態が未確定の間は買い切りオファーを先に表示しないよう制御
- `Discount` offeringから月額Packageを取得し、取得できない場合は従来の買い切りへフォールバック
- 既存Paywallを月額向けの訴求、価格カード、自動更新説明へ対応
- 月額向けの訴求を「長くご愛顧いただいている皆様へ」に統一
- アナウンスバーと起動時モーダルへオファープランを伝播
- Analyticsイベントへ`offer_plan`を追加
- 開発者オプションから買い切り／月額300円を選択できる確認導線を追加
- 1094日／1095日の境界、課金状態、Package取得失敗、Paywall、アナウンスバーのテストを追加

## 影響範囲

- 利用開始から3年以上の無料ユーザー向けオファー表示
- 長期利用者向けアナウンスバーと起動時モーダル
- 長期利用者向けPaywallの表示内容と購入対象Package
- オファー関連Analyticsイベント
- 開発者オプションのPaywall確認導線

3年未満のユーザーおよびプレミアムユーザーには、従来どおり買い切りオファーを提示する。

## 動作確認

- 関連テスト58件成功
- `git diff --check`成功
- iOS Simulator向けビルド成功
- iOS Simulator `pilll-add-offer-300yen-iOS26.5`で更新後のPaywallを表示
- 訴求文言、月額価格、自動更新説明、購入ボタンに表示崩れがないことを確認

<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/bannzai/Pilll/20260712/24ad2ae3-92db-4f6d-85f1-3cc6fa89ec5d.png" width="400" />

## Links

- #1818

## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた

## セッション再開

```sh
cd /Users/bannzai/worktrees/bannzai/Pilll/add-offer-300yen
codex resume 019f516c-2535-7c33-871f-3dcdd9ebf6de
```
