### PR TITLE
fix: 買い切りプランの割引バッジから通常価格の固定値フォールバックを削除する

### DIFF
--- a/lib/features/premium_introduction/components/lifetime_purchase_button.dart
+++ b/lib/features/premium_introduction/components/lifetime_purchase_button.dart
@@ -78,12 +78,13 @@ class LifetimePurchaseButton extends StatelessWidget {
               ),
             ),
           ),
-          if (discountRate != null && offeringType == OfferingType.discount)
+          // NOTE: 通常買い切り価格はストアから取得した値だけを表示する。取得できない時はバッジ自体を表示しない
+          if (discountRate != null && lifetimePremiumPackage != null && offeringType == OfferingType.discount)
             Positioned(
               top: -5,
               child: _LifetimeDiscountBadge(
                 discountRate: discountRate!,
-                lifetimePremiumPackage: lifetimePremiumPackage,
+                lifetimePremiumPackage: lifetimePremiumPackage!,
               ),
             ),
         ],
@@ -94,7 +95,7 @@ class LifetimePurchaseButton extends StatelessWidget {
 
 class _LifetimeDiscountBadge extends StatelessWidget {
   final double discountRate;
-  final Package? lifetimePremiumPackage;
+  final Package lifetimePremiumPackage;
 
   const _LifetimeDiscountBadge({
     required this.discountRate,
@@ -110,7 +111,7 @@ class _LifetimeDiscountBadge extends StatelessWidget {
         color: AppColors.secondary,
       ),
       child: Text(
-        '通常買い切り価格の ${lifetimePremiumPackage?.storeProduct.priceString ?? "¥20,000"} よりも ${discountRate.toInt()}％OFF',
+        '通常買い切り価格の ${lifetimePremiumPackage.storeProduct.priceString} よりも ${discountRate.toInt()}％OFF',
         style: const TextStyle(
           fontWeight: FontWeight.w700,
           fontSize: 10,

--- a/test/features/premium_introduction/components/lifetime_purchase_button_test.dart
+++ b/test/features/premium_introduction/components/lifetime_purchase_button_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pilll/features/premium_introduction/components/lifetime_purchase_button.dart';
+import 'package:pilll/provider/purchase.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
+
+class _FakeStoreProduct extends Fake implements StoreProduct {
+  _FakeStoreProduct({required this.fakePriceString});
+  final String fakePriceString;
+
+  @override
+  String get priceString => fakePriceString;
+}
+
+class _FakeLifetimePackage extends Fake implements Package {
+  _FakeLifetimePackage({required this.fakePriceString});
+  final String fakePriceString;
+
+  @override
+  StoreProduct get storeProduct => _FakeStoreProduct(fakePriceString: fakePriceString);
+
+  @override
+  PackageType get packageType => PackageType.lifetime;
+}
+
+void main() {
+  group('#LifetimePurchaseButton', () {
+    testWidgets('割引中で通常買い切り価格をストアから取得できている場合、割引バッジにストアの価格が表示される', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: LifetimePurchaseButton(
+              lifetimePackage: _FakeLifetimePackage(fakePriceString: '¥10,000'),
+              lifetimePremiumPackage: _FakeLifetimePackage(fakePriceString: '¥15,000'),
+              discountRate: 30,
+              offeringType: OfferingType.discount,
+              onTap: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('通常買い切り価格の ¥15,000 よりも 30％OFF'), findsOneWidget);
+    });
+
+    testWidgets('割引中でも通常買い切り価格をストアから取得できない場合、割引バッジ自体を表示しない', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: LifetimePurchaseButton(
+              lifetimePackage: _FakeLifetimePackage(fakePriceString: '¥10,000'),
+              lifetimePremiumPackage: null,
+              discountRate: 30,
+              offeringType: OfferingType.discount,
+              onTap: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.textContaining('通常買い切り価格'), findsNothing);
+      expect(find.textContaining('％OFF'), findsNothing);
+    });
+
+    testWidgets('割引提供ではない場合、割引バッジを表示しない', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: LifetimePurchaseButton(
+              lifetimePackage: _FakeLifetimePackage(fakePriceString: '¥10,000'),
+              lifetimePremiumPackage: _FakeLifetimePackage(fakePriceString: '¥15,000'),
+              discountRate: 30,
+              offeringType: OfferingType.premium,
+              onTap: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.textContaining('通常買い切り価格'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Abstract

外部 (ストア) が正を持つ価格に、クライアント側の固定値フォールバックを置いていた箇所を修正する。

`lib/features/premium_introduction/components/lifetime_purchase_button.dart` の `_LifetimeDiscountBadge` が、通常買い切り価格の package (`lifetimePremiumPackage`) をストアから取得できない時に、ストアフロントの通貨・実価格と無関係な固定値「¥20,000」を表示していた。

```dart
// 修正前
'通常買い切り価格の ${lifetimePremiumPackage?.storeProduct.priceString ?? "¥20,000"} よりも ${discountRate.toInt()}％OFF',
```

## Why

castle に追加されたコーディングルール「外部が正を持つ値にクライアントのデフォルト値を置かない」に反しているため。ストア・サーバー・外部 API が正を持つ値 (課金価格・通貨・無料トライアル期間など) を、それらしい固定値へフォールバックすると、実際と異なる金額をユーザーに見せることになる。

- 起票元: https://github.com/bannzai/castle/issues/741
- ルール追加 PR: https://github.com/bannzai/castle/pull/743

## 変更内容

### 割引バッジの表示条件 (`lifetime_purchase_button.dart`)

- `LifetimePurchaseButton` の表示条件に `lifetimePremiumPackage != null` を追加し、通常買い切り価格を取得できた時だけ割引バッジを表示する。取得できない時はバッジ自体を表示しない (価格なしで割引率だけを見せることもしない)
- `_LifetimeDiscountBadge.lifetimePremiumPackage` を `Package?` から `Package` に変更し、固定値フォールバックを型で排除する

なお `lifetimeDiscountRateProvider` は `lifetimePremiumPackage` が null の時に null を返すため、実行時には元々このフォールバックには到達しない想定だった。今回の変更で「到達しない想定」を型と表示条件で保証する形にした。

### テスト

`test/features/premium_introduction/components/lifetime_purchase_button_test.dart` を新規追加し、次の 3 ケースを検証する。

- 割引中で通常買い切り価格をストアから取得できている場合、割引バッジにストアの価格が表示される
- 割引中でも通常買い切り価格をストアから取得できない場合、割引バッジ自体を表示しない (固定値が出ない)
- 割引提供 (`OfferingType.discount`) ではない場合、割引バッジを表示しない

## 同種の違反の調査範囲

課金 UI (`lib/features/premium_introduction/`, `lib/features/lifetime_offer/`) の `priceString` / 価格リテラルを全て確認した。他の箇所は次のとおりで、固定価格フォールバックは今回修正した 1 箇所のみだった。

- `premium_introduction_discount.dart` / `annual_purchase_button.dart` / `monthly_purchase_button.dart` / `lifetime_purchase_button.dart` (買い切り価格本体): いずれも non-null の package から `priceString` を直接表示している
- `lifetime_offer/page.dart:393-395`: `lifetimeDiscountRate != null && lifetimePremiumPackage != null` の時だけ「通常価格 ¥X」を表示しており、今回の修正と同じ方針で既に実装されている
- `annual_purchase_button.dart` の割引率計算: ストアから取得した価格同士の計算で、固定値は使っていない

## 動作確認

ログはいずれも作業ディレクトリの `./tmp/` 配下 (git 管理外)。

| 内容 | コマンド | ログ | 結果 |
| --- | --- | --- | --- |
| 静的解析 | `flutter analyze` | `./tmp/verify-analyze.log` | exit=1 / 117 issues すべて `info` (既存の lint 情報)。`error` / `warning` は 0 件で、変更した 2 ファイルに対する指摘も 0 件 |
| テスト | `flutter test test/features/premium_introduction test/features/lifetime_offer` | `./tmp/verify-test.log` | exit=0 / 74 tests All tests passed (新規 3 件を含む) |
| 描画確認 | `flutter test ./tmp/render_lifetime_badge_test.dart` | `./tmp/verify-screenshot.log` | 下記スクリーンショット |

判定根拠:

- `flutter analyze`: ログ全文を `grep -i -e error -e warning` で検査し、`error` / `warning` 行が 0 件であることを確認した。exit=1 なのは `info` の既存 lint (117 件) が残っているためで、これは変更前の origin/main でも同数出る既存状態。`grep -n lifetime_purchase_button ./tmp/verify-analyze.log` も 0 件
- `flutter test`: ログ末尾の `All tests passed!` と `exit=0` を確認した。新規テスト 3 件が実行されたことは `grep "#LifetimePurchaseButton" ./tmp/verify-test.log` で確認した

### スクリーンショット

課金 UI の「ストアから通常買い切り価格を取得できない」状態は iOS Simulator 上では作れない (RevenueCat のオファリング取得結果に依存する) ため、widget test で実フォント (Noto Sans JP) を読み込み、`RepaintBoundary` を PNG に書き出して描画を確認した。

通常買い切り価格を取得できた場合 (バッジにストアの価格「¥15,000」が出る):

<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/bannzai/Pilll/20260831/e26a703d-d2f1-4a3b-93ca-3de32b97f0d2.png" width="500" />

通常買い切り価格を取得できない場合 (バッジ自体が出ない。修正前はここに「¥20,000」が出ていた):

<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/bannzai/Pilll/20260831/9bd91341-1e4e-40d4-8741-88f1a414d439.png" width="500" />

## 人間が確認

なし

## セッション再開

```sh
cd /Users/bannzai/worktrees/bannzai/Pilll/fix-external-price-fallback
claude --resume 30a9d770-19cb-4da1-a80c-4013fdda9e16
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 割引提供時、通常の買い切り価格を取得できる場合にのみ割引バッジを表示するようになりました。
  * 割引バッジに、ストアの通常価格と割引率を表示します。

* **不具合修正**
  * 通常価格を取得できない場合や通常プランでは、誤って割引バッジが表示されないよう修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->