### PR TITLE
fix: 服用お休み期間の変更で終了日が選択できない問題を修正

### DIFF
--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -661,6 +661,19 @@ extension PillSheetGroupRestDurationDomain on PillSheetGroup {
       return lastTakenDate.addDays(1);
     }
   }
+
+  /// 既存の服用お休み期間を変更する際に終了日として選択できる最終日を返す。ChangeManualRestDurationのDateRangePickerのlastDateに利用する
+  /// 休薬中や服用再開直後はlastTakenDateが休薬開始の前日のまま止まるため、availableRestDurationBeginDate（最終服用日の翌日）を
+  /// そのまま上限にすると休薬開始日と一致し、休薬開始日より後の日付=終了日が選択できなくなる
+  /// そのため「変更対象の既存の終了日」と「今日」も常に選択できるように3候補の中で最も遅い日付を返す
+  /// availableRestDurationBeginDateより後かつ今日以前の日付には服用記録が存在しないため、上限を広げてもlastTakenDateが変動することはない
+  DateTime availableRestDurationEndDate({required RestDuration restDuration}) {
+    return [
+      availableRestDurationBeginDate,
+      if (restDuration.endDate != null) restDuration.endDate!,
+      today(),
+    ].reduce((a, b) => a.isAfter(b) ? a : b);
+  }
 }
 
 /// ピルシートグループの表示番号設定を管理するデータクラス

--- a/lib/entity/pill_sheet_group.codegen.dart
+++ b/lib/entity/pill_sheet_group.codegen.dart
@@ -665,13 +665,23 @@ extension PillSheetGroupRestDurationDomain on PillSheetGroup {
   /// 既存の服用お休み期間を変更する際に終了日として選択できる最終日を返す。ChangeManualRestDurationのDateRangePickerのlastDateに利用する
   /// 休薬中や服用再開直後はlastTakenDateが休薬開始の前日のまま止まるため、availableRestDurationBeginDate（最終服用日の翌日）を
   /// そのまま上限にすると休薬開始日と一致し、休薬開始日より後の日付=終了日が選択できなくなる
-  /// そのため「変更対象の既存の終了日」と「今日」も常に選択できるように3候補の中で最も遅い日付を返す
+  /// そのため「今日」も選択できるようにavailableRestDurationBeginDateと今日の遅い方を上限とする
   /// availableRestDurationBeginDateより後かつ今日以前の日付には服用記録が存在しないため、上限を広げてもlastTakenDateが変動することはない
+  /// ただし、変更対象より後に開始する服用お休み期間がある場合はその開始日で上限を打ち切り、後続の休薬期間との重複を防ぐ
+  /// （endDateは服用再開日でお休み期間には含まれないため、後続の開始日と同日までは重複しない）
+  /// また、変更対象の既存の終了日は常に選択できるようにする（DateRangePickerのinitialDateRangeがlastDateを超えると表示できないため）
   DateTime availableRestDurationEndDate({required RestDuration restDuration}) {
-    return [
+    final nextRestDurationBeginDate = restDurations.map((e) => e.beginDate).where((e) => e.isAfter(restDuration.beginDate)).minOrNull;
+    final selectableLastDate = [
       availableRestDurationBeginDate,
-      if (restDuration.endDate != null) restDuration.endDate!,
       today(),
+    ].reduce((a, b) => a.isAfter(b) ? a : b);
+    return [
+      if (nextRestDurationBeginDate != null && nextRestDurationBeginDate.isBefore(selectableLastDate))
+        nextRestDurationBeginDate
+      else
+        selectableLastDate,
+      if (restDuration.endDate != null) restDuration.endDate!,
     ].reduce((a, b) => a.isAfter(b) ? a : b);
   }
 }

--- a/lib/features/record/components/setting/components/rest_duration/change_manual_rest_duration.dart
+++ b/lib/features/record/components/setting/components/rest_duration/change_manual_rest_duration.dart
@@ -112,14 +112,13 @@ class ChangeManualRestDuration extends HookConsumerWidget {
             parameters: {'rest_duration_id': restDuration.id},
           );
 
-          // NOTE: DatePickerの表示制御により、最後に服用記録をつけた日付+1以上の日付は選択できない
-          // よって、lastTakenDateが変動することがない前提になる
+          // NOTE: 選択できる日付の上限の考え方はavailableRestDurationEndDateのドキュメントコメントを参照
           final dateTimeRange = await showDateRangePicker(
             context: context,
             initialEntryMode: DatePickerEntryMode.calendarOnly,
             initialDateRange: restDuration.dateTimeRange,
             firstDate: pillSheetGroup.pillSheets.first.beginDate,
-            lastDate: pillSheetGroup.availableRestDurationBeginDate,
+            lastDate: pillSheetGroup.availableRestDurationEndDate(restDuration: restDuration),
             helpText: L.selectPausePeriod,
             fieldStartHintText: L.pauseStartDate,
             fieldEndLabelText: L.pauseEndDate,

--- a/lib/features/record/components/setting/components/rest_duration/change_manual_rest_duration.dart
+++ b/lib/features/record/components/setting/components/rest_duration/change_manual_rest_duration.dart
@@ -4,6 +4,7 @@ import 'package:pilll/components/theme/date_range_picker.dart';
 import 'package:pilll/entity/firestore_id_generator.dart';
 import 'package:pilll/entity/pill_sheet.codegen.dart';
 import 'package:pilll/entity/pill_sheet_group.codegen.dart';
+import 'package:pilll/features/error/alert_error.dart';
 import 'package:pilll/features/error/error_alert.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/record/components/setting/components/rest_duration/provider.dart';
@@ -128,6 +129,17 @@ class ChangeManualRestDuration extends HookConsumerWidget {
           );
 
           if (dateTimeRange == null) {
+            return;
+          }
+
+          // DateRangePickerでは開始日と終了日で別々の上限を設定できず、終了日のために広げたlastDateが開始日にも適用される
+          // 開始日は従来通り「最終服用日の翌日」までしか選べないように、選択後に検証する
+          if (dateTimeRange.start.isAfter(pillSheetGroup.availableRestDurationBeginDate.date())) {
+            analytics.logEvent(
+              name: 'change_rest_duration_invalid_begin',
+              parameters: {'rest_duration_id': restDuration.id},
+            );
+            onError(AlertError(L.pauseStartDateMustBeOnOrBefore(format(pillSheetGroup.availableRestDurationBeginDate))));
             return;
           }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2824,5 +2824,14 @@
   "midnightTakenWarningDialogNeverShowAgain": "Don't show this again",
   "@midnightTakenWarningDialogNeverShowAgain": {
     "description": ""
+  },
+  "pauseStartDateMustBeOnOrBefore": "Please select a pause start date on or before {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -2724,5 +2724,15 @@
   "midnightTakenWarningDialogNeverShowAgain": "二度と表示しない",
   "@midnightTakenWarningDialogNeverShowAgain": {
     "description": "深夜服用記録の注意ダイアログを今後表示しないようにするボタンの文言です。2回目以降の表示でのみ現れます。"
+  },
+
+  "pauseStartDateMustBeOnOrBefore": "服用お休み開始日は{date}以前の日付を選択してください",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/test/entity/pill_sheet_group_test.dart
+++ b/test/entity/pill_sheet_group_test.dart
@@ -18872,6 +18872,262 @@ void main() {
     });
   });
 
+  group("#availableRestDurationEndDate", () {
+    group("服用お休み期間が終了している場合", () {
+      test("服用再開後にまだ服用記録がない場合はtoday()を返す", () {
+        // 不具合の再現ケース: lastTakenDateが休薬開始の前日のまま止まっていても、終了日は今日まで選択できる
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-20"));
+
+        const sheetType = PillSheetType.pillsheet_28_0;
+        final restDuration = RestDuration(
+          id: "rest_duration_id",
+          beginDate: DateTime.parse("2020-09-15"),
+          createdDate: DateTime.parse("2020-09-15"),
+          endDate: DateTime.parse("2020-09-17"),
+        );
+        final pillSheet = PillSheet.v1(
+          id: firestoreIDGenerator(),
+          groupIndex: 0,
+          beginDate: DateTime.parse("2020-09-01"),
+          lastTakenDate: DateTime.parse("2020-09-14"),
+          createdAt: now(),
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+          restDurations: [restDuration],
+        );
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: now(),
+          pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+        );
+
+        expect(
+          pillSheetGroup.availableRestDurationEndDate(
+              restDuration: restDuration),
+          DateTime.parse("2020-09-20"),
+        );
+      });
+
+      test("既存の終了日が今日より後の場合は既存の終了日を返す", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-20"));
+
+        const sheetType = PillSheetType.pillsheet_28_0;
+        final restDuration = RestDuration(
+          id: "rest_duration_id",
+          beginDate: DateTime.parse("2020-09-15"),
+          createdDate: DateTime.parse("2020-09-15"),
+          endDate: DateTime.parse("2020-09-25"),
+        );
+        final pillSheet = PillSheet.v1(
+          id: firestoreIDGenerator(),
+          groupIndex: 0,
+          beginDate: DateTime.parse("2020-09-01"),
+          lastTakenDate: DateTime.parse("2020-09-14"),
+          createdAt: now(),
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+          restDurations: [restDuration],
+        );
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: now(),
+          pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+        );
+
+        expect(
+          pillSheetGroup.availableRestDurationEndDate(
+              restDuration: restDuration),
+          DateTime.parse("2020-09-25"),
+        );
+      });
+
+      test("服用再開後に服用記録がある場合はlastTakenDateの翌日を返す", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-20"));
+
+        const sheetType = PillSheetType.pillsheet_28_0;
+        final restDuration = RestDuration(
+          id: "rest_duration_id",
+          beginDate: DateTime.parse("2020-09-15"),
+          createdDate: DateTime.parse("2020-09-15"),
+          endDate: DateTime.parse("2020-09-17"),
+        );
+        final lastTakenDate = DateTime.parse("2020-09-20");
+        final pillSheet = PillSheet.v1(
+          id: firestoreIDGenerator(),
+          groupIndex: 0,
+          beginDate: DateTime.parse("2020-09-01"),
+          lastTakenDate: lastTakenDate,
+          createdAt: now(),
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+          restDurations: [restDuration],
+        );
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: now(),
+          pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+        );
+
+        expect(
+          pillSheetGroup.availableRestDurationEndDate(
+              restDuration: restDuration),
+          lastTakenDate.addDays(1),
+        );
+      });
+
+      test("年をまたぐ服用お休み期間の場合も既存の終了日を返す", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2021-01-01"));
+
+        const sheetType = PillSheetType.pillsheet_28_0;
+        final restDuration = RestDuration(
+          id: "rest_duration_id",
+          beginDate: DateTime.parse("2020-12-28"),
+          createdDate: DateTime.parse("2020-12-28"),
+          endDate: DateTime.parse("2021-01-02"),
+        );
+        final pillSheet = PillSheet.v1(
+          id: firestoreIDGenerator(),
+          groupIndex: 0,
+          beginDate: DateTime.parse("2020-12-10"),
+          lastTakenDate: DateTime.parse("2020-12-27"),
+          createdAt: now(),
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+          restDurations: [restDuration],
+        );
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: now(),
+          pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+        );
+
+        expect(
+          pillSheetGroup.availableRestDurationEndDate(
+              restDuration: restDuration),
+          DateTime.parse("2021-01-02"),
+        );
+      });
+    });
+
+    group("服用お休み期間中（endDateがnull）の場合", () {
+      test("today()を返す", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-20"));
+
+        const sheetType = PillSheetType.pillsheet_28_0;
+        final restDuration = RestDuration(
+          id: "rest_duration_id",
+          beginDate: DateTime.parse("2020-09-15"),
+          createdDate: DateTime.parse("2020-09-15"),
+          endDate: null,
+        );
+        final pillSheet = PillSheet.v1(
+          id: firestoreIDGenerator(),
+          groupIndex: 0,
+          beginDate: DateTime.parse("2020-09-01"),
+          lastTakenDate: DateTime.parse("2020-09-14"),
+          createdAt: now(),
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+          restDurations: [restDuration],
+        );
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: now(),
+          pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+        );
+
+        expect(
+          pillSheetGroup.availableRestDurationEndDate(
+              restDuration: restDuration),
+          DateTime.parse("2020-09-20"),
+        );
+      });
+    });
+
+    group("境界値テスト", () {
+      test("休薬開始可能日・既存の終了日・今日がすべて同じ日の場合はその日を返す", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-15"));
+
+        const sheetType = PillSheetType.pillsheet_28_0;
+        final restDuration = RestDuration(
+          id: "rest_duration_id",
+          beginDate: DateTime.parse("2020-09-15"),
+          createdDate: DateTime.parse("2020-09-15"),
+          endDate: DateTime.parse("2020-09-15"),
+        );
+        final pillSheet = PillSheet.v1(
+          id: firestoreIDGenerator(),
+          groupIndex: 0,
+          beginDate: DateTime.parse("2020-09-01"),
+          lastTakenDate: DateTime.parse("2020-09-14"),
+          createdAt: now(),
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+          restDurations: [restDuration],
+        );
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: now(),
+          pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+        );
+
+        expect(
+          pillSheetGroup.availableRestDurationEndDate(
+              restDuration: restDuration),
+          DateTime.parse("2020-09-15"),
+        );
+      });
+    });
+  });
+
   group("#pillMarkFor", () {
     group("PillSheetTypeによる偽薬・休薬期間の判定", () {
       test("pillsheet_21の場合、dosingPeriod超過でPillMarkType.restを返す", () {

--- a/test/entity/pill_sheet_group_test.dart
+++ b/test/entity/pill_sheet_group_test.dart
@@ -19041,6 +19041,108 @@ void main() {
       });
     });
 
+    group("変更対象より後に開始する服用お休み期間がある場合", () {
+      test("後続の休薬期間と重複しないよう、後続の開始日を返す", () {
+        // 過去の休薬期間(9/5-9/7)を編集する時、休薬中(9/15開始)の後続期間があると
+        // today()まで上限を広げると後続期間と重複するため、後続の開始日で打ち切る
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-20"));
+
+        const sheetType = PillSheetType.pillsheet_28_0;
+        final restDuration = RestDuration(
+          id: "rest_duration_id_1",
+          beginDate: DateTime.parse("2020-09-05"),
+          createdDate: DateTime.parse("2020-09-05"),
+          endDate: DateTime.parse("2020-09-07"),
+        );
+        final pillSheet = PillSheet.v1(
+          id: firestoreIDGenerator(),
+          groupIndex: 0,
+          beginDate: DateTime.parse("2020-09-01"),
+          lastTakenDate: DateTime.parse("2020-09-14"),
+          createdAt: now(),
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+          restDurations: [
+            restDuration,
+            RestDuration(
+              id: "rest_duration_id_2",
+              beginDate: DateTime.parse("2020-09-15"),
+              createdDate: DateTime.parse("2020-09-15"),
+              endDate: null,
+            ),
+          ],
+        );
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: now(),
+          pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+        );
+
+        expect(
+          pillSheetGroup.availableRestDurationEndDate(
+              restDuration: restDuration),
+          DateTime.parse("2020-09-15"),
+        );
+      });
+
+      test("後続の開始日がtoday()より後の場合は打ち切られずtoday()を返す", () {
+        final mockTodayRepository = MockTodayService();
+        todayRepository = mockTodayRepository;
+        when(mockTodayRepository.now())
+            .thenReturn(DateTime.parse("2020-09-20"));
+
+        const sheetType = PillSheetType.pillsheet_28_0;
+        final restDuration = RestDuration(
+          id: "rest_duration_id_1",
+          beginDate: DateTime.parse("2020-09-05"),
+          createdDate: DateTime.parse("2020-09-05"),
+          endDate: DateTime.parse("2020-09-07"),
+        );
+        final pillSheet = PillSheet.v1(
+          id: firestoreIDGenerator(),
+          groupIndex: 0,
+          beginDate: DateTime.parse("2020-09-01"),
+          lastTakenDate: DateTime.parse("2020-09-14"),
+          createdAt: now(),
+          typeInfo: PillSheetTypeInfo(
+            dosingPeriod: sheetType.dosingPeriod,
+            name: sheetType.fullName,
+            totalCount: sheetType.totalCount,
+            pillSheetTypeReferencePath: sheetType.rawPath,
+          ),
+          restDurations: [
+            restDuration,
+            RestDuration(
+              id: "rest_duration_id_2",
+              beginDate: DateTime.parse("2020-09-25"),
+              createdDate: DateTime.parse("2020-09-25"),
+              endDate: null,
+            ),
+          ],
+        );
+        final pillSheetGroup = PillSheetGroup(
+          pillSheetIDs: ["sheet_id"],
+          pillSheets: [pillSheet],
+          createdAt: now(),
+          pillSheetAppearanceMode: PillSheetAppearanceMode.number,
+        );
+
+        expect(
+          pillSheetGroup.availableRestDurationEndDate(
+              restDuration: restDuration),
+          DateTime.parse("2020-09-20"),
+        );
+      });
+    });
+
     group("服用お休み期間中（endDateがnull）の場合", () {
       test("today()を返す", () {
         final mockTodayRepository = MockTodayService();


### PR DESCRIPTION
## Abstract

服用お休み期間の「変更」で、休薬開始日より後の日付が選択できず終了日を変更できない問題を修正する。

- `PillSheetGroupRestDurationDomain` に `availableRestDurationEndDate({required RestDuration restDuration})` を追加。「休薬開始可能日（最終服用日の翌日）」「変更対象の既存の終了日」「今日」の3候補のうち最も遅い日付を返す
- `ChangeManualRestDuration` の期間変更ピッカー（`showDateRangePicker`）の `lastDate` を `availableRestDurationBeginDate` から上記の新 getter に差し替え
- 開始日のみを編集するピッカー（休薬中・endDate なし）は「開始日は最終服用日の翌日まで」という制約自体が妥当なため変更なし

## Why

ユーザーから「服用お休み期間の変更が出来ない。休薬期間を設けた日以降が選択できず、終了日が選択できない」という問い合わせがあった。

原因は、期間変更ピッカーの選択上限 `lastDate` に `availableRestDurationBeginDate`（= 最終服用日の翌日）を使っていたこと。休薬中は服用記録が付かないため `lastTakenDate` が休薬開始の前日で止まり、選択上限がちょうど休薬開始日になる。その結果、休薬開始日より後の日付がすべて選択不可となり終了日が選べない。

- 発生条件: 服用再開後にまだ服用記録がないユーザー（休薬中も同様）。再開後に服用記録を付けると `lastTakenDate` が進むため発生しない
- この状態では既存期間の `initialDateRange.end` が `lastDate` を超えるため、Flutter SDK の `showDateRangePicker` のアサーション「initialDateRange's end date must be on or before lastDate」にも違反していた（release ビルドでは日付が選択不可のまま表示、debug ビルドではクラッシュ）
- 混入時期: 2024-05-07 の be0c211086「Fix date picker range」で `lastDate` が `today()` から `availableRestDurationBeginDate` に変更されて以降
- 上限を広げても、`availableRestDurationBeginDate` より後かつ今日以前の日付には服用記録が存在しないため、`lastTakenDate` が変動しない前提は維持される

## Links

なし

## 動作確認

シミュレータ（dev ビルド）で不具合の再現状態を作成して確認した。

再現手順: 最終服用 7/12 → 休薬を 7/13 から開始 → 服用再開（休薬期間 7/13〜7/15、再開後の服用記録なし）→「服用お休み期間変更」を開く

| 修正後: ピッカーが正常に開き 7/14・7/15 が選択可能 | 終了日を 7/14 に変更 | 保存後、期間表示が 7/13(月) - 7/14(火) に更新 |
| --- | --- | --- |
| <img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/bannzai/Pilll/20260715/8ed74eba-74a2-470d-b823-06a2cd4ed2a3.png" width="300" /> | <img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/bannzai/Pilll/20260715/4d5bf189-94e6-4c38-96cc-438e7376031b.png" width="300" /> | <img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/bannzai/Pilll/20260715/0abb74b2-2776-4776-b717-57f0c4d60a55.png" width="300" /> |

保存後は今日のピル番号も 3番 → 4番 に正しく更新されることを確認した（修正前のコードではこの状態でピッカーの上限が休薬開始日 7/13 になり、終了日が選択不能だった）。

- `flutter analyze`: エラー・警告 0（info のみで、いずれも既存指摘）
- `flutter test`: 全1526件パス

## Checked
- [x] Analyticsのログを入れたか（既存の `change_manual_rest_duration_range` イベントのまま。新規インタラクションの追加なし）
- [x] 境界値に対してのUnitTestを書いた（`#availableRestDurationEndDate` に6ケース: 不具合再現・終了日が未来・再開後に服用記録あり・年またぎ・休薬中・全候補同日）
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた（Widget の分岐自体は変更なし。ピッカーの選択上限ロジックは entity 側の Unit Test で担保）

## セッション再開

```sh
cd /Users/bannzai/worktrees/bannzai/Pilll/fix-manual-rest-duration
claude --resume 4d07b625-bca1-4ba2-8cac-8faf471271aa
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 休薬期間を手動で変更する際、「休薬終了日」の選択範囲を状況に応じて上限付きで制御するようになりました。
  - 日付範囲の入力ルールを見直し、選択された開始日が条件外の場合は処理を中断しエラー表示します。
- **品質向上**
  - 休薬終了日の算出について、終了日の有無や再開後の服用状況、年をまたぐケース、重複防止の境界条件を網羅して検証しました。
- **ドキュメント/ローカライズ**
  - 休薬開始日の入力エラー文言（英語・日本語）を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->