### PR TITLE
tmux-setup-symlink-targets skill で worktree 共有ファイルを宣言

### DIFF
--- a/.tmux_setup_copy_target
+++ b/.tmux_setup_copy_target
@@ -1,0 +1,3 @@
+# tmux-issue-setup / tmux-branch-setup が worktree へ反映する git 管理外ファイル
+android/local.properties
+android/app/src/main/res/values/values.xml

--- a/.tmux_setup_symlink_target
+++ b/.tmux_setup_symlink_target
@@ -1,0 +1,7 @@
+# tmux-issue-setup / tmux-branch-setup が worktree へ反映する git 管理外ファイル
+android/app/src/dev/google-services.json
+android/app/src/google-services.json
+android/app/src/prod/google-services.json
+android/secret.properties
+ios/Firebase/GoogleService-Info.plist
+ios/Runner/StoreKitTestCertificate.cer


### PR DESCRIPTION
## 概要

tmux-setup-symlink-targets skill を適用し、worktree にも必要な git 管理外ファイルを `.tmux_setup_symlink_target` / `.tmux_setup_copy_target` に宣言した。tmux-issue-setup / tmux-branch-setup が新しい worktree 作成時にこれらを symlink / copy し、ローカル設定の欠落を防ぐ。

## 動機

/propagate-changes による tmux-setup-symlink-targets skill の一括適用。

## 変更ファイル

- `.tmux_setup_symlink_target`: Android / iOS の Firebase 設定、Android 署名設定、StoreKit テスト証明書の6パスを共有する。
- `.tmux_setup_copy_target`: ビルドが更新する `android/local.properties` と `android/app/src/main/res/values/values.xml` の2パスを worktree ごとにコピーする。

## 検証

- メイン checkout を scan し、設定の内容を表示せず候補を確認した。
- skill スクリプトの一時実行用コピーで宣言の読み書き先のみこの worktree に変更し、共有元の宣言・設定は変更していない。
- この worktree に8パスを反映し、symlink の参照先と copy の独立性をメタデータで確認した。
- add / apply の再実行で、宣言の重複と宛先の上書きが発生しないことを確認した。
- `git diff --cached --check` 成功。差分は宣言ファイル2つのパスとコメントのみ。ステージ済み差分・未送信コミットの電話番号検査は検出0件。
- アプリコードの変更がないため、Flutter のユニットテスト・ビルド・Maestro E2E は実施していない。

## 除外・保留

- `.DS_Store`、`android/gradlew.bat`、`lib/l10n/app_localizations.dart` は、OS のメタデータまたは再生成されるファイルのため除外した。
- `ios/.envrc` は、内容を読まずに共有可否を確定できないため保留した。

## 人間が確認

なし

## セッション再開

```sh
cd /Users/bannzai/worktrees/bannzai/Pilll/tmux-setup-symlink-targets
codex resume 01a08449-32dc-76c3-aea2-ffc2d58b33be
```

---

> この PR は `propagate-changes` skill の一括適用として作成しました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - tmuxを利用した開発環境セットアップで、Android・iOSのローカル設定やサービス設定ファイルをワークツリーへ反映できるようになりました。
  - Gitで管理されない設定ファイルも、ブランチや課題ごとの環境構築時に適切に引き継がれます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->