### PR TITLE
CLAUDE.md / AGENTS.md に issue の読み書き先 (bannzai/PilllBackend) を明記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,12 @@
 ## Development Guidelines
 - Think in English, but generate responses in Japanese (思考は英語、回答の生成は日本語で行うように)
 
+## issue の読み書き先
+このリポジトリ (bannzai/Pilll) は public で issue 機能が無効。issue は private の bannzai/PilllBackend で管理している。
+
+- 指示・skill に登場する issue のやりとり（作成・閲覧・コメント・ラベル操作など）は、すべて bannzai/PilllBackend の issue を読み書きする
+- `gh issue` 系コマンドは必ず `--repo bannzai/PilllBackend` を指定する
+
 <!-- ai-review-config begin -->
 <!--
 このブロックは自動生成です。直接編集せず、テンプレートを更新してから再生成してください。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,12 @@ iOS・Androidアプリ両方を提供しております。Flutter製のアプリ
 1. Firebaseの設定ファイルは環境ごとに分かれている（main.dev.dart/main.prod.dart）
 2. RemoteConfigでフィーチャーフラグを管理
 
+## issue の読み書き先
+このリポジトリ (bannzai/Pilll) は public で issue 機能が無効。issue は private の bannzai/PilllBackend で管理している。
+
+- 指示・skill に登場する issue のやりとり（作成・閲覧・コメント・ラベル操作など）は、すべて bannzai/PilllBackend の issue を読み書きする
+- `gh issue` 系コマンドは必ず `--repo bannzai/PilllBackend` を指定する
+
 ------------------------------------
 
 # プログラムテストについて


### PR DESCRIPTION
## Abstract

CLAUDE.md と AGENTS.md に「issue の読み書き先は bannzai/PilllBackend」という指示を追記しました。

- 対象: AI エージェント向け指示ファイル 2 つ（CLAUDE.md / AGENTS.md）
- 追記内容:
  - このリポジトリ (bannzai/Pilll) は public で issue 機能が無効 (has_issues: false)。issue は private の bannzai/PilllBackend で管理している
  - 指示・skill に登場する issue のやりとり（作成・閲覧・コメント・ラベル操作など）は、すべて bannzai/PilllBackend の issue を読み書きする
  - `gh issue` 系コマンドは必ず `--repo bannzai/PilllBackend` を指定する

コミット構成:
1. CLAUDE.md への追記
2. AGENTS.md への追記（Codex 等 AGENTS.md を読むエージェント向けに同内容）

## Why

- bannzai/Pilll は public リポジトリのため issue 機能を無効にしており、issue は private の bannzai/PilllBackend 側で管理している
- 作成先の明記がないと、AI エージェントが `gh issue create` を `--repo` なしで実行して origin (bannzai/Pilll) に作成しようとして失敗する・誤った先に作ろうとするため、指示ファイルに作成先を明記した
- 当初 CLAUDE.local.md（非コミットのローカル指示）として作成したが、リポジトリの正式な運用ルールとしてコミット対象の CLAUDE.md / AGENTS.md に記載する方針に変更した（CLAUDE.local.md は削除済み）

## Links


## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた

※ ドキュメント（エージェント指示ファイル）のみの変更のため、上記チェック項目および動作確認スクリーンショットは対象外です。

## セッション再開

```sh
cd /Users/bannzai/ghq/github.com/bannzai/pilll
claude --resume 3e04dad5-2603-4296-8770-6f881e85a41d
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * Issue の作成・閲覧・コメント・ラベル操作などの手順を整理しました。
  * Issue 機能を利用する際の対象リポジトリと、CLI コマンドで必要な指定を明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->