### PR TITLE
setup-dependabot skill で dependabot.yml を生成

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# Managed by setup-dependabot skill ( https://github.com/bannzai/castle )
+# 再実行するとファイル全体が再生成される。手動管理に切り替える場合はこのヘッダーを削除する。
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directories:
+      - "/"
+      - "/ios"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "gradle"
+    directory: "/android"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## 概要

setup-dependabot skill を適用し、リリース後待機日数（cooldown）付きの `.github/dependabot.yml` を生成した。Bundler（ルート・iOS）、GitHub Actions、Gradle（Android）、pub を対象に、既定の週次更新・待機7日を設定した。npm 系の対象はない。

## 目的

`propagate-changes` による setup-dependabot skill の一括適用。

## 変更ファイル

- `.github/dependabot.yml`

## 検証

- 検出結果をリポジトリ内の manifest の配置と照合した。
- 生成時は `action=create`、同じコマンドの再実行は `action=noop`（ともに終了コード0）。
- `git diff --cached --check` は終了コード0。ステージ済み差分・未送信コミットの電話番号検査は検出0件。差分の秘匿情報も点検済み。
- 設定ファイルのみの変更のため、Flutter のユニットテスト・Maestro E2E は未実施。GitHub 上での Dependabot の実稼働はデフォルトブランチへの反映後となるため未検証。

## 人間が確認

なし

## セッション再開

```sh
cd /Users/bannzai/worktrees/bannzai/Pilll/setup-dependabot
codex resume 01a083f8-e79a-7472-8819-cdd9e749d7a6
```

---

> この PR は `propagate-changes` skill による一括適用で作成しました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の更新を週次で確認・整理する設定を追加しました。
  * 軽微な更新をまとめて管理し、更新頻度を抑制する設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->