### PR TITLE
l10n: pauseStartDateMustBeOnOrBeforeを欠落していた77言語のarbに追加

### DIFF
--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -2818,5 +2818,14 @@
   "midnightTakenWarningDialogBody": "Jou pille is aangeteken as geneem tot en met {takenDate}. Vandag se ({takenDate}) kennisgewing om {reminderTimes} sal nie afgelewer word nie.\nAs dit 'n fout was, keer asseblief die innameaantekening terug.",
   "midnightTakenWarningDialogNeverShowAgain": "Moenie dit weer wys nie",
   "midnightTakenWarningDialogSeeHowToRevert": "Sien hoe om 'n innameaantekening terug te keer",
-  "midnightTakenWarningDialogTitle": "Let asseblief op"
+  "midnightTakenWarningDialogTitle": "Let asseblief op",
+  "pauseStartDateMustBeOnOrBefore": "Kies asseblief 'n datum op of voor {date} as die begindatum van die pilpouse.",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_am.arb
+++ b/lib/l10n/app_am.arb
@@ -2818,5 +2818,14 @@
   "midnightTakenWarningDialogTitle": "እባክዎ ልብ ይበሉ",
   "midnightTakenWarningDialogBody": "እስከ {takenDate} ድረስ የመድሃኒት አወሳሰድ ተመዝግቧል። ዛሬ ({takenDate}) በ{reminderTimes} ሰዓት የሚደርስዎት ማሳወቂያ አይደርስዎትም።\nበስህተት ከሆነ፣ እባክዎ የመውሰድ መዝገቡን ይሰርዙ።",
   "midnightTakenWarningDialogNeverShowAgain": "እንደገና አያሳዩ",
-  "midnightTakenWarningDialogSeeHowToRevert": "የመውሰድ መዝገብን እንዴት እንደሚሰርዙ ይመልከቱ"
+  "midnightTakenWarningDialogSeeHowToRevert": "የመውሰድ መዝገብን እንዴት እንደሚሰርዙ ይመልከቱ",
+  "pauseStartDateMustBeOnOrBefore": "前の返答に文字化けがありました。訂正します。\n\n**Amharic訳:**\n\nየመድኃኒት እረፍት መጀመሪያ ቀን ከ{date} በፊት የሆነ ቀን ይምረጡ",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -2818,5 +2818,14 @@
   "midnightTakenWarningDialogTitle": "يرجى الانتباه",
   "midnightTakenWarningDialogBody": "تم تسجيل تناول الحبوب حتى تاريخ {takenDate}. لن يصلك إشعار التذكير اليوم ({takenDate}) في {reminderTimes}.\nإذا كان هذا خطأً، يرجى إلغاء تسجيل التناول",
   "midnightTakenWarningDialogNeverShowAgain": "عدم العرض مرة أخرى",
-  "midnightTakenWarningDialogSeeHowToRevert": "عرض كيفية إلغاء تسجيل التناول"
+  "midnightTakenWarningDialogSeeHowToRevert": "عرض كيفية إلغاء تسجيل التناول",
+  "pauseStartDateMustBeOnOrBefore": "يُرجى اختيار تاريخ بدء استراحة تناول الدواء يسبق {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_as.arb
+++ b/lib/l10n/app_as.arb
@@ -2818,5 +2818,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} লৈকে সেৱন ৰেকৰ্ড কৰা হৈছে। {takenDate} অৰ্থাৎ আজিৰ {reminderTimes} ৰ জাননী আপোনাৰ ওচৰলৈ নাযাব।\nভুলক্ৰমে হ'লে, অনুগ্ৰহ কৰি সেৱনৰ ৰেকৰ্ড বাতিল কৰক",
   "midnightTakenWarningDialogNeverShowAgain": "পুনৰ নেদেখুৱাব",
   "midnightTakenWarningDialogSeeHowToRevert": "সেৱন বাতিলকৰণৰ পদ্ধতি চাওক",
-  "midnightTakenWarningDialogTitle": "সাৱধান হওক"
+  "midnightTakenWarningDialogTitle": "সাৱধান হওক",
+  "pauseStartDateMustBeOnOrBefore": "服用お休み開始日は{date}以前の日付を選択してください",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_az.arb
+++ b/lib/l10n/app_az.arb
@@ -2818,5 +2818,14 @@
   "midnightTakenWarningDialogTitle": "Diqqət edin",
   "midnightTakenWarningDialogNeverShowAgain": "Bir daha göstərmə",
   "midnightTakenWarningDialogSeeHowToRevert": "Qəbul qeydinin necə ləğv ediləcəyini görün",
-  "midnightTakenWarningDialogBody": "Həb qəbulunuz {takenDate} tarixinədək qeydə alınıb. Bu günə ({takenDate}) aid saat {reminderTimes}-dəki bildiriş sizə çatmayacaq.\nSəhvən olubsa, zəhmət olmasa qəbul qeydini ləğv edin."
+  "midnightTakenWarningDialogBody": "Həb qəbulunuz {takenDate} tarixinədək qeydə alınıb. Bu günə ({takenDate}) aid saat {reminderTimes}-dəki bildiriş sizə çatmayacaq.\nSəhvən olubsa, zəhmət olmasa qəbul qeydini ləğv edin.",
+  "pauseStartDateMustBeOnOrBefore": "Xidarlıq başlama tarixi olaraq {date} tarixindən əvvəlki bir tarix seçin",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_be.arb
+++ b/lib/l10n/app_be.arb
@@ -2818,5 +2818,14 @@
   "midnightTakenWarningDialogTitle": "Звярніце ўвагу",
   "midnightTakenWarningDialogBody": "Прыём таблетак быў запісаны ўключна да {takenDate}. Сённяшняе паведамленне ({takenDate}) у {reminderTimes} не прыйдзе.\nКалі гэта памылка, скасуйце прыём.",
   "midnightTakenWarningDialogNeverShowAgain": "Больш не паказваць",
-  "midnightTakenWarningDialogSeeHowToRevert": "Паглядзець, як скасаваць прыём"
+  "midnightTakenWarningDialogSeeHowToRevert": "Паглядзець, як скасаваць прыём",
+  "pauseStartDateMustBeOnOrBefore": "Калі ласка, абярыце дату пачатку перапынку ў прыёме не пазней за {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -2818,5 +2818,14 @@
   "midnightTakenWarningDialogBody": "Записан е прием на хапчета до {takenDate}. Днешното ({takenDate}) напомняне в {reminderTimes} няма да бъде изпратено.\nАко това е грешка, моля отменете записа за приема.",
   "midnightTakenWarningDialogNeverShowAgain": "Не показвай отново",
   "midnightTakenWarningDialogSeeHowToRevert": "Вижте как да отмените записа за приема",
-  "midnightTakenWarningDialogTitle": "Внимание"
+  "midnightTakenWarningDialogTitle": "Внимание",
+  "pauseStartDateMustBeOnOrBefore": "Служебният ви прием на хапчета трябва да е преди {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -2818,5 +2818,14 @@
   "midnightTakenWarningDialogTitle": "অনুগ্রহ করে লক্ষ্য করুন",
   "midnightTakenWarningDialogBody": "{takenDate} পর্যন্ত সেবনের রেকর্ড করা হয়ে গেছে। আজ, {takenDate}-এর {reminderTimes} সময়ের বিজ্ঞপ্তি আপনার কাছে পৌঁছাবে না।\nভুল হয়ে থাকলে সেবন বাতিল করুন",
   "midnightTakenWarningDialogNeverShowAgain": "আর দেখাবেন না",
-  "midnightTakenWarningDialogSeeHowToRevert": "সেবন বাতিলের পদ্ধতি দেখুন"
+  "midnightTakenWarningDialogSeeHowToRevert": "সেবন বাতিলের পদ্ধতি দেখুন",
+  "pauseStartDateMustBeOnOrBefore": "服用お休み開始日は{date}以前の日付を選択してください\n\nবিরতি শুরুর তারিখ হিসেবে {date} বা তার আগের একটি তারিখ নির্বাচন করুন",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_bs.arb
+++ b/lib/l10n/app_bs.arb
@@ -2818,5 +2818,14 @@
   "midnightTakenWarningDialogBody": "Zapisi o uzimanju su izvršeni zaključno sa {takenDate}. Današnje ({takenDate}) obavještenje u {reminderTimes} neće biti dostavljeno.\nAko je ovo greška, molimo poništite zapis o uzimanju.",
   "midnightTakenWarningDialogNeverShowAgain": "Ne prikazuj ponovo",
   "midnightTakenWarningDialogSeeHowToRevert": "Pogledajte kako poništiti zapis o uzimanju",
-  "midnightTakenWarningDialogTitle": "Napomena"
+  "midnightTakenWarningDialogTitle": "Napomena",
+  "pauseStartDateMustBeOnOrBefore": "Služba se izostavlja u periodu prije {date}, molimo odaberite taj datum",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -2818,5 +2818,14 @@
   "midnightTakenWarningDialogTitle": "Tingueu-ho en compte",
   "midnightTakenWarningDialogBody": "S'ha registrat la presa de la píndola fins al {takenDate}. La notificació d'avui ({takenDate}) de les {reminderTimes} no arribarà.\nSi ha estat un error, cancel·leu el registre de presa.",
   "midnightTakenWarningDialogNeverShowAgain": "No tornis a mostrar-ho",
-  "midnightTakenWarningDialogSeeHowToRevert": "Veure com cancel·lar un registre de presa"
+  "midnightTakenWarningDialogSeeHowToRevert": "Veure com cancel·lar un registre de presa",
+  "pauseStartDateMustBeOnOrBefore": "Si la data límit per començar el període de descans és el {date}, seleccioneu una data anterior a aquesta",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "Upozornění",
   "midnightTakenWarningDialogBody": "Užití pilulek je zaznamenáno až do data {takenDate}. Dnešní ({takenDate}) upozornění na užití v {reminderTimes} vám proto nepřijde.\nPokud šlo o omyl, zrušte prosím záznam o užití.",
   "midnightTakenWarningDialogNeverShowAgain": "Příště nezobrazovat",
-  "midnightTakenWarningDialogSeeHowToRevert": "Zobrazit návod, jak zrušit záznam o užití"
+  "midnightTakenWarningDialogSeeHowToRevert": "Zobrazit návod, jak zrušit záznam o užití",
+  "pauseStartDateMustBeOnOrBefore": "Podejte prosím před {date}.",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_cy.arb
+++ b/lib/l10n/app_cy.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "Sylwch, os gwelwch yn dda",
   "midnightTakenWarningDialogBody": "Mae cofnod cymryd y bilsen wedi'i wneud hyd at {takenDate}. Ni fyddwch yn derbyn hysbysiad atgoffa heddiw ({takenDate}) am {reminderTimes}.\nOs camgymeriad oedd hyn, canslwch y cofnod cymryd os gwelwch yn dda.",
   "midnightTakenWarningDialogNeverShowAgain": "Peidiwch â dangos hwn eto",
-  "midnightTakenWarningDialogSeeHowToRevert": "Gweld sut i ganslo cofnod cymryd"
+  "midnightTakenWarningDialogSeeHowToRevert": "Gweld sut i ganslo cofnod cymryd",
+  "pauseStartDateMustBeOnOrBefore": "Gwestai i'r dyddiad {date} neu cyn hynny fel dyddiad dechrau'r saib cymryd",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Dine piller er blevet registreret som taget frem til {takenDate}. Dagens ({takenDate}) påmindelse kl. {reminderTimes} bliver ikke sendt.\nHvis dette var en fejl, skal du annullere indtagelsesregistreringen.",
   "midnightTakenWarningDialogNeverShowAgain": "Vis ikke dette igen",
   "midnightTakenWarningDialogSeeHowToRevert": "Se hvordan du annullerer en indtagelsesregistrering",
-  "midnightTakenWarningDialogTitle": "Bemærk venligst"
+  "midnightTakenWarningDialogTitle": "Bemærk venligst",
+  "pauseStartDateMustBeOnOrBefore": "Servicedagen for pillepause skal starte senest {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Die Einnahme wurde bis einschließlich {takenDate} aufgezeichnet. Die heutige ({takenDate}) Benachrichtigung um {reminderTimes} wird nicht zugestellt.\nFalls dies ein Versehen war, stornieren Sie bitte die Einnahme.",
   "midnightTakenWarningDialogNeverShowAgain": "Nicht mehr anzeigen",
   "midnightTakenWarningDialogSeeHowToRevert": "Anleitung zum Stornieren der Einnahme ansehen",
-  "midnightTakenWarningDialogTitle": "Bitte beachten"
+  "midnightTakenWarningDialogTitle": "Bitte beachten",
+  "pauseStartDateMustBeOnOrBefore": "服用お休み開始日は{date}以前の日付を選択してください",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "Παρακαλώ προσέξτε",
   "midnightTakenWarningDialogBody": "Η λήψη έχει καταγραφεί έως {takenDate}. Η σημερινή ({takenDate}) ειδοποίηση υπενθύμισης στις {reminderTimes} δεν θα σας αποσταλεί.\nΕάν έγινε κατά λάθος, παρακαλώ ακυρώστε την καταγραφή λήψης.",
   "midnightTakenWarningDialogNeverShowAgain": "Να μην εμφανιστεί ξανά",
-  "midnightTakenWarningDialogSeeHowToRevert": "Δείτε τον τρόπο ακύρωσης της καταγραφής λήψης"
+  "midnightTakenWarningDialogSeeHowToRevert": "Δείτε τον τρόπο ακύρωσης της καταγραφής λήψης",
+  "pauseStartDateMustBeOnOrBefore": "Greek翻訳を出力します。\n\nΠαρακαλούμε επιλέξτε ημερομηνία πριν ή στις {date} για την ημερομηνία έναρξης της παύσης λήψης",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Se ha registrado la toma hasta el {takenDate}. La notificación de hoy ({takenDate}) programada para las {reminderTimes} no se recibirá.\nSi esto fue un error, cancele el registro de toma.",
   "midnightTakenWarningDialogNeverShowAgain": "No volver a mostrar esto",
   "midnightTakenWarningDialogSeeHowToRevert": "Ver cómo cancelar el registro de toma",
-  "midnightTakenWarningDialogTitle": "Atención"
+  "midnightTakenWarningDialogTitle": "Atención",
+  "pauseStartDateMustBeOnOrBefore": "Selecciona una fecha igual o anterior a {date} como fecha de inicio de la pausa de la toma",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Teie tabletid on märgitud võetuks kuni {takenDate}. Tänase ({takenDate}) päeva teavitus kell {reminderTimes} jääb saatmata.\nKui see oli eksitus, palun tühistage võtmiskirje.",
   "midnightTakenWarningDialogNeverShowAgain": "Ära näita seda enam",
   "midnightTakenWarningDialogSeeHowToRevert": "Vaata, kuidas võtmiskirjet tühistada",
-  "midnightTakenWarningDialogTitle": "Pange tähele"
+  "midnightTakenWarningDialogTitle": "Pange tähele",
+  "pauseStartDateMustBeOnOrBefore": "Valige pausi alguskuupäevaks kuupäev, mis on {date} või varasem",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_eu.arb
+++ b/lib/l10n/app_eu.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Zure pilulak hartu bezala erregistratu dira {takenDate} arte. Gaurko ({takenDate}) {reminderTimes}etako jakinarazpena ez zaizu bidaliko.\nOkerra bada, mesedez, ezeztatu hartzea.",
   "midnightTakenWarningDialogNeverShowAgain": "Ez erakutsi berriro",
   "midnightTakenWarningDialogSeeHowToRevert": "Hartzea ezeztatzeko modua ikusi",
-  "midnightTakenWarningDialogTitle": "Kontuan izan"
+  "midnightTakenWarningDialogTitle": "Kontuan izan",
+  "pauseStartDateMustBeOnOrBefore": "Zure eguna hasi baino lehen jarraibide bat aukeratu behar da: {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "لطفاً توجه کنید",
   "midnightTakenWarningDialogBody": "مصرف قرص تا تاریخ {takenDate} ثبت شده است. اعلان یادآوری امروز ({takenDate}) در ساعت {reminderTimes} برای شما ارسال نخواهد شد.\nدر صورت اشتباه بودن، لطفاً مصرف را لغو کنید.",
   "midnightTakenWarningDialogNeverShowAgain": "دیگر نمایش داده نشود",
-  "midnightTakenWarningDialogSeeHowToRevert": "مشاهده روش لغو ثبت مصرف"
+  "midnightTakenWarningDialogSeeHowToRevert": "مشاهده روش لغو ثبت مصرف",
+  "pauseStartDateMustBeOnOrBefore": "既存の用語（\"وقفه مصرف\" = 服用お休み）と表現スタイルを確認しました。\n\nلطفاً تاریخی قبل از {date} را برای تاریخ شروع وقفه مصرف انتخاب کنید",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Pillerit on kirjattu otetuiksi {takenDate} asti. Tämän päivän ({takenDate}) klo {reminderTimes} ilmoitus ei saavu sinulle.\nJos tämä on virhe, peruuta merkintä.",
   "midnightTakenWarningDialogNeverShowAgain": "Älä näytä tätä uudelleen",
   "midnightTakenWarningDialogSeeHowToRevert": "Katso, miten peruutat merkinnän",
-  "midnightTakenWarningDialogTitle": "Huomioithan"
+  "midnightTakenWarningDialogTitle": "Huomioithan",
+  "pauseStartDateMustBeOnOrBefore": "Ottelupäivä on valittava ennen päivämäärää {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_fil.arb
+++ b/lib/l10n/app_fil.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Naitala na ang inyong pag-inom ng pills hanggang sa {takenDate}. Hindi na maipapadala ang paalala ngayong araw ({takenDate}) sa {reminderTimes}.\nKung nagkamali, mangyaring i-cancel ang record ng pag-inom.",
   "midnightTakenWarningDialogNeverShowAgain": "Huwag nang ipakita muli",
   "midnightTakenWarningDialogSeeHowToRevert": "Tingnan ang paraan ng pag-cancel ng record ng pag-inom",
-  "midnightTakenWarningDialogTitle": "Paalala"
+  "midnightTakenWarningDialogTitle": "Paalala",
+  "pauseStartDateMustBeOnOrBefore": "Ipili petsa bago o katumbas ng {date} para sa petsa ng simula ng pahinga sa pag-inom",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -499,6 +499,15 @@
   "@pauseEndDate": {
     "description": "ピルの休薬期間（服用を一時的に停止する期間）の終了日を指定する際に表示されるラベルです。生理周期に合わせた服用スケジュール管理で使用されます。"
   },
+  "pauseStartDateMustBeOnOrBefore": "Veuillez sélectionner une date de début de pause au plus tard le {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "endPillSheet": "Pack de pilules terminé",
   "@endPillSheet": {
     "description": "ピル（経口避妊薬）の一包装（通常シート状で28日分程度）がすべて服用完了した際に表示されるメッセージです。次のピルシートへの切り替えやタイミングを知らせる重要な通知として使用されます。"

--- a/lib/l10n/app_gl.arb
+++ b/lib/l10n/app_gl.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Rexistrouse a toma de píldoras ata o {takenDate}. A notificación de hoxe ({takenDate}) ás {reminderTimes} non chegará.\nSe foi un erro, cancela o rexistro de toma.",
   "midnightTakenWarningDialogNeverShowAgain": "Non mostrar isto de novo",
   "midnightTakenWarningDialogSeeHowToRevert": "Ver como cancelar o rexistro de toma",
-  "midnightTakenWarningDialogTitle": "Aviso"
+  "midnightTakenWarningDialogTitle": "Aviso",
+  "pauseStartDateMustBeOnOrBefore": "Vólvese antes de que remate para escoller a data de inicio da pausa de dose que remate {date} ou antes",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_gsw.arb
+++ b/lib/l10n/app_gsw.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "Bitte beachten",
   "midnightTakenWarningDialogBody": "D'Iinahm isch bis und mit {takenDate} als gnaa erfasst worde. D'Benachrichtigung vo hüt, am {takenDate}, um {reminderTimes} wird Ihne dromit nöd zuegstellt.\nFalls das aus Versehe passiert isch, mached Sie bitte d'Iinahm rückgängig.",
   "midnightTakenWarningDialogSeeHowToRevert": "Aaleitig zum Rückgängigmache vo de Iinahm aaluege",
-  "midnightTakenWarningDialogNeverShowAgain": "Nie me aazeige"
+  "midnightTakenWarningDialogNeverShowAgain": "Nie me aazeige",
+  "pauseStartDateMustBeOnOrBefore": "Bitte wähl für dr Start vo dr Iinahmepause es Datum vor oder am {date} us.",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} સુધીની ગોળીઓ સેવન તરીકે નોંધાઈ ગઈ છે. આજે એટલે કે {takenDate} ના રોજ {reminderTimes} ની સૂચના તમને નહીં મળે.\nજો આ ભૂલથી થયું હોય, તો કૃપા કરીને સેવન રેકોર્ડ રદ કરો",
   "midnightTakenWarningDialogNeverShowAgain": "ફરીથી બતાવશો નહીં",
   "midnightTakenWarningDialogSeeHowToRevert": "સેવન રદ કરવાની રીત જુઓ",
-  "midnightTakenWarningDialogTitle": "કૃપા કરીને નોંધ લો"
+  "midnightTakenWarningDialogTitle": "કૃપા કરીને નોંધ લો",
+  "pauseStartDateMustBeOnOrBefore": "ગોળી બંધ રાખવાની શરૂઆતની તારીખ તરીકે {date} અથવા તે પહેલાંની તારીખ પસંદ કરો",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "שים לב",
   "midnightTakenWarningDialogBody": "נרשמה נטילת הגלולות עד {takenDate}. הודעת התזכורת של היום ({takenDate}) בשעה {reminderTimes} לא תישלח אליך.\nאם מדובר בטעות, אנא בטל את רישום הנטילה",
   "midnightTakenWarningDialogNeverShowAgain": "אל תציג הודעה זו שוב",
-  "midnightTakenWarningDialogSeeHowToRevert": "לראות איך לבטל רישום נטילה"
+  "midnightTakenWarningDialogSeeHowToRevert": "לראות איך לבטל רישום נטילה",
+  "pauseStartDateMustBeOnOrBefore": "יש לבחור תאריך התחלה להפסקת הנטילה שחל בתאריך {date} או לפניו",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} तक की गोलियां सेवन के रूप में दर्ज हो चुकी हैं। आज ({takenDate}) के {reminderTimes} बजे की सूचना आपको नहीं मिलेगी।\nअगर यह गलती से हुआ है, तो कृपया सेवन रद्द करें।",
   "midnightTakenWarningDialogNeverShowAgain": "दोबारा न दिखाएं",
   "midnightTakenWarningDialogSeeHowToRevert": "सेवन रद्द करने का तरीका देखें",
-  "midnightTakenWarningDialogTitle": "कृपया ध्यान दें"
+  "midnightTakenWarningDialogTitle": "कृपया ध्यान दें",
+  "pauseStartDateMustBeOnOrBefore": "服用お休み開始日は{date}以前के दिनांक का चयन करें",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Zapisano je uzimanje pilula zaključno s {takenDate}. Obavijest za danas, {takenDate}, u {reminderTimes} neće stići.\nAko je ovo pogreška, poništite zapis o uzimanju.",
   "midnightTakenWarningDialogNeverShowAgain": "Ne prikazuj ponovno",
   "midnightTakenWarningDialogSeeHowToRevert": "Pogledaj kako poništiti zapis o uzimanju",
-  "midnightTakenWarningDialogTitle": "Napomena"
+  "midnightTakenWarningDialogTitle": "Napomena",
+  "pauseStartDateMustBeOnOrBefore": "Napomena o razdoblju bez uzimanja tablete molimo odaberite datum prije {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "A bevétel rögzítve lett {takenDate}-ig bezárólag. A mai napi ({takenDate}) {reminderTimes} órakor esedékes értesítés emiatt nem fog megérkezni.\nHa ez tévedésből történt, kérjük, vonja vissza a bevétel rögzítését.",
   "midnightTakenWarningDialogNeverShowAgain": "Ne jelenjen meg többé",
   "midnightTakenWarningDialogSeeHowToRevert": "A bevétel visszavonásának módja",
-  "midnightTakenWarningDialogTitle": "Figyelem"
+  "midnightTakenWarningDialogTitle": "Figyelem",
+  "pauseStartDateMustBeOnOrBefore": "Hazai bevétele előtti szüneteltetés kezdő napjaként válasszon {date} előtti dátumot",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_hy.arb
+++ b/lib/l10n/app_hy.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Ընդունման գրառումն արվել է մինչև {takenDate}-ը ներառյալ։ Այսօրվա՝ {takenDate}-ի, ժամը {reminderTimes}-ի ծանուցումն այլևս ձեզ չի հասնի։\nԵթե դա սխալմամբ է եղել, խնդրում ենք չեղարկել ընդունման գրառումը",
   "midnightTakenWarningDialogNeverShowAgain": "Այլևս երբեք չցուցադրել",
   "midnightTakenWarningDialogSeeHowToRevert": "Տեսնել՝ ինչպես չեղարկել ընդունման գրառումը",
-  "midnightTakenWarningDialogTitle": "Ուշադրություն դարձրեք"
+  "midnightTakenWarningDialogTitle": "Ուշադրություն դարձրեք",
+  "pauseStartDateMustBeOnOrBefore": "Ծովն ընդմիշտ սկսելու օրը պետք է լինի {date} ամսաթվից առաջ",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Catatan konsumsi pil hingga {takenDate} telah dibuat. Notifikasi pengingat pukul {reminderTimes} untuk hari ini ({takenDate}) tidak akan dikirim.\nJika ini adalah kesalahan, silakan batalkan catatan konsumsi tersebut",
   "midnightTakenWarningDialogNeverShowAgain": "Jangan tampilkan lagi",
   "midnightTakenWarningDialogSeeHowToRevert": "Lihat cara membatalkan catatan konsumsi",
-  "midnightTakenWarningDialogTitle": "Perhatian"
+  "midnightTakenWarningDialogTitle": "Perhatian",
+  "pauseStartDateMustBeOnOrBefore": "服用お休み期間の開始日変更エラーで、開始日として選択できる最終日を{date}に示すメッセージをインドネシア語に翻訳します。\n\nSilakan pilih tanggal sebelum {date} sebagai tanggal mulai jeda minum obat",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_is.arb
+++ b/lib/l10n/app_is.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Þú hefur skráð pillutöku til og með {takenDate}. Tilkynningin fyrir daginn í dag ({takenDate}) klukkan {reminderTimes} berst þér ekki.\nEf þetta voru mistök skaltu afturkalla tökuskráninguna.",
   "midnightTakenWarningDialogNeverShowAgain": "Ekki sýna þetta aftur",
   "midnightTakenWarningDialogSeeHowToRevert": "Skoða leiðbeiningar um að afturkalla tökuskráningu",
-  "midnightTakenWarningDialogTitle": "Athugið"
+  "midnightTakenWarningDialogTitle": "Athugið",
+  "pauseStartDateMustBeOnOrBefore": "Vinsamlegast veldu dagsetningu fyrir eða á {date} sem upphafsdag pilluhlés",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Le pillole risultano registrate come assunte fino al {takenDate}. La notifica di oggi ({takenDate}) delle {reminderTimes} non ti verrà consegnata.\nSe si tratta di un errore, annulla l'assunzione registrata.",
   "midnightTakenWarningDialogNeverShowAgain": "Non mostrare più questo messaggio",
   "midnightTakenWarningDialogSeeHowToRevert": "Vedi come annullare l'assunzione registrata",
-  "midnightTakenWarningDialogTitle": "Attenzione"
+  "midnightTakenWarningDialogTitle": "Attenzione",
+  "pauseStartDateMustBeOnOrBefore": "Il servizio di sospensione dell'assunzione deve iniziare entro il {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "აბების მიღება ჩაწერილია {takenDate}-ის ჩათვლით. დღევანდელი ({takenDate}) შეხსენება {reminderTimes} საათზე არ მოგივათ.\nშეცდომის შემთხვევაში, გთხოვთ გააუქმოთ მიღების ჩანაწერი",
   "midnightTakenWarningDialogNeverShowAgain": "აღარ მაჩვენო ეს",
   "midnightTakenWarningDialogSeeHowToRevert": "მიღების გაუქმების მეთოდი იხილეთ",
-  "midnightTakenWarningDialogTitle": "გთხოვთ გაითვალისწინოთ"
+  "midnightTakenWarningDialogTitle": "გთხოვთ გაითვალისწინოთ",
+  "pauseStartDateMustBeOnOrBefore": "მიღების შესვენების დაწყების თარიღად აირჩიეთ {date} ან მასზე ადრეული თარიღი",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_kk.arb
+++ b/lib/l10n/app_kk.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} дейінгі қабылдау жазбалары тіркелді. Бүгінгі ({takenDate}) {reminderTimes} хабарландыруы жеткізілмейді.\nҚате болса, қабылдауды болдырмаңыз",
   "midnightTakenWarningDialogNeverShowAgain": "Қайта көрсетпеу",
   "midnightTakenWarningDialogSeeHowToRevert": "Қабылдауды болдырмау тәсілін көру",
-  "midnightTakenWarningDialogTitle": "Назар аударыңыз"
+  "midnightTakenWarningDialogTitle": "Назар аударыңыз",
+  "pauseStartDateMustBeOnOrBefore": "Дәрі қабылдамау үзілісінің басталу күні ретінде {date} немесе одан бұрынғы күнді таңдаңыз.",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_km.arb
+++ b/lib/l10n/app_km.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "កំណត់ត្រាការទទួលថ្នាំត្រូវបានធ្វើរហូតដល់ថ្ងៃ {takenDate}។ ដោយសារថ្ងៃនេះគឺ {takenDate} ការជូនដំណឹងម៉ោង {reminderTimes} នឹងមិនមកដល់ទេ។\nប្រសិនបើជាកំហុស សូមលុបចោលកំណត់ត្រាការទទួលថ្នាំ",
   "midnightTakenWarningDialogNeverShowAgain": "កុំបង្ហាញម្តងទៀត",
   "midnightTakenWarningDialogSeeHowToRevert": "មើលរបៀបលុបចោលកំណត់ត្រាការទទួលថ្នាំ",
-  "midnightTakenWarningDialogTitle": "សូមចំណាំ"
+  "midnightTakenWarningDialogTitle": "សូមចំណាំ",
+  "pauseStartDateMustBeOnOrBefore": "សូមជ្រើសរើសកាលបរិច្ឆេទដែលមុន {date} ជាថ្ងៃចាប់ផ្តើមឈប់ញ៉ាំថ្នាំ",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_kn.arb
+++ b/lib/l10n/app_kn.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} ವರೆಗಿನ ಪಿಲ್ ಸೇವನೆ ದಾಖಲಾಗಿದೆ. ಇಂದು ({takenDate}) {reminderTimes} ಸಮಯದ ಸೂಚನೆ ನಿಮಗೆ ತಲುಪುವುದಿಲ್ಲ.\nಇದು ತಪ್ಪಾಗಿದ್ದರೆ, ದಯವಿಟ್ಟು ಸೇವನೆಯನ್ನು ರದ್ದುಗೊಳಿಸಿ",
   "midnightTakenWarningDialogNeverShowAgain": "ಇನ್ನು ಮುಂದೆ ತೋರಿಸಬೇಡಿ",
   "midnightTakenWarningDialogSeeHowToRevert": "ಸೇವನೆ ರದ್ದುಗೊಳಿಸುವ ವಿಧಾನವನ್ನು ನೋಡಿ",
-  "midnightTakenWarningDialogTitle": "ದಯವಿಟ್ಟು ಗಮನಿಸಿ"
+  "midnightTakenWarningDialogTitle": "ದಯವಿಟ್ಟು ಗಮನಿಸಿ",
+  "pauseStartDateMustBeOnOrBefore": "ಔಷಧಿ ವಿರಾಮದ ಪ್ರಾರಂಭ ದಿನಾಂಕವನ್ನು {date} ಅಥವಾ ಅದಕ್ಕಿಂತ ಮೊದಲಿನ ದಿನಾಂಕವಾಗಿ ಆಯ್ಕೆಮಾಡಿ",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate}분까지 복용 기록이 완료되었습니다. {takenDate}인 오늘의 {reminderTimes} 알림은 전송되지 않습니다.\n실수하신 경우에는 복용 기록을 취소해 주세요",
   "midnightTakenWarningDialogNeverShowAgain": "다시 표시하지 않기",
   "midnightTakenWarningDialogSeeHowToRevert": "복용 취소 방법 보기",
-  "midnightTakenWarningDialogTitle": "확인해 주세요"
+  "midnightTakenWarningDialogTitle": "확인해 주세요",
+  "pauseStartDateMustBeOnOrBefore": "服용お休み시작일은 {date} 이전 날짜를 선택해 주세요",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ky.arb
+++ b/lib/l10n/app_ky.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate}күнгө чейинки дары ичүү катталды. Бүгүн ({takenDate}) {reminderTimes} убагындагы эскертүү сизге келбейт.\nЭгер ката менен болсо, дары ичкенди жокко чыгарыңыз",
   "midnightTakenWarningDialogNeverShowAgain": "Экинчи көрсөтпөө",
   "midnightTakenWarningDialogSeeHowToRevert": "Дары ичкенди жокко чыгаруу жолун көрүү",
-  "midnightTakenWarningDialogTitle": "Көңүл буруңуз"
+  "midnightTakenWarningDialogTitle": "Көңүл буруңуз",
+  "pauseStartDateMustBeOnOrBefore": "服用お休み開始日は{date}以前の日付を選択してください\n\nКыргызча которгондо, \"{date}\" сакталууда жарамдуу форматты сактоо менен:\n\nДем алуу мезгилин баштаган күн {date} чейинки күндөн тандалышы керек",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_lo.arb
+++ b/lib/l10n/app_lo.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "ໄດ້ບັນທຶກການກິນຢາໃຫ້ຮອດວັນທີ {takenDate} ແລ້ວ. ການແຈ້ງເຕືອນເວລາ {reminderTimes} ຂອງມື້ນີ້ ({takenDate}) ຈະບໍ່ຖືກສົ່ງໄປຫາທ່ານ.\nຖ້າແມ່ນຄວາມຜິດພາດ, ກະລຸນາຍົກເລີກການບັນທຶກການກິນຢາ",
   "midnightTakenWarningDialogNeverShowAgain": "ບໍ່ຕ້ອງສະແດງອີກ",
   "midnightTakenWarningDialogSeeHowToRevert": "ເບິ່ງວິທີຍົກເລີກການບັນທຶກການກິນຢາ",
-  "midnightTakenWarningDialogTitle": "ກະລຸນາຮັບຊາບ"
+  "midnightTakenWarningDialogTitle": "ກະລຸນາຮັບຊາບ",
+  "pauseStartDateMustBeOnOrBefore": "ຄວນເລືອກວັນທີກ່ອນວັນທີ {date} ເປັນວັນເລີ່ມຕົ້ນຢຸດການກິນຢາ",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Vartojimas užregistruotas iki {takenDate}. Šiandienos ({takenDate}) priminimas {reminderTimes} nebus pristatytas.\nJei tai klaida, atšaukite vartojimo įrašą.",
   "midnightTakenWarningDialogNeverShowAgain": "Daugiau nerodyti",
   "midnightTakenWarningDialogSeeHowToRevert": "Peržiūrėti, kaip atšaukti vartojimo įrašą",
-  "midnightTakenWarningDialogTitle": "Atkreipkite dėmesį"
+  "midnightTakenWarningDialogTitle": "Atkreipkite dėmesį",
+  "pauseStartDateMustBeOnOrBefore": "Servų vartojimo pertraukos pradžios data turi būti ankstesnė nei {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Tabletes ir atzīmētas kā lietotas līdz {takenDate}. Šodienas ({takenDate}) atgādinājuma paziņojums plkst. {reminderTimes} netiks nosūtīts.\nJa tā notika kļūdas dēļ, lūdzu, atceliet lietošanas atzīmi.",
   "midnightTakenWarningDialogNeverShowAgain": "Vairs nerādīt",
   "midnightTakenWarningDialogSeeHowToRevert": "Skatīt, kā atcelt lietošanas atzīmi",
-  "midnightTakenWarningDialogTitle": "Lūdzu, ņemiet vērā"
+  "midnightTakenWarningDialogTitle": "Lūdzu, ņemiet vērā",
+  "pauseStartDateMustBeOnOrBefore": "Lūdzu, izvēlieties lietošanas pārtraukuma sākuma datumu, kas nav vēlāks par {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_mk.arb
+++ b/lib/l10n/app_mk.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "Внимание",
   "midnightTakenWarningDialogBody": "Земањето на пилулите е запишано до {takenDate}. Денешното известување ({takenDate}) закажано за {reminderTimes} нема да биде испратено.\nАко ова е грешка, Ве молиме откажете го записот за земање.",
   "midnightTakenWarningDialogNeverShowAgain": "Не прикажувај повторно",
-  "midnightTakenWarningDialogSeeHowToRevert": "Видете како да го откажете записот за земање"
+  "midnightTakenWarningDialogSeeHowToRevert": "Видете како да го откажете записот за земање",
+  "pauseStartDateMustBeOnOrBefore": "Изберете датум пред или еднаков на {date} за почетниот датум на паузата во земањето на пилулите",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ml.arb
+++ b/lib/l10n/app_ml.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "ദയവായി ശ്രദ്ധിക്കുക",
   "midnightTakenWarningDialogBody": "{takenDate} വരെയുള്ള ഗുളിക സേവന രേഖ ചെയ്യപ്പെട്ടിരിക്കുന്നു. ഇന്ന് ({takenDate}) {reminderTimes}-ന് ലഭിക്കേണ്ട അറിയിപ്പ് നിങ്ങൾക്ക് ലഭിക്കില്ല.\nഇത് തെറ്റാണെങ്കിൽ, ദയവായി സേവന രേഖ റദ്ദാക്കുക",
   "midnightTakenWarningDialogSeeHowToRevert": "സേവനം റദ്ദാക്കുന്ന വിധം കാണുക",
-  "midnightTakenWarningDialogNeverShowAgain": "ഇനി ഇത് കാണിക്കരുത്"
+  "midnightTakenWarningDialogNeverShowAgain": "ഇനി ഇത് കാണിക്കരുത്",
+  "pauseStartDateMustBeOnOrBefore": "既存の ml.arb では「服用お休み」を「മരുന്ന് ഇടവേള」「സേവന വിശ്രമ」と訳しています。この用語と一貫性を保ちつつ翻訳します。\n\nദയവായി ഗുളിക ഇടവേള ആരംഭ തീയതിയായി {date}-നോ അതിനു മുമ്പോ ഉള്ള തീയതി തിരഞ്ഞെടുക്കുക",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_mn.arb
+++ b/lib/l10n/app_mn.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate}-ы хүртэлх уусан бүртгэл хийгдсэн байна. Өнөөдөр буюу {takenDate}-ны {reminderTimes} цагийн мэдэгдэл тань ирэхгүй.\nХэрэв алдаатай бол уусан бүртгэлээ цуцлана уу",
   "midnightTakenWarningDialogNeverShowAgain": "Дахин бүү харуул",
   "midnightTakenWarningDialogSeeHowToRevert": "Уусан бүртгэлийг цуцлах аргыг үзэх",
-  "midnightTakenWarningDialogTitle": "Анхаарна уу"
+  "midnightTakenWarningDialogTitle": "Анхаарна уу",
+  "pauseStartDateMustBeOnOrBefore": "Эм уухыг завсарлах эхлэх өдрийг {date}-ээс өмнөх огноогоор сонгоно уу",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "कृपया लक्ष द्या",
   "midnightTakenWarningDialogBody": "{takenDate} पर्यंतच्या सेवनाची नोंद झाली आहे. आज ({takenDate}) {reminderTimes} वाजताची सूचना तुम्हाला मिळणार नाही.\nचुकून नोंद झाली असल्यास, कृपया सेवन रद्द करा",
   "midnightTakenWarningDialogNeverShowAgain": "पुन्हा दाखवू नका",
-  "midnightTakenWarningDialogSeeHowToRevert": "सेवन रद्द करण्याची पद्धत पहा"
+  "midnightTakenWarningDialogSeeHowToRevert": "सेवन रद्द करण्याची पद्धत पहा",
+  "pauseStartDateMustBeOnOrBefore": "कृपया औषध घेण्याच्या सुट्टीची सुरुवात तारीख {date} रोजी किंवा त्यापूर्वी निवडा",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ms.arb
+++ b/lib/l10n/app_ms.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "Sila ambil perhatian",
   "midnightTakenWarningDialogBody": "Rekod pengambilan pil anda telah disimpan sehingga {takenDate}. Pemberitahuan peringatan pada {reminderTimes} untuk hari ini ({takenDate}) tidak akan dihantar.\nJika ini adalah kesilapan, sila batalkan rekod pengambilan tersebut.",
   "midnightTakenWarningDialogNeverShowAgain": "Jangan tunjukkan lagi",
-  "midnightTakenWarningDialogSeeHowToRevert": "Lihat cara membatalkan rekod pengambilan"
+  "midnightTakenWarningDialogSeeHowToRevert": "Lihat cara membatalkan rekod pengambilan",
+  "pauseStartDateMustBeOnOrBefore": "Sila pilih tarikh sebelum {date} sebagai tarikh mula rehat pengambilan pil",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_my.arb
+++ b/lib/l10n/app_my.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "သတိပြုပါ",
   "midnightTakenWarningDialogBody": "{takenDate} အထိ ဆေးသောက်မှတ်တမ်း ထည့်ပြီးဖြစ်ပါသည်။ ယနေ့ {takenDate} ၏ {reminderTimes} အချိန် သတိပေးချက်ကို လက်ခံရရှိမည်မဟုတ်ပါ။\nအမှားဖြစ်ပါက ဆေးသောက်မှတ်တမ်းကို ပယ်ဖျက်ပေးပါ",
   "midnightTakenWarningDialogSeeHowToRevert": "ဆေးသောက်မှတ်တမ်း ပယ်ဖျက်နည်းကို ကြည့်ရှုရန်",
-  "midnightTakenWarningDialogNeverShowAgain": "နောက်တစ်ဖန် မပြပါနှင့်"
+  "midnightTakenWarningDialogNeverShowAgain": "နောက်တစ်ဖန် မပြပါနှင့်",
+  "pauseStartDateMustBeOnOrBefore": "ရက်စွဲ {date} ​ မတိုင်မီ ဆေးမသောက်ဘဲ နားရက် စတင်ရက်ကို ရွေးချယ်ပါ",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Pillene dine er registrert som tatt til og med {takenDate}. Dagens ({takenDate}) varsel kl. {reminderTimes} vil ikke bli sendt.\nHvis dette var en feil, kan du angre inntaksregistreringen.",
   "midnightTakenWarningDialogNeverShowAgain": "Ikke vis dette igjen",
   "midnightTakenWarningDialogSeeHowToRevert": "Se hvordan du angrer en inntaksregistrering",
-  "midnightTakenWarningDialogTitle": "Vær oppmerksom"
+  "midnightTakenWarningDialogTitle": "Vær oppmerksom",
+  "pauseStartDateMustBeOnOrBefore": "Vennligst velg en startdato for pillepausen som er {date} eller tidligere",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ne.arb
+++ b/lib/l10n/app_ne.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "कृपया ध्यान दिनुहोस्",
   "midnightTakenWarningDialogBody": "{takenDate} सम्मको सेवन रेकर्ड गरिसकिएको छ। आजको ({takenDate}) {reminderTimes} को सूचना तपाईंलाई प्राप्त हुनेछैन।\nयदि यो गल्तीले भएको हो भने, सेवन रद्द गर्नुहोस्",
   "midnightTakenWarningDialogSeeHowToRevert": "सेवन रद्द गर्ने तरिका हेर्नुहोस्",
-  "midnightTakenWarningDialogNeverShowAgain": "फेरि नदेखाउनुहोस्"
+  "midnightTakenWarningDialogNeverShowAgain": "फेरि नदेखाउनुहोस्",
+  "pauseStartDateMustBeOnOrBefore": "服用お休み開始日は{date}以前の日付を選択してください",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Uw pillen zijn geregistreerd als ingenomen tot en met {takenDate}. De melding van vandaag ({takenDate}) om {reminderTimes} wordt niet verzonden.\nAls dit een vergissing was, maak dan de inname-registratie ongedaan.",
   "midnightTakenWarningDialogNeverShowAgain": "Niet meer tonen",
   "midnightTakenWarningDialogSeeHowToRevert": "Bekijk hoe u een inname-registratie ongedaan kunt maken",
-  "midnightTakenWarningDialogTitle": "Let op"
+  "midnightTakenWarningDialogTitle": "Let op",
+  "pauseStartDateMustBeOnOrBefore": "Stop de innamedatum voor de pilpauze moet vóór {date} liggen",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_no.arb
+++ b/lib/l10n/app_no.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "Vær oppmerksom",
   "midnightTakenWarningDialogBody": "Pillene dine er registrert som tatt til og med {takenDate}. Dagens ({takenDate}) varsel klokken {reminderTimes} vil ikke bli sendt.\nHvis dette var en feil, kan du avbryte inntaksregistreringen.",
   "midnightTakenWarningDialogSeeHowToRevert": "Se hvordan du avbryter en inntaksregistrering",
-  "midnightTakenWarningDialogNeverShowAgain": "Ikke vis dette igjen"
+  "midnightTakenWarningDialogNeverShowAgain": "Ikke vis dette igjen",
+  "pauseStartDateMustBeOnOrBefore": "Startdatoen for pilletablett-pause bør velges før {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_or.arb
+++ b/lib/l10n/app_or.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} ପର୍ଯ୍ୟନ୍ତ ପିଲ୍ ସେବନ ରେକର୍ଡ ହୋଇସାରିଛି। ଆଜି ({takenDate}) ର {reminderTimes} ବିଜ୍ଞପ୍ତି ଆପଣଙ୍କ ପାଖରେ ପହଞ୍ଚିବ ନାହିଁ।\nଯଦି ଏହା ଭୁଲ ହୋଇଥାଏ, ଦୟାକରି ସେବନ ରେକର୍ଡ ବାତିଲ କରନ୍ତୁ।",
   "midnightTakenWarningDialogNeverShowAgain": "ଏହା ଆଉ ଦେଖାନ୍ତୁ ନାହିଁ",
   "midnightTakenWarningDialogSeeHowToRevert": "ସେବନ ବାତିଲ କରିବାର ବିଧି ଦେଖନ୍ତୁ",
-  "midnightTakenWarningDialogTitle": "ଦୟାକରି ଧ୍ୟାନ ଦିଅନ୍ତୁ"
+  "midnightTakenWarningDialogTitle": "ଦୟାକରି ଧ୍ୟାନ ଦିଅନ୍ତୁ",
+  "pauseStartDateMustBeOnOrBefore": "服用お休み期間開始日は{date}以前の日付を選択してください",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} ਤੱਕ ਦੀ ਗੋਲੀ ਲੈਣ ਦਾ ਰਿਕਾਰਡ ਹੋ ਚੁੱਕਾ ਹੈ। ਅੱਜ ({takenDate}) {reminderTimes} ਦੀ ਸੂਚਨਾ ਤੁਹਾਨੂੰ ਨਹੀਂ ਮਿਲੇਗੀ।\nਜੇ ਇਹ ਗਲਤੀ ਨਾਲ ਹੋਇਆ ਹੈ ਤਾਂ ਕਿਰਪਾ ਕਰਕੇ ਸੇਵਨ ਰਿਕਾਰਡ ਨੂੰ ਰੱਦ ਕਰੋ",
   "midnightTakenWarningDialogNeverShowAgain": "ਦੁਬਾਰਾ ਨਾ ਦਿਖਾਓ",
   "midnightTakenWarningDialogSeeHowToRevert": "ਸੇਵਨ ਰਿਕਾਰਡ ਰੱਦ ਕਰਨ ਦਾ ਤਰੀਕਾ ਦੇਖੋ",
-  "midnightTakenWarningDialogTitle": "ਕਿਰਪਾ ਕਰਕੇ ਧਿਆਨ ਦਿਓ"
+  "midnightTakenWarningDialogTitle": "ਕਿਰਪਾ ਕਰਕੇ ਧਿਆਨ ਦਿਓ",
+  "pauseStartDateMustBeOnOrBefore": "ਸੇਵਨ ਦੀ ਛੁੱਟੀ ਸ਼ੁਰੂ ਹੋਣ ਦੀ ਮਿਤੀ {date} ਜਾਂ ਇਸ ਤੋਂ ਪਹਿਲਾਂ ਦੀ ਚੁਣੋ",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "Zwróć uwagę",
   "midnightTakenWarningDialogBody": "Zarejestrowano przyjęcie pigułek do dnia {takenDate}. Dzisiejsze ({takenDate}) powiadomienie o godzinie {reminderTimes} nie zostanie dostarczone.\nJeśli to pomyłka, cofnij przyjęcie.",
   "midnightTakenWarningDialogNeverShowAgain": "Nie pokazuj ponownie",
-  "midnightTakenWarningDialogSeeHowToRevert": "Zobacz, jak cofnąć przyjęcie"
+  "midnightTakenWarningDialogSeeHowToRevert": "Zobacz, jak cofnąć przyjęcie",
+  "pauseStartDateMustBeOnOrBefore": "Termin ostatniego dnia przyjmowania przerwy musi przypadać przed {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ps.arb
+++ b/lib/l10n/app_ps.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "ستاسو د ګولۍ اخیستل تر {takenDate} پورې ثبت شوي دي. نن ({takenDate}) د {reminderTimes} خبرتیا به تاسو ته ونه رسیږي.\nکه دا یوه تېروتنه وه، مهرباني وکړئ د اخیستلو ثبت لغوه کړئ",
   "midnightTakenWarningDialogNeverShowAgain": "دا نور مه ښکاره کوئ",
   "midnightTakenWarningDialogSeeHowToRevert": "د اخیستلو ثبت د لغوه کولو طریقه وګورئ",
-  "midnightTakenWarningDialogTitle": "پام وکړئ"
+  "midnightTakenWarningDialogTitle": "پام وکړئ",
+  "pauseStartDateMustBeOnOrBefore": "مهرباني وکړئ د ګولۍ تعطیل د پیل نیټه د {date} څخه مخکې وټاکئ",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "O registro de tomada foi feito até {takenDate}. O lembrete de hoje ({takenDate}) às {reminderTimes} não será enviado.\nSe isso foi um engano, desfaça o registro de tomada.",
   "midnightTakenWarningDialogNeverShowAgain": "Não mostrar novamente",
   "midnightTakenWarningDialogSeeHowToRevert": "Ver como desfazer o registro de tomada",
-  "midnightTakenWarningDialogTitle": "Atenção"
+  "midnightTakenWarningDialogTitle": "Atenção",
+  "pauseStartDateMustBeOnOrBefore": "Serviço de saúde deve ser interrompido antes de {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogTitle": "Vă rugăm să rețineți",
   "midnightTakenWarningDialogBody": "Administrarea pilulei a fost înregistrată ca fiind luată până în data de {takenDate}. Notificarea de reamintire de astăzi ({takenDate}), programată pentru ora {reminderTimes}, nu va fi trimisă.\nDacă aceasta este o greșeală, vă rugăm să anulați administrarea.",
   "midnightTakenWarningDialogNeverShowAgain": "Nu mai afișa din nou",
-  "midnightTakenWarningDialogSeeHowToRevert": "Vezi cum să anulezi administrarea"
+  "midnightTakenWarningDialogSeeHowToRevert": "Vezi cum să anulezi administrarea",
+  "pauseStartDateMustBeOnOrBefore": "Vă rugăm să selectați o dată anterioară datei de {date} pentru începerea pauzei de administrare a pilulei",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Приём таблеток отмечен как выполненный по {takenDate} включительно. Сегодняшнее ({takenDate}) уведомление-напоминание в {reminderTimes} не будет отправлено.\nЕсли это ошибка, отмените запись о приёме.",
   "midnightTakenWarningDialogNeverShowAgain": "Больше не показывать",
   "midnightTakenWarningDialogSeeHowToRevert": "Посмотреть, как отменить запись о приёме",
-  "midnightTakenWarningDialogTitle": "Обратите внимание"
+  "midnightTakenWarningDialogTitle": "Обратите внимание",
+  "pauseStartDateMustBeOnOrBefore": "Извините, дату для начала перерыва в приёме нужно выбрать не позднее {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_si.arb
+++ b/lib/l10n/app_si.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} දක්වා පිල් ගැනීම් සටහන් වී ඇත. අද දිනය {takenDate} බැවින්, අද {reminderTimes} හි දැනුම්දීම ඔබට නොලැබෙනු ඇත.\nවැරදීමකින් නම්, කරුණාකර ගැනීම අවලංගු කරන්න",
   "midnightTakenWarningDialogNeverShowAgain": "නැවත මෙය නොපෙන්වන්න",
   "midnightTakenWarningDialogSeeHowToRevert": "ගැනීම අවලංගු කරන ආකාරය බලන්න",
-  "midnightTakenWarningDialogTitle": "කරුණාකර සැලකිල්ලට ගන්න"
+  "midnightTakenWarningDialogTitle": "කරුණාකර සැලකිල්ලට ගන්න",
+  "pauseStartDateMustBeOnOrBefore": "කරුණාකර ඖෂධ සේවන විරාමයේ ආරම්භක දිනය ලෙස {date} හෝ ඊට පෙර දිනයක් තෝරන්න",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Záznam o užití bol vykonaný až do dňa {takenDate}. Dnešné upozornenie ({takenDate}) o {reminderTimes} preto nebude doručené.\nAk ide o omyl, zrušte prosím záznam o užití.",
   "midnightTakenWarningDialogNeverShowAgain": "Túto správu už nezobrazovať",
   "midnightTakenWarningDialogSeeHowToRevert": "Pozrieť návod na zrušenie záznamu o užití",
-  "midnightTakenWarningDialogTitle": "Upozornenie"
+  "midnightTakenWarningDialogTitle": "Upozornenie",
+  "pauseStartDateMustBeOnOrBefore": "Prišla ste na výberu dátumu skoršieho ako {date} pre začiatok prestávky v užívaní.",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Jemanje je zabeleženo do {takenDate}. Današnje ({takenDate}) obvestilo ob {reminderTimes} zato ne bo prejeto.\nČe je prišlo do napake, prosimo, razveljavite zapis o jemanju.",
   "midnightTakenWarningDialogNeverShowAgain": "Ne prikaži več",
   "midnightTakenWarningDialogSeeHowToRevert": "Poglejte, kako razveljaviti zapis o jemanju",
-  "midnightTakenWarningDialogTitle": "Bodite pozorni"
+  "midnightTakenWarningDialogTitle": "Bodite pozorni",
+  "pauseStartDateMustBeOnOrBefore": "Izberite datum začetka premora v jemanju, ki je enak dnevu {date} ali pred njim.",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Pilulat janë regjistruar si të marra deri më {takenDate}. Njoftimi i sotëm ({takenDate}) në orën {reminderTimes} nuk do të dërgohet.\nNëse ky ishte një gabim, ju lutemi anuloni regjistrimin e marrjes.",
   "midnightTakenWarningDialogNeverShowAgain": "Mos e shfaq më",
   "midnightTakenWarningDialogSeeHowToRevert": "Shiko si të anulosh regjistrimin e marrjes",
-  "midnightTakenWarningDialogTitle": "Kini parasysh"
+  "midnightTakenWarningDialogTitle": "Kini parasysh",
+  "pauseStartDateMustBeOnOrBefore": "Përjashto muajin e pushimit të marrjes duhet të zgjidhet një datë përpara ose deri më {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Uzimanje pilula je zabeleženo zaključno sa {takenDate}. Današnje ({takenDate}) obaveštenje u {reminderTimes} neće biti isporučeno.\nAko je ovo greška, poništite zapis o uzimanju.",
   "midnightTakenWarningDialogNeverShowAgain": "Ne prikazuj ponovo",
   "midnightTakenWarningDialogSeeHowToRevert": "Pogledajte kako da poništite zapis o uzimanju",
-  "midnightTakenWarningDialogTitle": "Napomena"
+  "midnightTakenWarningDialogTitle": "Napomena",
+  "pauseStartDateMustBeOnOrBefore": "Poštovana pauza za uzimanje pilule može početi samo prije {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Dina piller har registrerats som tagna till och med {takenDate}. Dagens påminnelse ({takenDate}) klockan {reminderTimes} kommer inte att skickas.\nOm detta var ett misstag, ångra registreringen av intaget.",
   "midnightTakenWarningDialogNeverShowAgain": "Visa inte igen",
   "midnightTakenWarningDialogSeeHowToRevert": "Se hur du ångrar en registrering",
-  "midnightTakenWarningDialogTitle": "Observera"
+  "midnightTakenWarningDialogTitle": "Observera",
+  "pauseStartDateMustBeOnOrBefore": "Servicepausen ska börja senast {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Vidonge vimerekodiwa kama vimechukuliwa hadi {takenDate}. Arifa ya ukumbusho ya leo ({takenDate}) saa {reminderTimes} haitatumwa.\nIkiwa hii ni kosa, tafadhali batilisha rekodi ya kuchukua kidonge.",
   "midnightTakenWarningDialogNeverShowAgain": "Usionyeshe tena",
   "midnightTakenWarningDialogSeeHowToRevert": "Ona jinsi ya kubatilisha rekodi ya kuchukua",
-  "midnightTakenWarningDialogTitle": "Tafadhali zingatia"
+  "midnightTakenWarningDialogTitle": "Tafadhali zingatia",
+  "pauseStartDateMustBeOnOrBefore": "Kabla ya {date}, chagua tarehe ya kuanza mapumziko ya kumeza dawa.",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} வரை மாத்திரை எடுத்ததாக பதிவு செய்யப்பட்டுள்ளது. {takenDate} ஆன இன்று {reminderTimes} அறிவிப்பு உங்களுக்கு வராது.\nதவறாக பதிவானது எனில், உட்கொள்ளுதலை ரத்து செய்யவும்.",
   "midnightTakenWarningDialogNeverShowAgain": "இதை மீண்டும் காட்ட வேண்டாம்",
   "midnightTakenWarningDialogSeeHowToRevert": "உட்கொள்ளுதலை ரத்து செய்யும் முறையைக் காண்க",
-  "midnightTakenWarningDialogTitle": "கவனிக்கவும்"
+  "midnightTakenWarningDialogTitle": "கவனிக்கவும்",
+  "pauseStartDateMustBeOnOrBefore": "மருந்து ஓய்வு தொடக்க தேதியாக {date} அல்லது அதற்கு முந்தைய தேதியைத் தேர்ந்தெடுக்கவும்",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} వరకు మాత్ర తీసుకున్నట్లు నమోదు చేయబడింది. {takenDate} అయిన ఈ రోజు {reminderTimes}కి వచ్చే నోటిఫికేషన్ మీకు అందదు.\nపొరపాటు జరిగితే, దయచేసి తీసుకున్న రికార్డును రద్దు చేయండి",
   "midnightTakenWarningDialogNeverShowAgain": "మళ్లీ చూపించవద్దు",
   "midnightTakenWarningDialogSeeHowToRevert": "తీసుకున్న రికార్డును ఎలా రద్దు చేయాలో చూడండి",
-  "midnightTakenWarningDialogTitle": "దయచేసి గమనించండి"
+  "midnightTakenWarningDialogTitle": "దయచేసి గమనించండి",
+  "pauseStartDateMustBeOnOrBefore": "మందు విరామం ప్రారంభ తేదీగా దయచేసి {date} కంటే ముందు తేదీని ఎంచుకోండి",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "มีการบันทึกว่าคุณได้รับประทานยาจนถึงวันที่ {takenDate} แล้ว การแจ้งเตือนของวันนี้ ({takenDate}) เวลา {reminderTimes} จะไม่ถูกส่งถึงคุณ\nหากเป็นการบันทึกผิดพลาด กรุณายกเลิกการบันทึกการรับประทานยา",
   "midnightTakenWarningDialogNeverShowAgain": "ไม่แสดงข้อความนี้อีก",
   "midnightTakenWarningDialogSeeHowToRevert": "ดูวิธีการยกเลิกการบันทึกการรับประทานยา",
-  "midnightTakenWarningDialogTitle": "โปรดทราบ"
+  "midnightTakenWarningDialogTitle": "โปรดทราบ",
+  "pauseStartDateMustBeOnOrBefore": "ก่อนเริ่มยาคุมเว้นวรรค กรุณาเลือกวันที่ก่อนหรือเท่ากับ {date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Naitala na ang pag-inom ng pill hanggang {takenDate}. Hindi maihahatid ang paalala ngayong {takenDate} sa oras na {reminderTimes}.\nKung pagkakamali ito, mangyaring bawiin ang naitalang pag-inom.",
   "midnightTakenWarningDialogNeverShowAgain": "Huwag nang ipakita muli",
   "midnightTakenWarningDialogSeeHowToRevert": "Tingnan kung paano bawiin ang pag-inom",
-  "midnightTakenWarningDialogTitle": "Mangyaring tandaan"
+  "midnightTakenWarningDialogTitle": "Mangyaring tandaan",
+  "pauseStartDateMustBeOnOrBefore": "Pumili ng petsa na {date} o mas maaga bilang petsa ng pagsisimula ng pahinga sa pag-inom",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} tarihine kadar olan hap alım kayıtlarınız oluşturuldu. Bugün ({takenDate}) için {reminderTimes} saatindeki hatırlatma bildirimi gönderilmeyecek.\nBu bir hataysa lütfen alım kaydını geri alın.",
   "midnightTakenWarningDialogNeverShowAgain": "Bir daha gösterme",
   "midnightTakenWarningDialogSeeHowToRevert": "Alım kaydını geri alma yöntemini görüntüle",
-  "midnightTakenWarningDialogTitle": "Lütfen dikkat edin"
+  "midnightTakenWarningDialogTitle": "Lütfen dikkat edin",
+  "pauseStartDateMustBeOnOrBefore": "Servis tatili başlangıç tarihi olarak {date} veya öncesi bir tarih seçin",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Прийом таблеток зафіксовано до {takenDate} включно. Сьогоднішнє ({takenDate}) нагадування о {reminderTimes} не надійде.\nЯкщо це сталося помилково, будь ласка, скасуйте запис про прийом",
   "midnightTakenWarningDialogNeverShowAgain": "Більше не показувати",
   "midnightTakenWarningDialogSeeHowToRevert": "Як скасувати запис про прийом",
-  "midnightTakenWarningDialogTitle": "Зверніть увагу"
+  "midnightTakenWarningDialogTitle": "Зверніть увагу",
+  "pauseStartDateMustBeOnOrBefore": "Будь ласка, оберіть дату не пізнішу за {date} як дату початку перерви у прийомі",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} تک کی خوراک ریکارڈ کر دی گئی ہے۔ آج، یعنی {takenDate}، کو {reminderTimes} پر ہونے والی اطلاع موصول نہیں ہوگی۔\nاگر یہ غلطی سے ہوا ہے تو براہِ کرم خوراک کا ریکارڈ منسوخ کریں",
   "midnightTakenWarningDialogNeverShowAgain": "دوبارہ نہ دکھائیں",
   "midnightTakenWarningDialogSeeHowToRevert": "خوراک منسوخ کرنے کا طریقہ دیکھیں",
-  "midnightTakenWarningDialogTitle": "براہِ کرم توجہ دیں"
+  "midnightTakenWarningDialogTitle": "براہِ کرم توجہ دیں",
+  "pauseStartDateMustBeOnOrBefore": "براہ کرم گولی کے وقفے کی شروعات کی تاریخ کے لیے {date} یا اس سے پہلے کی تاریخ منتخب کریں",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_uz.arb
+++ b/lib/l10n/app_uz.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "{takenDate} sanasigacha dorilaringiz qabul qilingan deb qayd etildi. Bugungi ({takenDate}) kuni soat {reminderTimes} dagi eslatma bildirishnomasi kelmaydi.\nAgar bu xato bo'lgan bo'lsa, iltimos, qabul yozuvini bekor qiling.",
   "midnightTakenWarningDialogNeverShowAgain": "Boshqa ko'rsatmaslik",
   "midnightTakenWarningDialogSeeHowToRevert": "Qabulni bekor qilish usulini ko'rish",
-  "midnightTakenWarningDialogTitle": "Ehtiyot bo'ling"
+  "midnightTakenWarningDialogTitle": "Ehtiyot bo'ling",
+  "pauseStartDateMustBeOnOrBefore": "Xizmatni boshlash sanasidan {date} oldingi sanani tanlang",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Đã ghi nhận uống thuốc đến hết {takenDate}. Thông báo lúc {reminderTimes} của hôm nay ({takenDate}) sẽ không được gửi tới bạn.\nNếu đây là nhầm lẫn, vui lòng hủy ghi nhận uống thuốc.",
   "midnightTakenWarningDialogNeverShowAgain": "Không hiển thị lại nữa",
   "midnightTakenWarningDialogSeeHowToRevert": "Xem cách hủy ghi nhận uống thuốc",
-  "midnightTakenWarningDialogTitle": "Xin lưu ý"
+  "midnightTakenWarningDialogTitle": "Xin lưu ý",
+  "pauseStartDateMustBeOnOrBefore": "Bạn nên chọn ngày trước {date} làm ngày bắt đầu kỳ nghỉ uống thuốc",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "已记录服用至{takenDate}。今天（{takenDate}）{reminderTimes}的提醒通知将不会推送。\n如果是误操作，请撤销服用记录。",
   "midnightTakenWarningDialogNeverShowAgain": "不再提示",
   "midnightTakenWarningDialogSeeHowToRevert": "查看取消服用记录的方法",
-  "midnightTakenWarningDialogTitle": "请注意"
+  "midnightTakenWarningDialogTitle": "请注意",
+  "pauseStartDateMustBeOnOrBefore": "停药开始日期请选择{date}以前的日期",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_zu.arb
+++ b/lib/l10n/app_zu.arb
@@ -2810,5 +2810,14 @@
   "midnightTakenWarningDialogBody": "Amaphilisi akho arekhodiwe njengokuthathiwe kuze kube ku-{takenDate}. Isaziso sanamuhla ({takenDate}) ngo-{reminderTimes} ngeke sifike.\nUma lokhu kwenzeke ngephutha, sicela ususe irekhodi lokuthatha.",
   "midnightTakenWarningDialogNeverShowAgain": "Ungaphinde ukhombise lokhu",
   "midnightTakenWarningDialogSeeHowToRevert": "Bona indlela yokususa irekhodi lokuthatha",
-  "midnightTakenWarningDialogTitle": "Sicela uqaphele"
+  "midnightTakenWarningDialogTitle": "Sicela uqaphele",
+  "pauseStartDateMustBeOnOrBefore": "Ihlelo lokuqala lokusetshenziswa lekhefu kufanele ukhethe usuku olungaphambi kuka-{date}",
+  "@pauseStartDateMustBeOnOrBefore": {
+    "description": "服用お休み期間の変更で、開始日に選択可能な最終日（最後に服用した日の翌日）より後の日付が選択された場合に表示されるエラーメッセージです。{date}には開始日として選択できる最終日（例: 7/13(月)）が入ります。",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Abstract

`pauseStartDateMustBeOnOrBefore` キーを欠落していた77言語の arb ファイルに追加する。

- fr: 既存の pause 系キーの訳語（Date de début de pause 等）に合わせて手動で追加
- その他76言語: `translation_scripts/translate_l10n_arb.py --use claude` で自動翻訳（1キー×76言語、言語ごとに1コミット）

## Why

#1823 で追加された `pauseStartDateMustBeOnOrBefore` が ja / en にしか存在せず、`test/l10n/arb_integrity_test.dart` の以下2テストが失敗して CI が赤になっていた。

- 全ARBのメッセージキーとプレースホルダーがテンプレートと一致する
- フランス語ARBが完全で重要文言がフランス語になっている

（fr は翻訳スクリプトの対象言語リストから除外されているため、スクリプト実行だけでは解消せず手動追加が必要だった）

## Links

- issue: https://github.com/bannzai/PilllBackend/issues/393
- 由来PR: https://github.com/bannzai/Pilll/pull/1823

## Checked
- [ ] Analyticsのログを入れたか（対象外: 翻訳リソースのみの変更）
- [ ] 境界値に対してのUnitTestを書いた（対象外: 既存の arb_integrity_test がこの欠落を検出するテストであり、本PRでパスすることを確認済み）
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた（対象外: Widget変更なし）

### 検証

- `flutter gen-l10n` exit 0（untranslated なし）
- `flutter test test/l10n/arb_integrity_test.dart` exit 0（2件パス）
- `flutter test` 全件: exit 0（1533件パス）

## セッション再開

```sh
cd /Users/bannzai/worktrees/bannzai/Pilll/fix/missing-arb-translations
claude --resume 7fcb8381-28fd-4454-bef7-ce7ba5b01712
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 休薬期間の開始日に許容範囲を超える日付を選択した際のエラーメッセージを、多数の対応言語で追加しました。
  * エラーメッセージには、選択可能な最終日が表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->