### PR TITLE
月額300円オファーを未購入ユーザーに限定

### DIFF
--- a/lib/features/lifetime_offer/lifetime_offer_plan.dart
+++ b/lib/features/lifetime_offer/lifetime_offer_plan.dart
@@ -1,9 +1,0 @@
-/// 長期利用者向けオファーで提示するプラン。
-enum LifetimeOfferPlan {
-  lifetime('lifetime'),
-  monthly300('monthly_300');
-
-  const LifetimeOfferPlan(this.analyticsValue);
-
-  final String analyticsValue;
-}

--- a/lib/features/lifetime_offer/page.dart
+++ b/lib/features/lifetime_offer/page.dart
@@ -10,7 +10,6 @@ import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/features/error/error_alert.dart';
 import 'package:pilll/features/error/page.dart';
 import 'package:pilll/features/lifetime_offer/lifetime_offer_copy_variant.dart';
-import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/features/lifetime_offer/provider.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/components/premium_introduction_footer.dart';
@@ -29,12 +28,12 @@ import 'package:url_launcher/url_launcher.dart';
 class LifetimeOfferPage extends HookConsumerWidget {
   final PaywallSource source;
   final LifetimeOfferCopyVariant copyVariant;
-  final LifetimeOfferPlan offerPlan;
+  final bool isMonthly300Offer;
   const LifetimeOfferPage({
     super.key,
     required this.source,
     required this.copyVariant,
-    required this.offerPlan,
+    required this.isMonthly300Offer,
   });
 
   @override
@@ -45,7 +44,7 @@ class LifetimeOfferPage extends HookConsumerWidget {
               user: user,
               source: source,
               copyVariant: copyVariant,
-              offerPlan: offerPlan,
+              isMonthly300Offer: isMonthly300Offer,
             );
           },
           error: (error, stackTrace) => UniversalErrorPage(
@@ -64,14 +63,14 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
   final User user;
   final PaywallSource source;
   final LifetimeOfferCopyVariant copyVariant;
-  final LifetimeOfferPlan offerPlan;
+  final bool isMonthly300Offer;
 
   const LifetimeOfferPageBody({
     super.key,
     required this.user,
     required this.source,
     required this.copyVariant,
-    required this.offerPlan,
+    required this.isMonthly300Offer,
   });
 
   @override
@@ -90,10 +89,7 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
     // ページを開いたまま表示期限を迎えた場合に購入導線を無効化するための判定。false→trueの変化時のみ再ビルドされる
     final isOverLifetimeOfferDeadline = ref.watch(isOverLifetimeOfferDeadlineProvider);
 
-    final offerPackage = switch (offerPlan) {
-      LifetimeOfferPlan.lifetime => lifetimeDiscountPackage,
-      LifetimeOfferPlan.monthly300 => monthlyDiscountPackage,
-    };
+    final offerPackage = isMonthly300Offer ? monthlyDiscountPackage : lifetimeDiscountPackage;
     if (offerPackage == null) {
       return const ScaffoldIndicator();
     }
@@ -178,13 +174,12 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
                 ],
                 const SizedBox(height: 12),
                 Text(
-                  switch (offerPlan) {
-                    LifetimeOfferPlan.monthly300 => '長くご愛顧いただいている皆様へ\n月額プランのご案内です',
-                    LifetimeOfferPlan.lifetime => switch (copyVariant) {
-                        LifetimeOfferCopyVariant.defaultVariant => '長く使ってくださっている方へ\n買い切りプランのご案内です',
-                        LifetimeOfferCopyVariant.ownership => '一度の購入で、ずっとプレミアム。\n月々のお支払いは不要です',
-                      },
-                  },
+                  isMonthly300Offer
+                      ? '長くご愛顧いただいている皆様へ\n月額プランのご案内です'
+                      : switch (copyVariant) {
+                          LifetimeOfferCopyVariant.defaultVariant => '長く使ってくださっている方へ\n買い切りプランのご案内です',
+                          LifetimeOfferCopyVariant.ownership => '一度の購入で、ずっとプレミアム。\n月々のお支払いは不要です',
+                        },
                   textAlign: TextAlign.center,
                   style: const TextStyle(
                     color: TextColor.main,
@@ -207,11 +202,11 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
                 const SizedBox(height: 8),
                 const LifetimeOfferCountdownText(),
                 const SizedBox(height: 28),
-                if (offerPlan == LifetimeOfferPlan.lifetime && isActiveSubscriber) ...[
+                if (!isMonthly300Offer && isActiveSubscriber) ...[
                   const LifetimeOfferSubscriptionCancelNotice(),
                   const SizedBox(height: 16),
                 ],
-                if (offerPlan == LifetimeOfferPlan.lifetime)
+                if (!isMonthly300Offer)
                   LifetimeOfferPriceCard(
                     lifetimeDiscountPackage: offerPackage,
                     lifetimePremiumPackage: lifetimePremiumPackage,
@@ -235,7 +230,7 @@ class LifetimeOfferPageBody extends HookConsumerWidget {
                                 parameters: {
                                   'paywall_source': source.value,
                                   'copy_variant': copyVariant.value,
-                                  'offer_plan': offerPlan.analyticsValue
+                                  'offer_plan': isMonthly300Offer ? 'monthly_300' : 'lifetime'
                                 },
                               );
                               if (isLoading.value) return;
@@ -496,12 +491,12 @@ Future<void> showLifetimeOfferPage(
   BuildContext context, {
   required PaywallSource source,
   required LifetimeOfferCopyVariant copyVariant,
-  required LifetimeOfferPlan offerPlan,
+  required bool isMonthly300Offer,
 }) async {
   analytics.logScreenView(screenName: 'LifetimeOfferPage');
   analytics.logEvent(
     name: 'paywall_viewed',
-    parameters: {'paywall_source': source.value, 'copy_variant': copyVariant.value, 'offer_plan': offerPlan.analyticsValue},
+    parameters: {'paywall_source': source.value, 'copy_variant': copyVariant.value, 'offer_plan': isMonthly300Offer ? 'monthly_300' : 'lifetime'},
   );
   analytics.setUserProperties('lifetime_offer_variant', copyVariant.value);
 
@@ -511,7 +506,7 @@ Future<void> showLifetimeOfferPage(
       builder: (_) => LifetimeOfferPage(
         source: source,
         copyVariant: copyVariant,
-        offerPlan: offerPlan,
+        isMonthly300Offer: isMonthly300Offer,
       ),
     ),
   );

--- a/lib/features/lifetime_offer/provider.dart
+++ b/lib/features/lifetime_offer/provider.dart
@@ -28,7 +28,7 @@ const _lifetimeOfferCycleDays = 365;
 /// 月額300円オファーを優先する利用日数。3年を365日/年として判定する。
 const monthly300OfferUsageDaysSince = _lifetimeOfferCycleDays * 3;
 
-/// 無料かつ3年以上の利用者にはDiscount offeringの月額プランを優先する。
+/// 無料・3年以上・購入履歴なしの利用者にはDiscount offeringの月額プランを優先する。
 final lifetimeOfferPlanProvider = Provider.autoDispose<LifetimeOfferPlan?>((ref) {
   final user = ref.watch(userProvider).valueOrNull;
   final usageDays = ref.watch(lifetimeOfferUsageDaysProvider);
@@ -39,8 +39,14 @@ final lifetimeOfferPlanProvider = Provider.autoDispose<LifetimeOfferPlan?>((ref)
   if (usageDays >= monthly300OfferUsageDaysSince && user == null) {
     return null;
   }
-  if (user != null && !user.isPremium && usageDays >= monthly300OfferUsageDaysSince && ref.watch(monthlyDiscountPackageProvider) != null) {
-    return LifetimeOfferPlan.monthly300;
+  if (user != null && !user.isPremium && usageDays >= monthly300OfferUsageDaysSince) {
+    final hasPurchasedAnyProduct = ref.watch(hasPurchasedAnyProductProvider).valueOrNull;
+    if (hasPurchasedAnyProduct == null) {
+      return null;
+    }
+    if (!hasPurchasedAnyProduct && ref.watch(monthlyDiscountPackageProvider) != null) {
+      return LifetimeOfferPlan.monthly300;
+    }
   }
   return LifetimeOfferPlan.lifetime;
 });

--- a/lib/features/lifetime_offer/provider.dart
+++ b/lib/features/lifetime_offer/provider.dart
@@ -1,5 +1,4 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/provider/auth.dart';
 import 'package:pilll/provider/purchase.dart';
 import 'package:pilll/provider/remote_config_parameter.dart';
@@ -28,8 +27,11 @@ const _lifetimeOfferCycleDays = 365;
 /// 月額300円オファーを優先する利用日数。3年を365日/年として判定する。
 const monthly300OfferUsageDaysSince = _lifetimeOfferCycleDays * 3;
 
-/// 無料・3年以上・購入履歴なしの利用者にはDiscount offeringの月額プランを優先する。
-final lifetimeOfferPlanProvider = Provider.autoDispose<LifetimeOfferPlan?>((ref) {
+/// Discount offeringの月額300円プランを提示するかどうかを返す。
+///
+/// 無料・3年以上・購入履歴なしの利用者が対象。
+/// 判定に必要な情報の取得中はnullを返す。
+final isMonthly300OfferProvider = Provider.autoDispose<bool?>((ref) {
   final user = ref.watch(userProvider).valueOrNull;
   final usageDays = ref.watch(lifetimeOfferUsageDaysProvider);
   if (usageDays == null) {
@@ -45,10 +47,10 @@ final lifetimeOfferPlanProvider = Provider.autoDispose<LifetimeOfferPlan?>((ref)
       return null;
     }
     if (!hasPurchasedAnyProduct && ref.watch(monthlyDiscountPackageProvider) != null) {
-      return LifetimeOfferPlan.monthly300;
+      return true;
     }
   }
-  return LifetimeOfferPlan.lifetime;
+  return false;
 });
 
 /// 買い切りオファーの周期番号（利用開始からの経過年数, 0始まり）を返すProvider
@@ -90,10 +92,10 @@ final shouldShowLifetimeOfferProvider = Provider.autoDispose<bool>((ref) {
   if (ref.watch(isLifetimePurchasedProvider).valueOrNull != false) {
     return false;
   }
-  final offerPlan = ref.watch(lifetimeOfferPlanProvider);
-  final offerPackageExists = switch (offerPlan) {
-    LifetimeOfferPlan.lifetime => ref.watch(lifetimeDiscountPackageProvider) != null,
-    LifetimeOfferPlan.monthly300 => ref.watch(monthlyDiscountPackageProvider) != null,
+  final isMonthly300Offer = ref.watch(isMonthly300OfferProvider);
+  final offerPackageExists = switch (isMonthly300Offer) {
+    false => ref.watch(lifetimeDiscountPackageProvider) != null,
+    true => ref.watch(monthlyDiscountPackageProvider) != null,
     null => false,
   };
   if (!offerPackageExists) {

--- a/lib/features/record/components/announcement_bar/announcement_bar.dart
+++ b/lib/features/record/components/announcement_bar/announcement_bar.dart
@@ -85,7 +85,7 @@ class AnnouncementBar extends HookConsumerWidget {
     );
     final lifetimePurchaseStatus = ref.watch(isLifetimePurchasedProvider);
     final shouldShowLifetimeOffer = ref.watch(shouldShowLifetimeOfferProvider);
-    final lifetimeOfferPlan = ref.watch(lifetimeOfferPlanProvider);
+    final isMonthly300Offer = ref.watch(isMonthly300OfferProvider);
 
     final historiesAsync = ref.watch(
       pillSheetModifiedHistoriesWithRangeProvider(
@@ -212,7 +212,7 @@ class AnnouncementBar extends HookConsumerWidget {
         if (shouldShowLifetimeOffer) {
           return LifetimeOfferAnnouncementBar(
             copyVariant: LifetimeOfferCopyVariant.fromString(remoteConfigParameter.lifetimeOfferCopyVariant),
-            offerPlan: lifetimeOfferPlan!,
+            isMonthly300Offer: isMonthly300Offer!,
           );
         }
 
@@ -253,7 +253,7 @@ class AnnouncementBar extends HookConsumerWidget {
       if (shouldShowLifetimeOffer) {
         return LifetimeOfferAnnouncementBar(
           copyVariant: LifetimeOfferCopyVariant.fromString(remoteConfigParameter.lifetimeOfferCopyVariant),
-          offerPlan: lifetimeOfferPlan!,
+          isMonthly300Offer: isMonthly300Offer!,
         );
       }
 

--- a/lib/features/record/components/announcement_bar/components/lifetime_offer.dart
+++ b/lib/features/record/components/announcement_bar/components/lifetime_offer.dart
@@ -6,7 +6,6 @@ import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/features/lifetime_offer/lifetime_offer_copy_variant.dart';
-import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/features/lifetime_offer/page.dart';
 import 'package:pilll/features/lifetime_offer/provider.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
@@ -17,14 +16,15 @@ import 'package:pilll/utils/analytics.dart';
 /// 初回表示から表示期限までの残り時間を毎秒更新でカウントダウン表示し、期限を過ぎると自動で消える。
 class LifetimeOfferAnnouncementBar extends HookConsumerWidget {
   final LifetimeOfferCopyVariant copyVariant;
-  final LifetimeOfferPlan offerPlan;
-  const LifetimeOfferAnnouncementBar({super.key, required this.copyVariant, required this.offerPlan});
+  final bool isMonthly300Offer;
+  const LifetimeOfferAnnouncementBar({super.key, required this.copyVariant, required this.isMonthly300Offer});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     useEffect(() {
       analytics.logEvent(
-          name: 'lifetime_offer_announcement_bar_viewed', parameters: {'copy_variant': copyVariant.value, 'offer_plan': offerPlan.analyticsValue});
+          name: 'lifetime_offer_announcement_bar_viewed',
+          parameters: {'copy_variant': copyVariant.value, 'offer_plan': isMonthly300Offer ? 'monthly_300' : 'lifetime'});
       analytics.setUserProperties('lifetime_offer_variant', copyVariant.value);
       // 表示期限の起点となる初回表示時刻を記録する
       setLifetimeOfferFirstDisplayedDateTimeIfAbsent(ref);
@@ -44,12 +44,13 @@ class LifetimeOfferAnnouncementBar extends HookConsumerWidget {
         behavior: HitTestBehavior.opaque,
         onTap: () {
           analytics.logEvent(
-              name: 'lifetime_offer_announcement_bar_tap', parameters: {'copy_variant': copyVariant.value, 'offer_plan': offerPlan.analyticsValue});
+              name: 'lifetime_offer_announcement_bar_tap',
+              parameters: {'copy_variant': copyVariant.value, 'offer_plan': isMonthly300Offer ? 'monthly_300' : 'lifetime'});
           showLifetimeOfferPage(
             context,
             source: PaywallSource.lifetimeOfferBar,
             copyVariant: copyVariant,
-            offerPlan: offerPlan,
+            isMonthly300Offer: isMonthly300Offer,
           );
         },
         child: Stack(
@@ -57,14 +58,13 @@ class LifetimeOfferAnnouncementBar extends HookConsumerWidget {
             Align(
               alignment: Alignment.center,
               child: Text(
-                switch (offerPlan) {
-                  LifetimeOfferPlan.monthly300 => '長くご愛顧いただいている皆様へ！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
-                  LifetimeOfferPlan.lifetime => switch (copyVariant) {
-                      LifetimeOfferCopyVariant.defaultVariant =>
-                        'Pilllのご利用ありがとうございます！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
-                      LifetimeOfferCopyVariant.ownership => '一度の購入でずっとプレミアム！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
-                    },
-                },
+                isMonthly300Offer
+                    ? '長くご愛顧いただいている皆様へ！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}'
+                    : switch (copyVariant) {
+                        LifetimeOfferCopyVariant.defaultVariant =>
+                          'Pilllのご利用ありがとうございます！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
+                        LifetimeOfferCopyVariant.ownership => '一度の購入でずっとプレミアム！\n期間限定の割引価格は残り ${lifetimeOfferCountdownString(remainingDuration)}',
+                      },
                 style: const TextStyle(
                   fontFamily: FontFamily.japanese,
                   fontWeight: FontWeight.w600,

--- a/lib/features/root/resolver/show_lifetime_offer_on_app_launch.dart
+++ b/lib/features/root/resolver/show_lifetime_offer_on_app_launch.dart
@@ -20,7 +20,7 @@ class ShowLifetimeOfferOnAppLaunch extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final shouldShowLifetimeOffer = ref.watch(shouldShowLifetimeOfferProvider);
-    final lifetimeOfferPlan = ref.watch(lifetimeOfferPlanProvider);
+    final isMonthly300Offer = ref.watch(isMonthly300OfferProvider);
     // 周期番号が確定するまで（null）はshouldShowLifetimeOfferがfalseのため、仮のキー(cycle: 0)が使われることはない
     final lifetimeOfferCycle = ref.watch(lifetimeOfferCycleProvider);
     final lifetimeOfferAutoModalShown = ref.watch(
@@ -53,7 +53,7 @@ class ShowLifetimeOfferOnAppLaunch extends HookConsumerWidget {
               context,
               source: PaywallSource.lifetimeOfferAppLaunch,
               copyVariant: LifetimeOfferCopyVariant.fromString(ref.read(remoteConfigParameterProvider).lifetimeOfferCopyVariant),
-              offerPlan: lifetimeOfferPlan!,
+              isMonthly300Offer: isMonthly300Offer!,
             );
           }
         });

--- a/lib/features/settings/components/rows/lifetime_offer_paywall_row.dart
+++ b/lib/features/settings/components/rows/lifetime_offer_paywall_row.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/features/lifetime_offer/lifetime_offer_copy_variant.dart';
-import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/features/lifetime_offer/page.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/provider/purchase.dart';
@@ -42,8 +41,8 @@ class LifetimeOfferPaywallRow extends StatelessWidget {
         if (copyVariant == null || !context.mounted) {
           return;
         }
-        final offerPlan = await _selectLifetimeOfferPlan(context);
-        if (offerPlan == null || !context.mounted) {
+        final isMonthly300Offer = await _selectIsMonthly300Offer(context);
+        if (isMonthly300Offer == null || !context.mounted) {
           return;
         }
         Navigator.of(context).push(
@@ -68,7 +67,7 @@ class LifetimeOfferPaywallRow extends StatelessWidget {
               child: LifetimeOfferPage(
                 source: PaywallSource.lifetimeOfferBar,
                 copyVariant: copyVariant,
-                offerPlan: offerPlan,
+                isMonthly300Offer: isMonthly300Offer,
               ),
             ),
           ),
@@ -98,19 +97,19 @@ Future<LifetimeOfferCopyVariant?> _selectLifetimeOfferCopyVariant(BuildContext c
   );
 }
 
-/// 表示するオファープランを選択するダイアログを表示する。キャンセル時はnullを返す。
-Future<LifetimeOfferPlan?> _selectLifetimeOfferPlan(BuildContext context) {
-  return showDialog<LifetimeOfferPlan>(
+/// 月額300円オファーを表示するかを選択するダイアログを表示する。キャンセル時はnullを返す。
+Future<bool?> _selectIsMonthly300Offer(BuildContext context) {
+  return showDialog<bool>(
     context: context,
     builder: (context) => SimpleDialog(
       title: const Text('オファープランを選択'),
       children: [
         SimpleDialogOption(
-          onPressed: () => Navigator.of(context).pop(LifetimeOfferPlan.lifetime),
+          onPressed: () => Navigator.of(context).pop(false),
           child: const Text('買い切りプラン'),
         ),
         SimpleDialogOption(
-          onPressed: () => Navigator.of(context).pop(LifetimeOfferPlan.monthly300),
+          onPressed: () => Navigator.of(context).pop(true),
           child: const Text('月額300円プラン'),
         ),
       ],

--- a/lib/provider/purchase.dart
+++ b/lib/provider/purchase.dart
@@ -324,3 +324,17 @@ final isLifetimePurchasedProvider = FutureProvider.autoDispose<bool>((
     rethrow;
   }
 });
+
+/// RevenueCatに購入済み商品が1件以上あるかを返すProvider。
+///
+/// 失効・解約済みを含む購入履歴で判定する。取得に失敗した場合は未購入扱いにせず、
+/// 参照側でオファーを表示しない安全側へ倒せるようAsyncErrorを維持する。
+final hasPurchasedAnyProductProvider = FutureProvider.autoDispose<bool>((ref) async {
+  try {
+    final customerInfo = await Purchases.getCustomerInfo();
+    return customerInfo.allPurchasedProductIdentifiers.isNotEmpty;
+  } catch (e, stack) {
+    errorLogger.recordError(e, stack);
+    rethrow;
+  }
+});

--- a/test/features/lifetime_offer/page_test.dart
+++ b/test/features/lifetime_offer/page_test.dart
@@ -9,7 +9,6 @@ import 'package:pilll/components/molecules/indicator.dart';
 import 'package:pilll/entity/remote_config_parameter.codegen.dart';
 import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/features/lifetime_offer/lifetime_offer_copy_variant.dart';
-import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/features/lifetime_offer/page.dart';
 import 'package:pilll/features/lifetime_offer/provider.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
@@ -65,7 +64,7 @@ void main() {
       Map<String, Object> initialSharedPreferencesValues = const {},
       LifetimeOfferCopyVariant copyVariant =
           LifetimeOfferCopyVariant.defaultVariant,
-      LifetimeOfferPlan offerPlan = LifetimeOfferPlan.lifetime,
+      bool isMonthly300Offer = false,
     }) async {
       final mockTodayRepository = MockTodayService();
       when(mockTodayRepository.now()).thenReturn(DateTime(2026, 7, 3));
@@ -112,7 +111,7 @@ void main() {
                 user: user,
                 source: PaywallSource.lifetimeOfferAppLaunch,
                 copyVariant: copyVariant,
-                offerPlan: offerPlan,
+                isMonthly300Offer: isMonthly300Offer,
               ),
             ),
           ),
@@ -163,7 +162,7 @@ void main() {
       await pumpLifetimeOfferPageBody(
         tester,
         user: const User(isPremium: false),
-        offerPlan: LifetimeOfferPlan.monthly300,
+        isMonthly300Offer: true,
       );
 
       expect(find.text('長くご愛顧いただいている皆様へ\n月額プランのご案内です'), findsOneWidget);

--- a/test/features/lifetime_offer/provider_test.dart
+++ b/test/features/lifetime_offer/provider_test.dart
@@ -5,7 +5,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mockito/mockito.dart';
 import 'package:pilll/entity/remote_config_parameter.codegen.dart';
 import 'package:pilll/entity/user.codegen.dart';
-import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/features/lifetime_offer/provider.dart';
 import 'package:pilll/provider/auth.dart';
 import 'package:pilll/provider/purchase.dart';
@@ -24,8 +23,8 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
   });
 
-  group('#lifetimeOfferPlanProvider', () {
-    Future<LifetimeOfferPlan> readPlan(
+  group('#isMonthly300OfferProvider', () {
+    Future<bool> readIsMonthly300Offer(
         {required int usageDays,
         required bool isPremium,
         bool hasMonthlyPackage = true,
@@ -37,35 +36,33 @@ void main() {
           lifetimeOfferUsageDaysProvider.overrideWith((ref) => usageDays),
           monthlyDiscountPackageProvider.overrideWith(
               (ref) => hasMonthlyPackage ? FakeRevenueCatPackage() : null),
-          hasPurchasedAnyProductProvider.overrideWith(
-              (ref) => hasPurchasedAnyProduct),
+          hasPurchasedAnyProductProvider
+              .overrideWith((ref) => hasPurchasedAnyProduct),
         ],
       );
       addTearDown(container.dispose);
       await container.read(userProvider.future);
       await container.read(hasPurchasedAnyProductProvider.future);
-      return container.read(lifetimeOfferPlanProvider)!;
+      return container.read(isMonthly300OfferProvider)!;
     }
 
     test('無料ユーザーは利用1095日から月額300円プランを優先する', () async {
-      expect(await readPlan(usageDays: 1094, isPremium: false),
-          LifetimeOfferPlan.lifetime);
-      expect(await readPlan(usageDays: 1095, isPremium: false),
-          LifetimeOfferPlan.monthly300);
+      expect(await readIsMonthly300Offer(usageDays: 1094, isPremium: false),
+          isFalse);
+      expect(await readIsMonthly300Offer(usageDays: 1095, isPremium: false),
+          isTrue);
     });
 
     test('3年以上でもプレミアムユーザーには買い切りプランを提示する', () async {
-      expect(await readPlan(usageDays: 1095, isPremium: true),
-          LifetimeOfferPlan.lifetime);
+      expect(await readIsMonthly300Offer(usageDays: 1095, isPremium: true),
+          isFalse);
     });
 
     test('3年以上でも購入履歴がある無料ユーザーには買い切りプランを提示する', () async {
       expect(
-          await readPlan(
-              usageDays: 1095,
-              isPremium: false,
-              hasPurchasedAnyProduct: true),
-          LifetimeOfferPlan.lifetime);
+          await readIsMonthly300Offer(
+              usageDays: 1095, isPremium: false, hasPurchasedAnyProduct: true),
+          isFalse);
     });
 
     test('購入履歴の取得中はオファープランを確定しない', () async {
@@ -76,21 +73,21 @@ void main() {
           lifetimeOfferUsageDaysProvider.overrideWith((ref) => 1095),
           monthlyDiscountPackageProvider
               .overrideWith((ref) => FakeRevenueCatPackage()),
-          hasPurchasedAnyProductProvider.overrideWith(
-              (ref) => Completer<bool>().future),
+          hasPurchasedAnyProductProvider
+              .overrideWith((ref) => Completer<bool>().future),
         ],
       );
       addTearDown(container.dispose);
       await container.read(userProvider.future);
 
-      expect(container.read(lifetimeOfferPlanProvider), isNull);
+      expect(container.read(isMonthly300OfferProvider), isNull);
     });
 
     test('月額300円Packageを取得できない場合は買い切りプランへフォールバックする', () async {
       expect(
-          await readPlan(
+          await readIsMonthly300Offer(
               usageDays: 1095, isPremium: false, hasMonthlyPackage: false),
-          LifetimeOfferPlan.lifetime);
+          isFalse);
     });
   });
 

--- a/test/features/lifetime_offer/provider_test.dart
+++ b/test/features/lifetime_offer/provider_test.dart
@@ -28,7 +28,8 @@ void main() {
     Future<LifetimeOfferPlan> readPlan(
         {required int usageDays,
         required bool isPremium,
-        bool hasMonthlyPackage = true}) async {
+        bool hasMonthlyPackage = true,
+        FutureOr<bool> hasPurchasedAnyProduct = false}) async {
       final container = ProviderContainer(
         overrides: [
           userProvider
@@ -36,10 +37,13 @@ void main() {
           lifetimeOfferUsageDaysProvider.overrideWith((ref) => usageDays),
           monthlyDiscountPackageProvider.overrideWith(
               (ref) => hasMonthlyPackage ? FakeRevenueCatPackage() : null),
+          hasPurchasedAnyProductProvider.overrideWith(
+              (ref) => hasPurchasedAnyProduct),
         ],
       );
       addTearDown(container.dispose);
       await container.read(userProvider.future);
+      await container.read(hasPurchasedAnyProductProvider.future);
       return container.read(lifetimeOfferPlanProvider)!;
     }
 
@@ -53,6 +57,33 @@ void main() {
     test('3年以上でもプレミアムユーザーには買い切りプランを提示する', () async {
       expect(await readPlan(usageDays: 1095, isPremium: true),
           LifetimeOfferPlan.lifetime);
+    });
+
+    test('3年以上でも購入履歴がある無料ユーザーには買い切りプランを提示する', () async {
+      expect(
+          await readPlan(
+              usageDays: 1095,
+              isPremium: false,
+              hasPurchasedAnyProduct: true),
+          LifetimeOfferPlan.lifetime);
+    });
+
+    test('購入履歴の取得中はオファープランを確定しない', () async {
+      final container = ProviderContainer(
+        overrides: [
+          userProvider.overrideWith(
+              (ref) => Stream.value(const User(isPremium: false))),
+          lifetimeOfferUsageDaysProvider.overrideWith((ref) => 1095),
+          monthlyDiscountPackageProvider
+              .overrideWith((ref) => FakeRevenueCatPackage()),
+          hasPurchasedAnyProductProvider.overrideWith(
+              (ref) => Completer<bool>().future),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(userProvider.future);
+
+      expect(container.read(lifetimeOfferPlanProvider), isNull);
     });
 
     test('月額300円Packageを取得できない場合は買い切りプランへフォールバックする', () async {

--- a/test/features/record/announcement_bar/components/lifetime_offer_test.dart
+++ b/test/features/record/announcement_bar/components/lifetime_offer_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/features/lifetime_offer/lifetime_offer_copy_variant.dart';
-import 'package:pilll/features/lifetime_offer/lifetime_offer_plan.dart';
 import 'package:pilll/features/lifetime_offer/provider.dart';
 import 'package:pilll/features/record/components/announcement_bar/components/lifetime_offer.dart';
 import 'package:pilll/utils/analytics.dart';
@@ -19,7 +18,7 @@ void main() {
     Future<void> pumpBar(
       WidgetTester tester, {
       required LifetimeOfferCopyVariant copyVariant,
-      LifetimeOfferPlan offerPlan = LifetimeOfferPlan.lifetime,
+      bool isMonthly300Offer = false,
     }) async {
       await tester.pumpWidget(
         ProviderScope(
@@ -33,7 +32,8 @@ void main() {
           child: MaterialApp(
             home: Material(
               child: LifetimeOfferAnnouncementBar(
-                  copyVariant: copyVariant, offerPlan: offerPlan),
+                  copyVariant: copyVariant,
+                  isMonthly300Offer: isMonthly300Offer),
             ),
           ),
         ),
@@ -60,7 +60,7 @@ void main() {
       await pumpBar(
         tester,
         copyVariant: LifetimeOfferCopyVariant.defaultVariant,
-        offerPlan: LifetimeOfferPlan.monthly300,
+        isMonthly300Offer: true,
       );
 
       expect(find.textContaining('長くご愛顧いただいている皆様へ！'), findsOneWidget);


### PR DESCRIPTION
## Abstract

3年以上の無料ユーザー向け月額300円オファーを、RevenueCat上で一度も商品を購入していないユーザーだけに限定する。

## Why

従来の条件は現在の`isPremium`だけを見ていたため、過去に課金して解約したユーザーも月額300円オファーの対象になっていた。初回課金を促す施策として対象を正しく絞り込むため、失効・解約済みを含む購入履歴を確認する。

## 主な変更点

- RevenueCatの`CustomerInfo.allPurchasedProductIdentifiers`から購入履歴の有無を返すProviderを追加
- 無料・利用1095日以上・購入履歴なしの場合だけ月額300円プランを優先
- 過去の購入履歴がある無料ユーザーには従来の買い切りプランを提示
- 購入履歴の取得中・失敗時は未購入扱いにせず、オファー判定を確定しない安全側の挙動に変更
- `LifetimeOfferPlan` enumを削除し、月額300円オファーの対象かどうかを`isMonthly300Offer`のboolで判定・受け渡しする構成に整理
- 購入履歴あり／なし／取得中と、月額300円・買い切りそれぞれの表示分岐をテスト

## 影響範囲

- 3年以上利用している無料ユーザー向けオファーの対象判定
- RevenueCatのCustomerInfo取得処理
- オファーページ、起動時モーダル、お知らせバー、開発者オプション間の月額300円オファー判定の受け渡し

PaywallのUIおよび購入処理自体に変更はない。

## 動作確認

- 関連テスト65件成功
- `git diff --check`成功
- 月額300円オファーのPaywall表示は先行PR #1819でiOS Simulator確認済み

<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/bannzai/Pilll/20260712/3121af24-7b5f-433a-af06-0408a47abe5c.png" width="400" />

## Links

- #1819

## Checked
- [x] Analyticsのログを入れたか
- [x] 境界値に対してのUnitTestを書いた
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた

## セッション再開

```sh
cd /Users/bannzai/worktrees/bannzai/Pilll/add-offer-300yen
codex resume 019f516c-2535-7c33-871f-3dcdd9ebf6de
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 購入履歴を 確認 して、特別な 月額300円 オファーの 対象 をより正確に 判定します。
* **改善**
  * 購入履歴により、条件を満たしても 月額300円 が表示されない 場合があります。
  * 購入履歴の 確認中 は、判定が確定するまで表示を 保留します。
* **テスト**
  * 購入履歴の有無・確認中・フォールバック時の挙動を追加検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
