### PR TITLE
OSSライセンス一覧表示を追加

### DIFF
--- a/lib/features/settings/components/rows/oss_license.dart
+++ b/lib/features/settings/components/rows/oss_license.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:pilll/components/atoms/font.dart';
+import 'package:pilll/utils/analytics.dart';
+
+/// 設定画面の行。タップするとアプリが利用しているOSSの名称とライセンス本文の一覧を表示する
+///
+/// 一覧はFlutter標準の[showLicensePage]が[LicenseRegistry]から組み立てるため、依存関係の追加・更新に自動で追従する
+class OSSLicenseRow extends StatelessWidget {
+  const OSSLicenseRow({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(
+        // flutter_localizationsが70以上の言語で訳を持っているため、app_*.arbへキーを追加せずに多言語対応できる
+        MaterialLocalizations.of(context).licensesPageTitle,
+        style: const TextStyle(
+          fontFamily: FontFamily.roboto,
+          fontWeight: FontWeight.w300,
+          fontSize: 16,
+        ),
+      ),
+      onTap: () async {
+        analytics.logEvent(name: 'did_select_oss_license');
+
+        // MaterialAppにtitleを設定していないため、applicationNameを省略するとiOSでは実行ファイル名の「Runner」が表示される
+        final packageInfo = await PackageInfo.fromPlatform();
+        if (!context.mounted) {
+          return;
+        }
+        showLicensePage(
+          context: context,
+          applicationName: packageInfo.appName,
+          applicationVersion: packageInfo.version,
+        );
+      },
+    );
+  }
+}

--- a/lib/features/settings/page.dart
+++ b/lib/features/settings/page.dart
@@ -23,6 +23,7 @@ import 'package:pilll/features/settings/components/rows/list_explain.dart';
 import 'package:pilll/features/settings/components/rows/reminder_notification_customize_word.dart';
 import 'package:pilll/features/settings/components/rows/notification_in_rest_duration.dart';
 import 'package:pilll/features/settings/components/rows/notification_time.dart';
+import 'package:pilll/features/settings/components/rows/oss_license.dart';
 import 'package:pilll/features/settings/components/rows/pill_sheet_remove.dart';
 import 'package:pilll/features/settings/components/rows/premium_introduction.dart';
 import 'package:pilll/features/settings/components/rows/quick_record.dart';
@@ -333,6 +334,8 @@ Android: https://onl.sc/c9xnQUk''';
                             );
                           },
                         ),
+                        _separator(),
+                        const OSSLicenseRow(),
                         _separator(),
                         ListTile(
                           title: Text(

--- a/test/features/settings/components/rows/oss_license_test.dart
+++ b/test/features/settings/components/rows/oss_license_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pilll/features/settings/components/rows/oss_license.dart';
+import 'package:pilll/utils/environment.dart';
+
+void main() {
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    Environment.isTest = true;
+  });
+
+  group('#OSSLicenseRow', () {
+    testWidgets('ライセンス一覧を開く行が、端末のロケールに合わせた文言のListTileとして表示される',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          locale: Locale('ja'),
+          localizationsDelegates: GlobalMaterialLocalizations.delegates,
+          supportedLocales: [Locale('ja'), Locale('en')],
+          home: Material(child: OSSLicenseRow()),
+        ),
+      );
+
+      expect(find.byType(ListTile), findsOneWidget);
+      expect(find.text('ライセンス'), findsOneWidget);
+    });
+
+    testWidgets('英語ロケールでは英語の文言で表示される', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          locale: Locale('en'),
+          localizationsDelegates: GlobalMaterialLocalizations.delegates,
+          supportedLocales: [Locale('ja'), Locale('en')],
+          home: Material(child: OSSLicenseRow()),
+        ),
+      );
+
+      expect(find.text('Licenses'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Abstract

OSS ライセンス一覧表示を追加します。設定画面の「その他」セクションに「ライセンス」の行を追加し、Pilll が利用している OSS の名称とライセンス本文をアプリ内で確認できるようにしました。

## Why

アプリから、利用している OSS とそのライセンスをユーザーが確認できるようにするためです。依存関係の追加・更新に追従できるよう、手書きの固定一覧ではなく依存関係から自動生成される方式を採用しています。

## 導入方法

Flutter 標準の `showLicensePage` を使用しました。ライセンス一覧のための生成ツール・追加パッケージは導入していません。

- 一覧は Flutter の `LicenseRegistry` が各パッケージの LICENSE から組み立てるため、依存関係の追加・更新に自動追従します。生成物のコミットも再生成コマンドも不要です
- 行のラベルは `MaterialLocalizations.of(context).licensesPageTitle` を使いました。`flutter_localizations` が 70 以上の言語で訳を持っているため、`lib/l10n/app_*.arb`（79 ファイル）へキーを追加せずに多言語対応できます
- `MaterialApp` に `title` を設定していないため、`applicationName` を省略すると iOS では実行ファイル名の「Runner」が一覧の見出しに表示されます。`PackageInfo.fromPlatform()` からアプリ名とバージョンを渡して「Pilll-dev / 202608.05.041927」と表示されることを確認しました
- 行のタップで `did_select_oss_license` を Analytics に記録します（同セクションの利用規約・プライバシーポリシーと同じ方式）

## Links

- Flutter `showLicensePage`: https://api.flutter.dev/flutter/material/showLicensePage.html

## 表示導線

設定タブ →「その他」セクション →「ライセンス」（プライバシーポリシーと FAQ の間）→ ライセンス一覧 → パッケージを選択 → ライセンス本文

## 変更ファイル

- `lib/features/settings/components/rows/oss_license.dart`（新規）— ライセンス一覧を開く設定行
- `lib/features/settings/page.dart` — 「その他」セクションへ行を追加
- `test/features/settings/components/rows/oss_license_test.dart`（新規）— 行の Widget Test

## 検証結果

すべて Flutter 3.41.9 / worktree `add-oss-license-page` で実行しました。

| コマンド | 結果 |
|---|---|
| `dart format --output=none --set-exit-if-changed lib` | exit 0（516 files, 0 changed） |
| `flutter analyze --no-pub --no-fatal-infos --fatal-warnings` | exit 0。変更前 baseline と指摘を突き合わせ、新規指摘・消えた指摘ともに 0 件（既存 117 件の info のみ） |
| `flutter test` | exit 0（1590 passed / 1 skipped） |
| `flutter build ios --debug --simulator --target lib/main.dev.dart` | exit 0（`Built build/ios/iphonesimulator/Runner.app`） |
| `flutter build apk --debug --target lib/main.dev.dart` | exit 0（`Built build/app/outputs/flutter-apk/app-debug.apk`）。警告 3 件はいずれも依存パッケージ `google_mobile_ads` の Java コードの deprecated API 警告で、本 PR の変更とは無関係 |
| `maestro test .maestro/flows/feature_appeal/subflows/initial_setup.yaml` | exit 0（初期設定を完了しホーム画面へ到達） |

### UI 動作確認

iOS Simulator（`pilll-add-oss-license-page-iOS26.5` / iOS 26.5）に dev ビルドをインストールし、Maestro で初期設定を完了させたうえで確認しました。

| 設定 →「その他」に「ライセンス」 | ライセンス一覧（依存関係が列挙される） | ライセンス本文（abseil-cpp / Apache License 2.0） |
|---|---|---|
| <img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/bannzai/Pilll/20260811/c6401693-7211-4485-bdcb-759947cb79af.png" width="300" /> | <img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/bannzai/Pilll/20260811/0ae940cd-9bd6-42bb-ad48-5478611f419b.png" width="300" /> | <img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/bannzai/Pilll/20260811/abbc417b-4298-4749-93e0-955c5c8fca2f.png" width="300" /> |

- 一覧の見出しにアプリ名「Pilll-dev」とバージョン「202608.05.041927」が表示される
- 一覧は空ではなく、`_fe_analyzer_shared` / `abseil-cpp` / `accessibility` などパッケージごとにライセンス件数付きで並ぶ
- パッケージを選ぶとライセンス本文（Apache License Version 2.0 の全文）が読める

Android は端末での UI 確認は行わず、`flutter build apk --debug` の成否のみ確認しています（変更は Dart のみでプラットフォーム固有コードを含まないため）。

### ビルド時の注意

worktree では `.gitignore` 対象のビルド入力が未生成のため、そのままではビルドが失敗します。`make secret` で生成するか、メイン checkout から複製してからビルドしてください。いずれも本 PR の差分には含まれません。

- iOS: `ios/Firebase/GoogleService-Info.plist`、`ios/Runner/StoreKitTestCertificate.cer` が無いと `flutter build ios` が失敗する
- Android: `android/app/src/google-services.json` が無いと `:app:processDebugGoogleServices` で失敗する（`android/app/src/dev/google-services.json` だけでは足りない）
- 加えて worktree では `flutter-pod-warmup` の実行が必要（`ios/.symlinks` と `ios/Pods` の生成）

## Checked
- [x] Analyticsのログを入れたか（`did_select_oss_license`）
- [ ] 境界値に対してのUnitTestを書いた（日付・数値の境界を持つロジックがないため該当なし）
- [x] パターン分岐が発生するWidgetに対してWidgetTestを書いた（ロケールによる表示文言の切り替えを検証）

## 人間が確認

なし

## セッション再開

```sh
cd /Users/bannzai/worktrees/bannzai/Pilll/add-oss-license-page
claude --resume 4b2cb5c7-76a6-482e-a835-7c1367ecda81
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 設定画面に「ライセンス」項目を追加しました。
  * アプリ名とバージョン情報を含む、OSSライセンス一覧を表示できるようになりました。
  * 日本語・英語の表示に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->