### PR TITLE
FeatureAppeal 分析を反映した課金導線の改善 (Bar 露出の重み付け・トライアル中の paywall 導線・オンボーディング Paywall A/B) (PilllBackend#417)

### DIFF
--- a/lib/entity/remote_config_parameter.codegen.dart
+++ b/lib/entity/remote_config_parameter.codegen.dart
@@ -58,6 +58,9 @@ abstract class RemoteConfigKeys {
 
   /// ピルシート終了ダイアログの A/B バリアント識別子キー
   static const endedPillSheetDialogVariant = 'endedPillSheetDialogVariant';
+
+  /// オンボーディング内 Paywall 表示の A/B バリアント識別子キー
+  static const onboardingPaywallVariant = 'onboardingPaywallVariant';
 }
 
 /// Remote Configパラメータのデフォルト値定義
@@ -118,6 +121,9 @@ abstract class RemoteConfigParameterDefaultValues {
 
   /// ピルシート終了ダイアログのバリアント（空文字 = 実験未参加 / 非表示）
   static const endedPillSheetDialogVariant = '';
+
+  /// オンボーディング内 Paywall のバリアント（空文字 = 実験未参加。割当イベントも送らず現行フローのまま）
+  static const onboardingPaywallVariant = '';
 }
 
 // [RemoteConfigDefaultValues] でgrepした場所に全て設定する
@@ -220,6 +226,11 @@ class RemoteConfigParameter with _$RemoteConfigParameter {
     /// ピルシート終了ダイアログの A/B バリアント識別子
     /// 'history_blur' / 'summary_stats' / '' (非表示)。Firebase A/B Testing で配信する
     @Default(RemoteConfigParameterDefaultValues.endedPillSheetDialogVariant) String endedPillSheetDialogVariant,
+
+    /// オンボーディング内 Paywall 表示の A/B バリアント識別子
+    /// 'control' (現行フロー) / 'paywall' (initial_setting 完了後・premium_trial 紹介前に Paywall を表示) / '' (実験未参加)。
+    /// Firebase A/B Testing で配信する。解釈は lib/features/initial_setting/onboarding_paywall_variant.dart
+    @Default(RemoteConfigParameterDefaultValues.onboardingPaywallVariant) String onboardingPaywallVariant,
   }) = _RemoteConfigParameter;
   RemoteConfigParameter._();
   factory RemoteConfigParameter.fromJson(Map<String, dynamic> json) => _$RemoteConfigParameterFromJson(json);

--- a/lib/entity/remote_config_parameter.codegen.freezed.dart
+++ b/lib/entity/remote_config_parameter.codegen.freezed.dart
@@ -88,6 +88,11 @@ mixin _$RemoteConfigParameter {
   /// 'history_blur' / 'summary_stats' / '' (非表示)。Firebase A/B Testing で配信する
   String get endedPillSheetDialogVariant => throw _privateConstructorUsedError;
 
+  /// オンボーディング内 Paywall 表示の A/B バリアント識別子
+  /// 'control' (現行フロー) / 'paywall' (initial_setting 完了後・premium_trial 紹介前に Paywall を表示) / '' (実験未参加)。
+  /// Firebase A/B Testing で配信する。解釈は lib/features/initial_setting/onboarding_paywall_variant.dart
+  String get onboardingPaywallVariant => throw _privateConstructorUsedError;
+
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $RemoteConfigParameterCopyWith<RemoteConfigParameter> get copyWith => throw _privateConstructorUsedError;
@@ -115,7 +120,8 @@ abstract class $RemoteConfigParameterCopyWith<$Res> {
       int lifetimeOfferUserCreationDaysUntil,
       int lifetimeOfferDurationHours,
       String lifetimeOfferCopyVariant,
-      String endedPillSheetDialogVariant});
+      String endedPillSheetDialogVariant,
+      String onboardingPaywallVariant});
 }
 
 /// @nodoc
@@ -147,6 +153,7 @@ class _$RemoteConfigParameterCopyWithImpl<$Res, $Val extends RemoteConfigParamet
     Object? lifetimeOfferDurationHours = null,
     Object? lifetimeOfferCopyVariant = null,
     Object? endedPillSheetDialogVariant = null,
+    Object? onboardingPaywallVariant = null,
   }) {
     return _then(_value.copyWith(
       isPaywallFirst: null == isPaywallFirst
@@ -217,6 +224,10 @@ class _$RemoteConfigParameterCopyWithImpl<$Res, $Val extends RemoteConfigParamet
           ? _value.endedPillSheetDialogVariant
           : endedPillSheetDialogVariant // ignore: cast_nullable_to_non_nullable
               as String,
+      onboardingPaywallVariant: null == onboardingPaywallVariant
+          ? _value.onboardingPaywallVariant
+          : onboardingPaywallVariant // ignore: cast_nullable_to_non_nullable
+              as String,
     ) as $Val);
   }
 }
@@ -244,7 +255,8 @@ abstract class _$$RemoteConfigParameterImplCopyWith<$Res> implements $RemoteConf
       int lifetimeOfferUserCreationDaysUntil,
       int lifetimeOfferDurationHours,
       String lifetimeOfferCopyVariant,
-      String endedPillSheetDialogVariant});
+      String endedPillSheetDialogVariant,
+      String onboardingPaywallVariant});
 }
 
 /// @nodoc
@@ -273,6 +285,7 @@ class __$$RemoteConfigParameterImplCopyWithImpl<$Res> extends _$RemoteConfigPara
     Object? lifetimeOfferDurationHours = null,
     Object? lifetimeOfferCopyVariant = null,
     Object? endedPillSheetDialogVariant = null,
+    Object? onboardingPaywallVariant = null,
   }) {
     return _then(_$RemoteConfigParameterImpl(
       isPaywallFirst: null == isPaywallFirst
@@ -343,6 +356,10 @@ class __$$RemoteConfigParameterImplCopyWithImpl<$Res> extends _$RemoteConfigPara
           ? _value.endedPillSheetDialogVariant
           : endedPillSheetDialogVariant // ignore: cast_nullable_to_non_nullable
               as String,
+      onboardingPaywallVariant: null == onboardingPaywallVariant
+          ? _value.onboardingPaywallVariant
+          : onboardingPaywallVariant // ignore: cast_nullable_to_non_nullable
+              as String,
     ));
   }
 }
@@ -367,7 +384,8 @@ class _$RemoteConfigParameterImpl extends _RemoteConfigParameter {
       this.lifetimeOfferUserCreationDaysUntil = RemoteConfigParameterDefaultValues.lifetimeOfferUserCreationDaysUntil,
       this.lifetimeOfferDurationHours = RemoteConfigParameterDefaultValues.lifetimeOfferDurationHours,
       this.lifetimeOfferCopyVariant = RemoteConfigParameterDefaultValues.lifetimeOfferCopyVariant,
-      this.endedPillSheetDialogVariant = RemoteConfigParameterDefaultValues.endedPillSheetDialogVariant})
+      this.endedPillSheetDialogVariant = RemoteConfigParameterDefaultValues.endedPillSheetDialogVariant,
+      this.onboardingPaywallVariant = RemoteConfigParameterDefaultValues.onboardingPaywallVariant})
       : super._();
 
   factory _$RemoteConfigParameterImpl.fromJson(Map<String, dynamic> json) => _$$RemoteConfigParameterImplFromJson(json);
@@ -474,9 +492,16 @@ class _$RemoteConfigParameterImpl extends _RemoteConfigParameter {
   @JsonKey()
   final String endedPillSheetDialogVariant;
 
+  /// オンボーディング内 Paywall 表示の A/B バリアント識別子
+  /// 'control' (現行フロー) / 'paywall' (initial_setting 完了後・premium_trial 紹介前に Paywall を表示) / '' (実験未参加)。
+  /// Firebase A/B Testing で配信する。解釈は lib/features/initial_setting/onboarding_paywall_variant.dart
+  @override
+  @JsonKey()
+  final String onboardingPaywallVariant;
+
   @override
   String toString() {
-    return 'RemoteConfigParameter(isPaywallFirst: $isPaywallFirst, skipInitialSetting: $skipInitialSetting, trialDeadlineDateOffsetDay: $trialDeadlineDateOffsetDay, discountEntitlementOffsetDay: $discountEntitlementOffsetDay, discountCountdownBoundaryHour: $discountCountdownBoundaryHour, premiumIntroductionPattern: $premiumIntroductionPattern, premiumIntroductionShowsAppStoreReviewCard: $premiumIntroductionShowsAppStoreReviewCard, specialOfferingUserCreationDateTimeOffset: $specialOfferingUserCreationDateTimeOffset, specialOfferingUserCreationDateTimeOffsetSince: $specialOfferingUserCreationDateTimeOffsetSince, specialOfferingUserCreationDateTimeOffsetUntil: $specialOfferingUserCreationDateTimeOffsetUntil, specialOffering2UseAlternativeText: $specialOffering2UseAlternativeText, lifetimeOfferEnabled: $lifetimeOfferEnabled, lifetimeOfferUserCreationDaysSince: $lifetimeOfferUserCreationDaysSince, lifetimeOfferUserCreationDaysUntil: $lifetimeOfferUserCreationDaysUntil, lifetimeOfferDurationHours: $lifetimeOfferDurationHours, lifetimeOfferCopyVariant: $lifetimeOfferCopyVariant, endedPillSheetDialogVariant: $endedPillSheetDialogVariant)';
+    return 'RemoteConfigParameter(isPaywallFirst: $isPaywallFirst, skipInitialSetting: $skipInitialSetting, trialDeadlineDateOffsetDay: $trialDeadlineDateOffsetDay, discountEntitlementOffsetDay: $discountEntitlementOffsetDay, discountCountdownBoundaryHour: $discountCountdownBoundaryHour, premiumIntroductionPattern: $premiumIntroductionPattern, premiumIntroductionShowsAppStoreReviewCard: $premiumIntroductionShowsAppStoreReviewCard, specialOfferingUserCreationDateTimeOffset: $specialOfferingUserCreationDateTimeOffset, specialOfferingUserCreationDateTimeOffsetSince: $specialOfferingUserCreationDateTimeOffsetSince, specialOfferingUserCreationDateTimeOffsetUntil: $specialOfferingUserCreationDateTimeOffsetUntil, specialOffering2UseAlternativeText: $specialOffering2UseAlternativeText, lifetimeOfferEnabled: $lifetimeOfferEnabled, lifetimeOfferUserCreationDaysSince: $lifetimeOfferUserCreationDaysSince, lifetimeOfferUserCreationDaysUntil: $lifetimeOfferUserCreationDaysUntil, lifetimeOfferDurationHours: $lifetimeOfferDurationHours, lifetimeOfferCopyVariant: $lifetimeOfferCopyVariant, endedPillSheetDialogVariant: $endedPillSheetDialogVariant, onboardingPaywallVariant: $onboardingPaywallVariant)';
   }
 
   @override
@@ -513,7 +538,8 @@ class _$RemoteConfigParameterImpl extends _RemoteConfigParameter {
                 other.lifetimeOfferDurationHours == lifetimeOfferDurationHours) &&
             (identical(other.lifetimeOfferCopyVariant, lifetimeOfferCopyVariant) || other.lifetimeOfferCopyVariant == lifetimeOfferCopyVariant) &&
             (identical(other.endedPillSheetDialogVariant, endedPillSheetDialogVariant) ||
-                other.endedPillSheetDialogVariant == endedPillSheetDialogVariant));
+                other.endedPillSheetDialogVariant == endedPillSheetDialogVariant) &&
+            (identical(other.onboardingPaywallVariant, onboardingPaywallVariant) || other.onboardingPaywallVariant == onboardingPaywallVariant));
   }
 
   @JsonKey(ignore: true)
@@ -536,7 +562,8 @@ class _$RemoteConfigParameterImpl extends _RemoteConfigParameter {
       lifetimeOfferUserCreationDaysUntil,
       lifetimeOfferDurationHours,
       lifetimeOfferCopyVariant,
-      endedPillSheetDialogVariant);
+      endedPillSheetDialogVariant,
+      onboardingPaywallVariant);
 
   @JsonKey(ignore: true)
   @override
@@ -570,7 +597,8 @@ abstract class _RemoteConfigParameter extends RemoteConfigParameter {
       final int lifetimeOfferUserCreationDaysUntil,
       final int lifetimeOfferDurationHours,
       final String lifetimeOfferCopyVariant,
-      final String endedPillSheetDialogVariant}) = _$RemoteConfigParameterImpl;
+      final String endedPillSheetDialogVariant,
+      final String onboardingPaywallVariant}) = _$RemoteConfigParameterImpl;
   _RemoteConfigParameter._() : super._();
 
   factory _RemoteConfigParameter.fromJson(Map<String, dynamic> json) = _$RemoteConfigParameterImpl.fromJson;
@@ -660,6 +688,12 @@ abstract class _RemoteConfigParameter extends RemoteConfigParameter {
   /// ピルシート終了ダイアログの A/B バリアント識別子
   /// 'history_blur' / 'summary_stats' / '' (非表示)。Firebase A/B Testing で配信する
   String get endedPillSheetDialogVariant;
+  @override
+
+  /// オンボーディング内 Paywall 表示の A/B バリアント識別子
+  /// 'control' (現行フロー) / 'paywall' (initial_setting 完了後・premium_trial 紹介前に Paywall を表示) / '' (実験未参加)。
+  /// Firebase A/B Testing で配信する。解釈は lib/features/initial_setting/onboarding_paywall_variant.dart
+  String get onboardingPaywallVariant;
   @override
   @JsonKey(ignore: true)
   _$$RemoteConfigParameterImplCopyWith<_$RemoteConfigParameterImpl> get copyWith => throw _privateConstructorUsedError;

--- a/lib/entity/remote_config_parameter.codegen.g.dart
+++ b/lib/entity/remote_config_parameter.codegen.g.dart
@@ -35,6 +35,7 @@ _$RemoteConfigParameterImpl _$$RemoteConfigParameterImplFromJson(Map<String, dyn
           (json['lifetimeOfferDurationHours'] as num?)?.toInt() ?? RemoteConfigParameterDefaultValues.lifetimeOfferDurationHours,
       lifetimeOfferCopyVariant: json['lifetimeOfferCopyVariant'] as String? ?? RemoteConfigParameterDefaultValues.lifetimeOfferCopyVariant,
       endedPillSheetDialogVariant: json['endedPillSheetDialogVariant'] as String? ?? RemoteConfigParameterDefaultValues.endedPillSheetDialogVariant,
+      onboardingPaywallVariant: json['onboardingPaywallVariant'] as String? ?? RemoteConfigParameterDefaultValues.onboardingPaywallVariant,
     );
 
 Map<String, dynamic> _$$RemoteConfigParameterImplToJson(_$RemoteConfigParameterImpl instance) => <String, dynamic>{
@@ -55,4 +56,5 @@ Map<String, dynamic> _$$RemoteConfigParameterImplToJson(_$RemoteConfigParameterI
       'lifetimeOfferDurationHours': instance.lifetimeOfferDurationHours,
       'lifetimeOfferCopyVariant': instance.lifetimeOfferCopyVariant,
       'endedPillSheetDialogVariant': instance.endedPillSheetDialogVariant,
+      'onboardingPaywallVariant': instance.onboardingPaywallVariant,
     };

--- a/lib/features/feature_appeal/CLAUDE.md
+++ b/lib/features/feature_appeal/CLAUDE.md
@@ -39,6 +39,8 @@ tabController?.animateTo(HomePageTabType.{record|menstruation|calendar|setting}.
 
 Premium 機能の場合のみ、タブ移動前に `ref.watch(userProvider).requireValue` で user を取得し、`!user.premiumOrTrial` のとき `showPremiumIntroductionSheet(context)` でペイウォール表示。
 
+Premium 機能の HelpPage は「確認する」の下に `FeatureAppealPremiumPlanButton` (`feature_appeal_premium_plan_button.dart`) を置く。トライアル中ユーザーにだけ表示され、`feature_appeal_paywall_shown` (`trigger: premium_plan_button`) を送ってペイウォールを開く。
+
 ## ステップバイステップガイド
 
 ### 矢印
@@ -72,7 +74,8 @@ Premium 機能の場合のみ、タブ移動前に `ref.watch(userProvider).requ
 
 - 各機能には AnnouncementBar (`*_announcement_bar.dart`) と HelpPage (`*_help_page.dart`) がセット
 - AnnouncementBar タップで HelpPage に遷移する
-- 日次ローテーション: `daysBetween(epoch, today()) % candidates.length`
+- 日次ローテーション: `weightedRotationOrder` (転換実績に基づく `FeatureAppealBarWeight` の重み付き表示順) に対して `daysBetween(epoch, today()) % 表示順の長さ`。重みの根拠は `feature_appeal_bars_container.dart` のコメントを参照
+- 表示時に `feature_appeal_bar_shown` (feature_key / feature_type / weight / rotation_length) を送る
 - dismiss は SharedPreferences のキーで機能ごとに管理
 
 ## Route 定義
@@ -95,7 +98,7 @@ extension XxxHelpPageRoute on XxxHelpPage {
 3. `{feature}_announcement_bar.dart` を作成
 4. `lib/l10n/app_ja.arb` / `app_en.arb` に L10n キーを追加（Title, Headline, Point1/2/3）
 5. `flutter gen-l10n` で生成
-6. `lib/features/feature_appeal/feature_appeal_bars_container.dart` に AnnouncementBar を登録
+6. `lib/features/feature_appeal/feature_appeal_bars_container.dart` に AnnouncementBar を登録 (featureKey / featureType と `FeatureAppealBarWeight` の重みを付ける。転換実績が無い新機能は `noConversion`)
 7. `lib/features/settings/components/rows/feature_appeal_help_page_list_page.dart` の `pages` リストにエントリを追加
 8. **PilllBackend (`~/ghq/github.com/bannzai/PilllBackend`) の BigQuery も同期更新** (Pilll リリース前 or 同時に PR を merge する。ズレるとデータ欠損)
    - `bigquery/views/event_logs_feature_appeal.sql` の `firebaseScreen IN (...)` に新 HelpPage 名を追加

--- a/lib/features/feature_appeal/QA.md
+++ b/lib/features/feature_appeal/QA.md
@@ -1,8 +1,8 @@
 ---
 feature: feature_appeal
 verification: mobile-mcp
-last_verified_commit: 34b7e05eb0ed73e5ee0caa2a91a96147e2edaded
-last_verified_at: 2026-07-05
+last_verified_commit: 21853fcbe3916b4509d34b8a00a3fac51298721c
+last_verified_at: 2026-09-11
 ---
 
 # feature_appeal QA
@@ -12,6 +12,7 @@ last_verified_at: 2026-07-05
 ## 1. バー表示・ローテーション (共通コンテナ)
 
 - [x] **候補のうち1件のみ表示**: ホーム画面のアナウンスバー領域には feature_appeal の候補(最大13件)のうち1件だけが表示される(日付ベースのローテーションで日替わり)
+- [x] **転換実績に基づく重み付きローテーション**: 表示順は `FeatureAppealBarWeight` (alarm_kit / health_care_integration / quick_record = 3、future_schedule / menstruation / appearance_mode_date = 2、他 = 1) で重み付けされ、1 周目は全候補、2 周目以降は重みが残る候補だけが順に表示される。表示時に `feature_appeal_bar_shown` (feature_key / feature_type / weight / rotation_length) が送られる
 - [x] **iOS限定機能はAndroidで候補から除外**: Android端末では CriticalAlert・AlarmKit のバーが候補から除外される(設定画面に対応する行がないため)
 - [x] **×ボタンで当日は再表示されない**: 表示中のバーの×ボタンをタップすると feature_appeal 領域全体がその日は非表示になる(`featureAppealLastDismissedDate` に当日の日付が保存される)
 - [x] **全候補がdismiss済みの場合は領域ごと非表示**: 全機能をdismiss済みにした状態でホーム画面を開くと、feature_appeal 領域が何も表示せず高さ0で折りたたまれる
@@ -61,6 +62,18 @@ last_verified_at: 2026-07-05
 **確認日: 2026-07-05**
 
 ⏭️ 13機能すべての dismiss 済み SharedPreferences 状態は実機シミュレータのサンドボックス内 plist を書き換える必要があり本 session のツール制約上直接再現できないため、代替手段として自動テストで確認した。`flutter test test/features/feature_appeal/feature_appeal_bars_container_test.dart` の `13 機能全 dismiss → SizedBox.shrink が表示される` テストで13件全 dismiss 時に全 Bar が `findsNothing` となることを確認済み（13件中13件成功）。
+
+</details>
+
+### **転換実績に基づく重み付きローテーション**: 表示順は `FeatureAppealBarWeight` (alarm_kit / health_care_integration / quick_record = 3、future_schedule / menstruation / appearance_mode_date = 2、他 = 1) で重み付けされ、1 周目は全候補、2 周目以降は重みが残る候補だけが順に表示される。表示時に `feature_appeal_bar_shown` (feature_key / feature_type / weight / rotation_length) が送られる
+
+<details><summary>動作確認スクショ</summary>
+
+**確認日: 2026-09-11**
+
+初期設定直後のトライアル中ユーザー (iOS、全 13 候補・appIsReleased=true で表示順は 22 日周期) のホーム画面で「未来の予定を書き込もう」(future_schedule) が表示された。2026-09-11 は epoch (2024-01-01) から 984 日目で 984 % 22 = 16 → 2 周目 (13 件目以降) の 4 番目 = 重み 2 の future_schedule に一致する (1 周目 13 件 → 2 周目: quick_record / appearance_mode_date / menstruation / future_schedule / health_care_integration / alarm_kit)。日替わりの全周期は端末で確認できないため、`flutter test test/features/feature_appeal/feature_appeal_bars_container_test.dart` の `#weightedRotationOrder` (4 件) と `2 周目` / `3 周目の末尾と折り返し` のテストで表示順を検証した (181 件中 181 件成功)。`feature_appeal_bar_shown` の送信は BigQuery 着弾を待つ (PilllBackend `feature_appeal_bar_exposure.sql`)。
+
+<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/e971e1dd-5f63-4075-b518-6eb9b0c5e349-home_after_onboarding_trial.png" width="320">
 
 </details>
 
@@ -122,7 +135,9 @@ last_verified_at: 2026-07-05
 
 - [x] **プレミアムバッジ付きプレビュー表示**: プレミアム機能のHelpPage(例: `AlarmKitHelpPage`)には該当設定行のプレビューに `PremiumBadge` が表示される
 - [ ] **非プレミアムユーザーは確認するボタンでペイウォール表示**: 非プレミアムユーザーが「確認する」ボタンをタップすると、設定タブへの遷移前に `PremiumIntroductionSheet` が表示される
+  - ⏭️ スキップ: 2026-07-05 の記録 (下記エビデンス) のとおり未実施。今回 (2026-09-11) はトライアル中ユーザーの導線 (下の項目) を対象にしたため再実施していない。現在は開発者オプション「トライアル解除」で無料ユーザー状態を作れるので、次回の QA で確認する
 - [x] **プレミアムユーザーは確認するボタンで直接タブ遷移**: プレミアムまたはトライアル中のユーザーが同じボタンをタップすると、ペイウォールを経由せず設定タブへ直接遷移する
+- [x] **トライアル中ユーザーには「プレミアムプランを見る」ボタンが表示される**: プレミアム機能のHelpPageで、トライアル中(非プレミアム)のユーザーには「確認する」の下に「プレミアムプランを見る」(`FeatureAppealPremiumPlanButton`) が表示され、タップすると `PremiumIntroductionSheet` が開く。プレミアム会員・トライアル未開始/終了後の無料ユーザーには表示されない
 
 #### 動作確認
 <details>
@@ -159,6 +174,19 @@ last_verified_at: 2026-07-05
 トライアル中ユーザー(`isTrial=true`)がプレミアム機能(通知メッセージカスタマイズ)のHelpPageで「確認する」をタップすると、`PremiumIntroductionSheet` を経由せず設定タブへ直接遷移することを確認。
 
 <img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/bannzai/Pilll/20260705/0441d239-856f-470e-98d6-7023fdcce740.png" width="320">
+
+</details>
+
+### **トライアル中ユーザーには「プレミアムプランを見る」ボタンが表示される**: プレミアム機能のHelpPageで、トライアル中(非プレミアム)のユーザーには「確認する」の下に「プレミアムプランを見る」(`FeatureAppealPremiumPlanButton`) が表示され、タップすると `PremiumIntroductionSheet` が開く。プレミアム会員・トライアル未開始/終了後の無料ユーザーには表示されない
+
+<details><summary>動作確認スクショ</summary>
+
+**確認日: 2026-09-11**
+
+初期設定直後 (トライアル中) のユーザーで、開発者オプション「FeatureAppeal HelpPage 一覧」→ AlarmKit (iOS 26+) を開くと「確認する」の下に「プレミアムプランを見る」が表示され、タップで `PremiumIntroductionSheet` (プラン一覧) が開いた。非表示の条件 (プレミアム会員・トライアル未開始・トライアル終了後) は `flutter test test/features/feature_appeal/feature_appeal_premium_plan_button_test.dart` (4 件成功) で確認した。
+
+<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/9ab1e0dc-05a5-48b9-9079-042641157c9b-help_page_alarm_kit_trial.png" width="320">
+<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/0d1dd55d-5d96-4f65-8aa7-e4ebed792661-help_page_alarm_kit_paywall.png" width="320">
 
 </details>
 

--- a/lib/features/feature_appeal/alarm_kit/alarm_kit_help_page.dart
+++ b/lib/features/feature_appeal/alarm_kit/alarm_kit_help_page.dart
@@ -6,6 +6,7 @@ import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/feature_appeal/feature_appeal_premium_plan_button.dart';
 import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
@@ -121,30 +122,38 @@ class AlarmKitHelpPage extends ConsumerWidget {
       bottomNavigationBar: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: PrimaryButton(
-            text: L.featureAppealTryFeature,
-            onPressed: () async {
-              final user = ref.read(userProvider).requireValue;
-              analytics.logEvent(
-                name: 'feature_appeal_try_tapped',
-                parameters: {
-                  'feature_key': 'alarm_kit',
-                  'feature_type': 'premium',
-                  'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              PrimaryButton(
+                text: L.featureAppealTryFeature,
+                onPressed: () async {
+                  final user = ref.read(userProvider).requireValue;
+                  analytics.logEvent(
+                    name: 'feature_appeal_try_tapped',
+                    parameters: {
+                      'feature_key': 'alarm_kit',
+                      'feature_type': 'premium',
+                      'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+                    },
+                  );
+                  if (!user.premiumOrTrial) {
+                    analytics.logEvent(
+                      name: 'feature_appeal_paywall_shown',
+                      parameters: {'feature_key': 'alarm_kit', 'trigger': 'try'},
+                    );
+                    await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealAlarmKit);
+                    return;
+                  }
+                  final tabController = ref.read(homeTabControllerProvider);
+                  Navigator.of(context).popUntil((r) => r.isFirst);
+                  tabController?.animateTo(HomePageTabType.setting.index);
                 },
-              );
-              if (!user.premiumOrTrial) {
-                analytics.logEvent(
-                  name: 'feature_appeal_paywall_shown',
-                  parameters: {'feature_key': 'alarm_kit'},
-                );
-                await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealAlarmKit);
-                return;
-              }
-              final tabController = ref.read(homeTabControllerProvider);
-              Navigator.of(context).popUntil((r) => r.isFirst);
-              tabController?.animateTo(HomePageTabType.setting.index);
-            },
+              ),
+              const SizedBox(height: 8),
+              const FeatureAppealPremiumPlanButton(featureKey: 'alarm_kit', paywallSource: PaywallSource.featureAppealAlarmKit),
+            ],
           ),
         ),
       ),

--- a/lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart
+++ b/lib/features/feature_appeal/appearance_mode_date/appearance_mode_date_help_page.dart
@@ -5,6 +5,7 @@ import 'package:pilll/components/atoms/button.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
+import 'package:pilll/features/feature_appeal/feature_appeal_premium_plan_button.dart';
 import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
@@ -99,30 +100,38 @@ class AppearanceModeDateHelpPage extends ConsumerWidget {
       bottomNavigationBar: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: PrimaryButton(
-            text: L.featureAppealTryFeature,
-            onPressed: () async {
-              final user = ref.read(userProvider).requireValue;
-              analytics.logEvent(
-                name: 'feature_appeal_try_tapped',
-                parameters: {
-                  'feature_key': 'appearance_mode_date',
-                  'feature_type': 'premium',
-                  'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              PrimaryButton(
+                text: L.featureAppealTryFeature,
+                onPressed: () async {
+                  final user = ref.read(userProvider).requireValue;
+                  analytics.logEvent(
+                    name: 'feature_appeal_try_tapped',
+                    parameters: {
+                      'feature_key': 'appearance_mode_date',
+                      'feature_type': 'premium',
+                      'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+                    },
+                  );
+                  if (!user.premiumOrTrial) {
+                    analytics.logEvent(
+                      name: 'feature_appeal_paywall_shown',
+                      parameters: {'feature_key': 'appearance_mode_date', 'trigger': 'try'},
+                    );
+                    await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealAppearanceMode);
+                    return;
+                  }
+                  final tabController = ref.read(homeTabControllerProvider);
+                  Navigator.of(context).popUntil((r) => r.isFirst);
+                  tabController?.animateTo(HomePageTabType.record.index);
                 },
-              );
-              if (!user.premiumOrTrial) {
-                analytics.logEvent(
-                  name: 'feature_appeal_paywall_shown',
-                  parameters: {'feature_key': 'appearance_mode_date'},
-                );
-                await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealAppearanceMode);
-                return;
-              }
-              final tabController = ref.read(homeTabControllerProvider);
-              Navigator.of(context).popUntil((r) => r.isFirst);
-              tabController?.animateTo(HomePageTabType.record.index);
-            },
+              ),
+              const SizedBox(height: 8),
+              const FeatureAppealPremiumPlanButton(featureKey: 'appearance_mode_date', paywallSource: PaywallSource.featureAppealAppearanceMode),
+            ],
           ),
         ),
       ),

--- a/lib/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page.dart
+++ b/lib/features/feature_appeal/creating_new_pillsheet/creating_new_pillsheet_help_page.dart
@@ -6,6 +6,7 @@ import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/feature_appeal/feature_appeal_premium_plan_button.dart';
 import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
@@ -121,30 +122,41 @@ class CreatingNewPillSheetHelpPage extends ConsumerWidget {
       bottomNavigationBar: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: PrimaryButton(
-            text: L.featureAppealTryFeature,
-            onPressed: () async {
-              final user = ref.read(userProvider).requireValue;
-              analytics.logEvent(
-                name: 'feature_appeal_try_tapped',
-                parameters: {
-                  'feature_key': 'creating_new_pillsheet',
-                  'feature_type': 'premium',
-                  'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              PrimaryButton(
+                text: L.featureAppealTryFeature,
+                onPressed: () async {
+                  final user = ref.read(userProvider).requireValue;
+                  analytics.logEvent(
+                    name: 'feature_appeal_try_tapped',
+                    parameters: {
+                      'feature_key': 'creating_new_pillsheet',
+                      'feature_type': 'premium',
+                      'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+                    },
+                  );
+                  if (!user.premiumOrTrial) {
+                    analytics.logEvent(
+                      name: 'feature_appeal_paywall_shown',
+                      parameters: {'feature_key': 'creating_new_pillsheet', 'trigger': 'try'},
+                    );
+                    await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealCreatingPillSheet);
+                    return;
+                  }
+                  final tabController = ref.read(homeTabControllerProvider);
+                  Navigator.of(context).popUntil((r) => r.isFirst);
+                  tabController?.animateTo(HomePageTabType.setting.index);
                 },
-              );
-              if (!user.premiumOrTrial) {
-                analytics.logEvent(
-                  name: 'feature_appeal_paywall_shown',
-                  parameters: {'feature_key': 'creating_new_pillsheet'},
-                );
-                await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealCreatingPillSheet);
-                return;
-              }
-              final tabController = ref.read(homeTabControllerProvider);
-              Navigator.of(context).popUntil((r) => r.isFirst);
-              tabController?.animateTo(HomePageTabType.setting.index);
-            },
+              ),
+              const SizedBox(height: 8),
+              const FeatureAppealPremiumPlanButton(
+                featureKey: 'creating_new_pillsheet',
+                paywallSource: PaywallSource.featureAppealCreatingPillSheet,
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart
+++ b/lib/features/feature_appeal/critical_alert/critical_alert_help_page.dart
@@ -6,6 +6,7 @@ import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/feature_appeal/feature_appeal_premium_plan_button.dart';
 import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
@@ -117,30 +118,38 @@ class CriticalAlertHelpPage extends ConsumerWidget {
       bottomNavigationBar: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: PrimaryButton(
-            text: L.featureAppealTryFeature,
-            onPressed: () async {
-              final user = ref.read(userProvider).requireValue;
-              analytics.logEvent(
-                name: 'feature_appeal_try_tapped',
-                parameters: {
-                  'feature_key': 'critical_alert',
-                  'feature_type': 'premium',
-                  'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              PrimaryButton(
+                text: L.featureAppealTryFeature,
+                onPressed: () async {
+                  final user = ref.read(userProvider).requireValue;
+                  analytics.logEvent(
+                    name: 'feature_appeal_try_tapped',
+                    parameters: {
+                      'feature_key': 'critical_alert',
+                      'feature_type': 'premium',
+                      'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+                    },
+                  );
+                  if (!user.premiumOrTrial) {
+                    analytics.logEvent(
+                      name: 'feature_appeal_paywall_shown',
+                      parameters: {'feature_key': 'critical_alert', 'trigger': 'try'},
+                    );
+                    await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealCriticalAlert);
+                    return;
+                  }
+                  final tabController = ref.read(homeTabControllerProvider);
+                  Navigator.of(context).popUntil((r) => r.isFirst);
+                  tabController?.animateTo(HomePageTabType.setting.index);
                 },
-              );
-              if (!user.premiumOrTrial) {
-                analytics.logEvent(
-                  name: 'feature_appeal_paywall_shown',
-                  parameters: {'feature_key': 'critical_alert'},
-                );
-                await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealCriticalAlert);
-                return;
-              }
-              final tabController = ref.read(homeTabControllerProvider);
-              Navigator.of(context).popUntil((r) => r.isFirst);
-              tabController?.animateTo(HomePageTabType.setting.index);
-            },
+              ),
+              const SizedBox(height: 8),
+              const FeatureAppealPremiumPlanButton(featureKey: 'critical_alert', paywallSource: PaywallSource.featureAppealCriticalAlert),
+            ],
           ),
         ),
       ),

--- a/lib/features/feature_appeal/feature_appeal_bars_container.dart
+++ b/lib/features/feature_appeal/feature_appeal_bars_container.dart
@@ -16,6 +16,7 @@ import 'package:pilll/features/feature_appeal/reminder_notification_customize_wo
 import 'package:pilll/features/feature_appeal/rest_duration/rest_duration_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/today_pill_number/today_pill_number_announcement_bar.dart';
 import 'package:pilll/provider/shared_preferences.dart';
+import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/utils/datetime/date_compare.dart';
 import 'package:pilll/utils/datetime/day.dart';
 import 'package:pilll/utils/shared_preference/keys.dart';
@@ -25,8 +26,37 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// 変更すると既存ユーザーの「今日表示される Bar」がずれる。
 final DateTime _featureAppealEpoch = DateTime(2024, 1, 1);
 
+/// 転換実績に基づく Bar の表示重み。重み w の Bar は 1 周期 (全重みの合計日数) の中で w 日表示される。
+///
+/// 根拠: PilllBackend issue #373 の FeatureAppeal 課金分析 (2026-09-01 実行) のトライアル 30 日転換率
+/// (https://github.com/bannzai/PilllBackend/issues/373#issuecomment-5491959910)。
+/// - 3: alarm_kit 25.0% / health_care_integration 18.2% / quick_record 14.3% (転換率上位)
+/// - 2: future_schedule 8.3% / menstruation 6.7% / appearance_mode_date 4.8% (転換あり)
+/// - 1: 転換 0 の 7 機能 (露出最多の rest_duration を含む)。表示廃止ではなく頻度を下げて測定を続ける
+/// 転換者は十数人の小標本で因果効果ではないため、差は 3 倍までに留める (issue #417)。
+abstract class FeatureAppealBarWeight {
+  static const highConversion = 3;
+  static const someConversion = 2;
+  static const noConversion = 1;
+}
+
+/// 重み付きローテーションの表示順。
+/// 「全候補を一巡 → まだ重みが残る候補だけで一巡 → ...」を最大重みの回数繰り返す。
+/// 候補ごとに連続させる並び (A,A,A,B,C) では同じ Bar が連日続くため、周回ごとに候補を散らす。
+/// 例: 重み [A:3, B:1, C:2] → [A, B, C, A, C, A]
+List<T> weightedRotationOrder<T>({required List<({T candidate, int weight})> weightedCandidates}) {
+  // ループ条件で毎回 fold しないよう周回数を先に確定する
+  final roundCount = weightedCandidates.fold(0, (max, weighted) => weighted.weight > max ? weighted.weight : max);
+  return [
+    for (var round = 0; round < roundCount; round++)
+      for (final weighted in weightedCandidates)
+        if (weighted.weight > round) weighted.candidate,
+  ];
+}
+
 /// AnnouncementBar 領域に表示する FeatureAppeal 専用コンテナ。
-/// 候補 Bar のうち `daysBetween(epoch, today) % candidates.length` の 1 件だけを出す。
+/// 候補 Bar を FeatureAppealBarWeight で重み付けした表示順 (weightedRotationOrder) のうち
+/// `daysBetween(epoch, today) % 表示順の長さ` の 1 件だけを出す。
 class FeatureAppealBarsContainer extends HookConsumerWidget {
   /// 未リリース機能を非表示にするフラグ。
   final bool appIsReleased;
@@ -163,32 +193,120 @@ class FeatureAppealBarsContainer extends HookConsumerWidget {
     }, [sharedPreferences]);
 
     final isIOS = defaultTargetPlatform == TargetPlatform.iOS;
-    final candidates = <Widget>[
+    // featureKey / featureType は各 HelpPage が送る feature_appeal_try_tapped と同じ値 (BigQuery で結合するため)。
+    final weightedCandidates = <({({String featureKey, String featureType, Widget bar}) candidate, int weight})>[
       // CriticalAlert と AlarmKit の設定行は settings/page.dart で iOS 配下にあるため、
       // Bar も iOS に限定する (Android ユーザーが HelpPage から設定タブに飛んでも該当行がないため)。
       // dart:io の Platform.isIOS ではなく defaultTargetPlatform を使うのは、
       // Widget テストで debugDefaultTargetPlatformOverride による iOS 扱いを効かせるため。
-      if (!quickRecordIsClosed.value) QuickRecordAnnouncementBar(isClosed: quickRecordIsClosed),
+      if (!quickRecordIsClosed.value)
+        (
+          candidate: (featureKey: 'quick_record', featureType: 'premium', bar: QuickRecordAnnouncementBar(isClosed: quickRecordIsClosed)),
+          weight: FeatureAppealBarWeight.highConversion,
+        ),
       if (!reminderNotificationCustomizeWordIsClosed.value)
-        ReminderNotificationCustomizeWordAnnouncementBar(isClosed: reminderNotificationCustomizeWordIsClosed),
-      if (!restDurationIsClosed.value) RestDurationAnnouncementBar(isClosed: restDurationIsClosed),
-      if (isIOS && !criticalAlertIsClosed.value) CriticalAlertAnnouncementBar(isClosed: criticalAlertIsClosed),
-      if (appIsReleased && !appearanceModeDateIsClosed.value) AppearanceModeDateAnnouncementBar(isClosed: appearanceModeDateIsClosed),
-      if (!recordPillIsClosed.value) RecordPillAnnouncementBar(isClosed: recordPillIsClosed),
-      if (!menstruationIsClosed.value) MenstruationAnnouncementBar(isClosed: menstruationIsClosed),
-      if (!calendarDiaryIsClosed.value) CalendarDiaryAnnouncementBar(isClosed: calendarDiaryIsClosed),
-      if (!futureScheduleIsClosed.value) FutureScheduleAnnouncementBar(isClosed: futureScheduleIsClosed),
-      if (!healthCareIntegrationIsClosed.value) HealthCareIntegrationAnnouncementBar(isClosed: healthCareIntegrationIsClosed),
-      if (!creatingNewPillSheetIsClosed.value) CreatingNewPillSheetAnnouncementBar(isClosed: creatingNewPillSheetIsClosed),
-      if (isIOS && !alarmKitIsClosed.value) AlarmKitAnnouncementBar(isClosed: alarmKitIsClosed),
-      if (!todayPillNumberIsClosed.value) TodayPillNumberAnnouncementBar(isClosed: todayPillNumberIsClosed),
+        (
+          candidate: (
+            featureKey: 'reminder_notification_customize_word',
+            featureType: 'premium',
+            bar: ReminderNotificationCustomizeWordAnnouncementBar(isClosed: reminderNotificationCustomizeWordIsClosed),
+          ),
+          weight: FeatureAppealBarWeight.noConversion,
+        ),
+      if (!restDurationIsClosed.value)
+        (
+          candidate: (featureKey: 'rest_duration', featureType: 'free', bar: RestDurationAnnouncementBar(isClosed: restDurationIsClosed)),
+          weight: FeatureAppealBarWeight.noConversion,
+        ),
+      if (isIOS && !criticalAlertIsClosed.value)
+        (
+          candidate: (featureKey: 'critical_alert', featureType: 'premium', bar: CriticalAlertAnnouncementBar(isClosed: criticalAlertIsClosed)),
+          weight: FeatureAppealBarWeight.noConversion,
+        ),
+      if (appIsReleased && !appearanceModeDateIsClosed.value)
+        (
+          candidate: (
+            featureKey: 'appearance_mode_date',
+            featureType: 'premium',
+            bar: AppearanceModeDateAnnouncementBar(isClosed: appearanceModeDateIsClosed),
+          ),
+          weight: FeatureAppealBarWeight.someConversion,
+        ),
+      if (!recordPillIsClosed.value)
+        (
+          candidate: (featureKey: 'record_pill', featureType: 'free', bar: RecordPillAnnouncementBar(isClosed: recordPillIsClosed)),
+          weight: FeatureAppealBarWeight.noConversion,
+        ),
+      if (!menstruationIsClosed.value)
+        (
+          candidate: (featureKey: 'menstruation', featureType: 'free', bar: MenstruationAnnouncementBar(isClosed: menstruationIsClosed)),
+          weight: FeatureAppealBarWeight.someConversion,
+        ),
+      if (!calendarDiaryIsClosed.value)
+        (
+          candidate: (featureKey: 'calendar_diary', featureType: 'free', bar: CalendarDiaryAnnouncementBar(isClosed: calendarDiaryIsClosed)),
+          weight: FeatureAppealBarWeight.noConversion,
+        ),
+      if (!futureScheduleIsClosed.value)
+        (
+          candidate: (featureKey: 'future_schedule', featureType: 'free', bar: FutureScheduleAnnouncementBar(isClosed: futureScheduleIsClosed)),
+          weight: FeatureAppealBarWeight.someConversion,
+        ),
+      if (!healthCareIntegrationIsClosed.value)
+        (
+          candidate: (
+            featureKey: 'health_care_integration',
+            featureType: 'free',
+            bar: HealthCareIntegrationAnnouncementBar(isClosed: healthCareIntegrationIsClosed),
+          ),
+          weight: FeatureAppealBarWeight.highConversion,
+        ),
+      if (!creatingNewPillSheetIsClosed.value)
+        (
+          candidate: (
+            featureKey: 'creating_new_pillsheet',
+            featureType: 'premium',
+            bar: CreatingNewPillSheetAnnouncementBar(isClosed: creatingNewPillSheetIsClosed),
+          ),
+          weight: FeatureAppealBarWeight.noConversion,
+        ),
+      if (isIOS && !alarmKitIsClosed.value)
+        (
+          candidate: (featureKey: 'alarm_kit', featureType: 'premium', bar: AlarmKitAnnouncementBar(isClosed: alarmKitIsClosed)),
+          weight: FeatureAppealBarWeight.highConversion,
+        ),
+      if (!todayPillNumberIsClosed.value)
+        (
+          candidate: (featureKey: 'today_pill_number', featureType: 'free', bar: TodayPillNumberAnnouncementBar(isClosed: todayPillNumberIsClosed)),
+          weight: FeatureAppealBarWeight.noConversion,
+        ),
     ];
-    if (candidates.isEmpty) {
+    final rotationOrder = weightedRotationOrder(weightedCandidates: weightedCandidates);
+    final shown = rotationOrder.isEmpty ? null : rotationOrder[daysBetween(_featureAppealEpoch, today()) % rotationOrder.length];
+
+    // 重み付け後の表示分布を BigQuery (feature_appeal_bar_shown) で検証するための impression。
+    // 親 (AnnouncementBar) の再ビルドで重複計上しないよう、表示する Bar が変わった時だけ送る。
+    useEffect(() {
+      if (shown != null) {
+        analytics.logEvent(
+          name: 'feature_appeal_bar_shown',
+          parameters: {
+            'feature_key': shown.featureKey,
+            'feature_type': shown.featureType,
+            'weight': weightedCandidates.firstWhere((weighted) => weighted.candidate.featureKey == shown.featureKey).weight,
+            'rotation_length': rotationOrder.length,
+          },
+        );
+      }
+      return null;
+    }, [shown?.featureKey]);
+
+    if (shown == null) {
       return const SizedBox.shrink();
     }
     return Semantics(
       identifier: 'feature_appeal_bar',
-      child: candidates[daysBetween(_featureAppealEpoch, today()) % candidates.length],
+      child: shown.bar,
     );
   }
 

--- a/lib/features/feature_appeal/feature_appeal_premium_plan_button.dart
+++ b/lib/features/feature_appeal/feature_appeal_premium_plan_button.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/features/localizations/l.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
+import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
+import 'package:pilll/provider/user.dart';
+import 'package:pilll/utils/analytics.dart';
+
+/// Premium 機能の HelpPage で、トライアル中ユーザーを paywall (PremiumIntroductionSheet) へ接続するボタン。
+///
+/// 「確認する」はトライアル中ユーザーには機能画面 (タブ) へ遷移して paywall に到達しない。
+/// FeatureAppeal 分析 (PilllBackend issue #417) で try 後に paywall 未到達のユーザーが 667 人いたため、
+/// 機能を試す前後どちらでも paywall へ進める入口を HelpPage 内に置く。
+/// 非トライアルの無料ユーザーには「確認する」自体が paywall を開くので出さない。Premium 会員にも出さない。
+class FeatureAppealPremiumPlanButton extends ConsumerWidget {
+  /// feature_appeal_try_tapped と同じ feature_key (BigQuery でファネルを結合するため)。
+  final String featureKey;
+  final PaywallSource paywallSource;
+
+  const FeatureAppealPremiumPlanButton({super.key, required this.featureKey, required this.paywallSource});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // HelpPage はホーム画面から開かれ userProvider は読み込み済みのため、未読込 (AsyncLoading) の間は何も出さない
+    final user = ref.watch(userProvider).valueOrNull;
+    if (user == null || user.isPremium || !user.isTrial) {
+      return const SizedBox.shrink();
+    }
+    return AppOutlinedButton(
+      text: L.viewPremiumPlan,
+      onPressed: () async {
+        analytics.logEvent(
+          name: 'feature_appeal_paywall_shown',
+          parameters: {'feature_key': featureKey, 'trigger': 'premium_plan_button'},
+        );
+        await showPremiumIntroductionSheet(context, source: paywallSource);
+      },
+    );
+  }
+}

--- a/lib/features/feature_appeal/quick_record/quick_record_help_page.dart
+++ b/lib/features/feature_appeal/quick_record/quick_record_help_page.dart
@@ -8,6 +8,7 @@ import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/feature_appeal/feature_appeal_premium_plan_button.dart';
 import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
@@ -128,30 +129,38 @@ class QuickRecordHelpPage extends ConsumerWidget {
       bottomNavigationBar: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: PrimaryButton(
-            text: L.featureAppealTryFeature,
-            onPressed: () async {
-              final user = ref.read(userProvider).requireValue;
-              analytics.logEvent(
-                name: 'feature_appeal_try_tapped',
-                parameters: {
-                  'feature_key': 'quick_record',
-                  'feature_type': 'premium',
-                  'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              PrimaryButton(
+                text: L.featureAppealTryFeature,
+                onPressed: () async {
+                  final user = ref.read(userProvider).requireValue;
+                  analytics.logEvent(
+                    name: 'feature_appeal_try_tapped',
+                    parameters: {
+                      'feature_key': 'quick_record',
+                      'feature_type': 'premium',
+                      'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+                    },
+                  );
+                  if (!user.premiumOrTrial) {
+                    analytics.logEvent(
+                      name: 'feature_appeal_paywall_shown',
+                      parameters: {'feature_key': 'quick_record', 'trigger': 'try'},
+                    );
+                    await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealQuickRecord);
+                    return;
+                  }
+                  final tabController = ref.read(homeTabControllerProvider);
+                  Navigator.of(context).popUntil((r) => r.isFirst);
+                  tabController?.animateTo(HomePageTabType.setting.index);
                 },
-              );
-              if (!user.premiumOrTrial) {
-                analytics.logEvent(
-                  name: 'feature_appeal_paywall_shown',
-                  parameters: {'feature_key': 'quick_record'},
-                );
-                await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealQuickRecord);
-                return;
-              }
-              final tabController = ref.read(homeTabControllerProvider);
-              Navigator.of(context).popUntil((r) => r.isFirst);
-              tabController?.animateTo(HomePageTabType.setting.index);
-            },
+              ),
+              const SizedBox(height: 8),
+              const FeatureAppealPremiumPlanButton(featureKey: 'quick_record', paywallSource: PaywallSource.featureAppealQuickRecord),
+            ],
           ),
         ),
       ),

--- a/lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart
+++ b/lib/features/feature_appeal/reminder_notification_customize_word/reminder_notification_customize_word_help_page.dart
@@ -6,6 +6,7 @@ import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
 import 'package:pilll/components/atoms/text_color.dart';
 import 'package:pilll/components/molecules/premium_badge.dart';
+import 'package:pilll/features/feature_appeal/feature_appeal_premium_plan_button.dart';
 import 'package:pilll/features/home/page.dart';
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
@@ -115,30 +116,41 @@ class ReminderNotificationCustomizeWordHelpPage extends ConsumerWidget {
       bottomNavigationBar: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: PrimaryButton(
-            text: L.featureAppealTryFeature,
-            onPressed: () async {
-              final user = ref.read(userProvider).requireValue;
-              analytics.logEvent(
-                name: 'feature_appeal_try_tapped',
-                parameters: {
-                  'feature_key': 'reminder_notification_customize_word',
-                  'feature_type': 'premium',
-                  'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              PrimaryButton(
+                text: L.featureAppealTryFeature,
+                onPressed: () async {
+                  final user = ref.read(userProvider).requireValue;
+                  analytics.logEvent(
+                    name: 'feature_appeal_try_tapped',
+                    parameters: {
+                      'feature_key': 'reminder_notification_customize_word',
+                      'feature_type': 'premium',
+                      'is_paywall_shown': !user.premiumOrTrial ? 1 : 0,
+                    },
+                  );
+                  if (!user.premiumOrTrial) {
+                    analytics.logEvent(
+                      name: 'feature_appeal_paywall_shown',
+                      parameters: {'feature_key': 'reminder_notification_customize_word', 'trigger': 'try'},
+                    );
+                    await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealReminderCustomize);
+                    return;
+                  }
+                  final tabController = ref.read(homeTabControllerProvider);
+                  Navigator.of(context).popUntil((r) => r.isFirst);
+                  tabController?.animateTo(HomePageTabType.setting.index);
                 },
-              );
-              if (!user.premiumOrTrial) {
-                analytics.logEvent(
-                  name: 'feature_appeal_paywall_shown',
-                  parameters: {'feature_key': 'reminder_notification_customize_word'},
-                );
-                await showPremiumIntroductionSheet(context, source: PaywallSource.featureAppealReminderCustomize);
-                return;
-              }
-              final tabController = ref.read(homeTabControllerProvider);
-              Navigator.of(context).popUntil((r) => r.isFirst);
-              tabController?.animateTo(HomePageTabType.setting.index);
-            },
+              ),
+              const SizedBox(height: 8),
+              const FeatureAppealPremiumPlanButton(
+                featureKey: 'reminder_notification_customize_word',
+                paywallSource: PaywallSource.featureAppealReminderCustomize,
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/features/initial_setting/QA.md
+++ b/lib/features/initial_setting/QA.md
@@ -1,8 +1,8 @@
 ---
 feature: initial_setting
 verification: mobile-mcp
-last_verified_commit: 34b7e05eb0ed73e5ee0caa2a91a96147e2edaded
-last_verified_at: 2026-07-05
+last_verified_commit: 21853fcbe3916b4509d34b8a00a3fac51298721c
+last_verified_at: 2026-09-11
 ---
 
 # initial_setting QA
@@ -135,6 +135,9 @@ last_verified_at: 2026-07-05
 - [x] **飲み忘れ通知の時刻設定**: 「ピルの飲み忘れ通知」の案内のもと3つの時刻設定枠が表示され、各枠をタップするとタイムピッカーがボトムシートで表示され、選択した時刻が枠に反映される
 - [x] **利用規約・プライバシーポリシーのリンク**: 画面下部の「プライバシーポリシー」「利用規約」リンクをタップすると、それぞれWebViewで該当ページが開く
 - [x] **「次へ」でプレミアム体験開始画面に遷移**: 「次へ」ボタンをタップするとプレミアム体験開始画面に遷移する
+- [x] **オンボーディング Paywall A/B (実験未参加)**: Remote Config `onboardingPaywallVariant` が未設定 (空文字) の場合、「次へ」で Paywall は表示されず現行どおりプレミアム体験開始画面に遷移する (割当イベント `onboarding_paywall_assigned` も送られない)
+- [ ] **オンボーディング Paywall A/B (paywall 群)**: `onboardingPaywallVariant` = `paywall` の場合、「次へ」で `onboarding_paywall_assigned {variant: paywall}` が送られ、`PremiumIntroductionSheet` (paywall_source = onboarding) が表示され、閉じるとプレミアム体験開始画面に遷移する
+  - ⏭️ スキップ: Remote Config の値は Firebase コンソールでしか設定できず、dev / prod のどちらにもパラメータ `onboardingPaywallVariant` が未作成のため、実験群の状態を端末で作れない。variant の解決は `flutter test test/features/initial_setting/onboarding_paywall_variant_test.dart` (6 件成功) で確認した。パラメータ作成後に `paywall` を配信して再確認する (bannzai/PilllBackend#422 のユーザー作業)
 
 #### 動作確認
 <details>
@@ -171,6 +174,27 @@ last_verified_at: 2026-07-05
 **確認日: 2026-07-05**
 
 <img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/bannzai/Pilll/20260705/5a8366b0-bfd4-4118-a6f5-715dfc393896.png" width="320">
+
+</details>
+
+### **オンボーディング Paywall A/B (実験未参加)**: Remote Config `onboardingPaywallVariant` が未設定 (空文字) の場合、「次へ」で Paywall は表示されず現行どおりプレミアム体験開始画面に遷移する (割当イベント `onboarding_paywall_assigned` も送られない)
+
+<details><summary>動作確認スクショ</summary>
+
+**確認日: 2026-09-11**
+
+新規アカウント (clearState) で初期設定を進め、リマインダー時刻設定 (3/3) の「次へ」をタップすると、Paywall を経由せずプレミアム体験開始画面に遷移した (dev の Remote Config にパラメータ未作成 = 空文字 = 実験未参加)。
+
+<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/7cbbb3a1-10e2-44c3-ae6b-c3a84b804aba-onboarding_reminder_times.png" width="320">
+<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/4784f921-6f0f-4d88-b7fd-c1ad087e4844-onboarding_after_next_control.png" width="320">
+
+</details>
+
+### **オンボーディング Paywall A/B (paywall 群)**: `onboardingPaywallVariant` = `paywall` の場合、「次へ」で `onboarding_paywall_assigned {variant: paywall}` が送られ、`PremiumIntroductionSheet` (paywall_source = onboarding) が表示され、閉じるとプレミアム体験開始画面に遷移する
+
+<details><summary>動作確認スクショ</summary>
+
+（未実行）
 
 </details>
 

--- a/lib/features/initial_setting/onboarding_paywall_variant.dart
+++ b/lib/features/initial_setting/onboarding_paywall_variant.dart
@@ -1,0 +1,35 @@
+/// オンボーディング内 Paywall 表示の A/B バリアント。
+/// Firebase Remote Config の `onboardingPaywallVariant` で配信される文字列に対応する。
+/// 割当は Firebase A/B Testing が行い、アプリはリマインダー時刻設定 (3/3) の「次へ」で
+/// `onboarding_paywall_assigned` イベントに variant を載せて記録する。
+enum OnboardingPaywallVariant {
+  /// 対照群: 現行フロー (initial_setting → premium_trial 紹介)
+  control,
+
+  /// 実験群: initial_setting 完了後、premium_trial 紹介前に Paywall (premium_introduction) を表示
+  paywall,
+}
+
+extension OnboardingPaywallVariantFunction on OnboardingPaywallVariant {
+  /// Firebase Analytics の variant パラメータ / Remote Config に対応する snake_case 文字列。
+  String get value {
+    switch (this) {
+      case OnboardingPaywallVariant.control:
+        return 'control';
+      case OnboardingPaywallVariant.paywall:
+        return 'paywall';
+    }
+  }
+}
+
+/// Remote Config の文字列値から variant を解決する。空文字・未知値は null (実験未参加。割当イベントも送らない)。
+OnboardingPaywallVariant? onboardingPaywallVariantFromRemoteConfig(String value) {
+  switch (value) {
+    case 'control':
+      return OnboardingPaywallVariant.control;
+    case 'paywall':
+      return OnboardingPaywallVariant.paywall;
+    default:
+      return null;
+  }
+}

--- a/lib/features/initial_setting/reminder_times/page.dart
+++ b/lib/features/initial_setting/reminder_times/page.dart
@@ -6,7 +6,9 @@ import 'package:pilll/features/initial_setting/premium_trial/page.dart';
 import 'package:pilll/features/initial_setting/initial_setting_state_notifier.dart';
 import 'package:pilll/features/premium_introduction/paywall_source.dart';
 import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
+import 'package:pilll/entity/remote_config_parameter.codegen.dart';
 import 'package:pilll/provider/remote_config_parameter.dart';
+import 'package:pilll/utils/remote_config.dart';
 import 'package:pilll/components/atoms/button.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
@@ -27,7 +29,6 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(initialSettingStateNotifierProvider.notifier);
     final state = ref.watch(initialSettingStateNotifierProvider);
-    final onboardingPaywallVariant = onboardingPaywallVariantFromRemoteConfig(ref.watch(remoteConfigParameterProvider).onboardingPaywallVariant);
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -152,6 +153,15 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
                         );
                         // A/B テスト (PilllBackend issue #417): 群の割当をここで計測し、実験群には premium_trial 紹介の前に Paywall を出す。
                         // 対照群も割当イベントを送ることで、BigQuery で群間のトライアル開始率・転換率を比較できる。
+                        // 初回起動では setupRemoteConfig の fetchAndActivate を待たずに画面が進み、remoteConfigParameterProvider は
+                        // 起動直後の値 (未取得なら既定の空文字) を保持し続けるため、provider ではなくタップ時点の Remote Config を直接読む。
+                        // provider を invalidate すると、それを watch する initialSettingStateNotifierProvider の入力状態が消えるので使わない。
+                        final onboardingPaywallVariant = onboardingPaywallVariantFromRemoteConfig(
+                          remoteConfig.getStringOrDefault(
+                            RemoteConfigKeys.onboardingPaywallVariant,
+                            RemoteConfigParameterDefaultValues.onboardingPaywallVariant,
+                          ),
+                        );
                         if (onboardingPaywallVariant != null) {
                           analytics.logEvent(
                             name: 'onboarding_paywall_assigned',

--- a/lib/features/initial_setting/reminder_times/page.dart
+++ b/lib/features/initial_setting/reminder_times/page.dart
@@ -1,8 +1,12 @@
 import 'package:pilll/features/localizations/l.dart';
 import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/features/initial_setting/initial_setting_state.codegen.dart';
+import 'package:pilll/features/initial_setting/onboarding_paywall_variant.dart';
 import 'package:pilll/features/initial_setting/premium_trial/page.dart';
 import 'package:pilll/features/initial_setting/initial_setting_state_notifier.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
+import 'package:pilll/features/premium_introduction/premium_introduction_sheet.dart';
+import 'package:pilll/provider/remote_config_parameter.dart';
 import 'package:pilll/components/atoms/button.dart';
 import 'package:pilll/components/atoms/color.dart';
 import 'package:pilll/components/atoms/font.dart';
@@ -23,6 +27,7 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(initialSettingStateNotifierProvider.notifier);
     final state = ref.watch(initialSettingStateNotifierProvider);
+    final onboardingPaywallVariant = onboardingPaywallVariantFromRemoteConfig(ref.watch(remoteConfigParameterProvider).onboardingPaywallVariant);
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -145,6 +150,18 @@ class InitialSettingReminderTimesPage extends HookConsumerWidget {
                         analytics.logEvent(
                           name: 'next_initial_setting_reminder_times',
                         );
+                        // A/B テスト (PilllBackend issue #417): 群の割当をここで計測し、実験群には premium_trial 紹介の前に Paywall を出す。
+                        // 対照群も割当イベントを送ることで、BigQuery で群間のトライアル開始率・転換率を比較できる。
+                        if (onboardingPaywallVariant != null) {
+                          analytics.logEvent(
+                            name: 'onboarding_paywall_assigned',
+                            parameters: {'variant': onboardingPaywallVariant.value},
+                          );
+                        }
+                        if (onboardingPaywallVariant == OnboardingPaywallVariant.paywall) {
+                          await showPremiumIntroductionSheet(context, source: PaywallSource.onboarding);
+                        }
+                        if (!context.mounted) return;
                         Navigator.of(context).push(
                           IntiialSettingPremiumTrialStartPageRoute.route(),
                         );

--- a/lib/features/premium_introduction/paywall_source.dart
+++ b/lib/features/premium_introduction/paywall_source.dart
@@ -36,6 +36,9 @@ enum PaywallSource {
   lifetimeOfferAppLaunch,
   endedPillSheetDialogHistory,
   endedPillSheetDialogSummary,
+
+  /// オンボーディング (initial_setting) 完了直後・premium_trial 紹介前に表示する A/B テスト用 paywall
+  onboarding,
 }
 
 extension PaywallSourceFunction on PaywallSource {
@@ -101,6 +104,8 @@ extension PaywallSourceFunction on PaywallSource {
         return 'ended_pill_sheet_dialog_history';
       case PaywallSource.endedPillSheetDialogSummary:
         return 'ended_pill_sheet_dialog_summary';
+      case PaywallSource.onboarding:
+        return 'onboarding';
     }
   }
 }

--- a/lib/provider/remote_config_parameter.dart
+++ b/lib/provider/remote_config_parameter.dart
@@ -74,6 +74,10 @@ RemoteConfigParameter remoteConfigParameter(RemoteConfigParameterRef ref) {
       RemoteConfigKeys.endedPillSheetDialogVariant,
       RemoteConfigParameterDefaultValues.endedPillSheetDialogVariant,
     ),
+    onboardingPaywallVariant: remoteConfig.getStringOrDefault(
+      RemoteConfigKeys.onboardingPaywallVariant,
+      RemoteConfigParameterDefaultValues.onboardingPaywallVariant,
+    ),
   );
 }
 

--- a/lib/provider/remote_config_parameter.g.dart
+++ b/lib/provider/remote_config_parameter.g.dart
@@ -6,7 +6,7 @@ part of 'remote_config_parameter.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$remoteConfigParameterHash() => r'b1c92c35885cfa20dd9d093446a3d25a1ecd93b4';
+String _$remoteConfigParameterHash() => r'984e3cc31bca3e5a7a31625c435cff33be359d9d';
 
 /// See also [remoteConfigParameter].
 @ProviderFor(remoteConfigParameter)

--- a/lib/utils/remote_config.dart
+++ b/lib/utils/remote_config.dart
@@ -37,6 +37,7 @@ Future<void> setupRemoteConfig() async {
         RemoteConfigKeys.lifetimeOfferDurationHours: RemoteConfigParameterDefaultValues.lifetimeOfferDurationHours,
         RemoteConfigKeys.lifetimeOfferCopyVariant: RemoteConfigParameterDefaultValues.lifetimeOfferCopyVariant,
         RemoteConfigKeys.endedPillSheetDialogVariant: RemoteConfigParameterDefaultValues.endedPillSheetDialogVariant,
+        RemoteConfigKeys.onboardingPaywallVariant: RemoteConfigParameterDefaultValues.onboardingPaywallVariant,
       }),
     ).wait;
     // 項目が増えて来てfetchが重たくなっていてアプリが開かない説があるので非同期にする。計測はしてない。since: 2025-06-25

--- a/test/features/feature_appeal/alarm_kit/alarm_kit_help_page_test.dart
+++ b/test/features/feature_appeal/alarm_kit/alarm_kit_help_page_test.dart
@@ -3,16 +3,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:pilll/components/atoms/button.dart';
 import 'package:pilll/entity/setting.codegen.dart';
+import 'package:mockito/mockito.dart';
 import 'package:pilll/entity/user.codegen.dart';
 import 'package:pilll/features/feature_appeal/alarm_kit/alarm_kit_help_page.dart';
+import 'package:pilll/features/feature_appeal/feature_appeal_premium_plan_button.dart';
 import 'package:pilll/provider/setting.dart';
 import 'package:pilll/provider/user.dart';
+import 'package:pilll/utils/datetime/day.dart';
+
+import '../../../helper/mock.mocks.dart';
 
 void main() {
   group('#AlarmKitHelpPage', () {
-    List<Override> helpPageProviderOverrides() {
+    List<Override> helpPageProviderOverrides({User user = const User()}) {
       return [
-        userProvider.overrideWith((ref) => Stream.value(const User())),
+        userProvider.overrideWith((ref) => Stream.value(user)),
         settingProvider.overrideWith(
           (ref) => Stream.value(
             const Setting(
@@ -61,6 +66,38 @@ void main() {
 
       expect(find.byType(AppBar), findsOneWidget);
       expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+    });
+
+    testWidgets('トライアル中ユーザー → 「確認する」の下に Premium プランへの導線 (AppOutlinedButton) が表示される', (tester) async {
+      final mockTodayRepository = MockTodayService();
+      final mockToday = DateTime(2026, 9, 10);
+      when(mockTodayRepository.now()).thenReturn(mockToday);
+      todayRepository = mockTodayRepository;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: helpPageProviderOverrides(user: User(isPremium: false, trialDeadlineDate: mockToday.add(const Duration(days: 10)))),
+          child: const MaterialApp(home: AlarmKitHelpPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FeatureAppealPremiumPlanButton), findsOneWidget);
+      expect(find.byType(PrimaryButton), findsOneWidget);
+      expect(find.byType(AppOutlinedButton), findsOneWidget);
+    });
+
+    testWidgets('トライアル未開始ユーザー (User()) → Premium プランへの導線は出ず「確認する」だけ', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: helpPageProviderOverrides(),
+          child: const MaterialApp(home: AlarmKitHelpPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PrimaryButton), findsOneWidget);
+      expect(find.byType(AppOutlinedButton), findsNothing);
     });
   });
 }

--- a/test/features/feature_appeal/feature_appeal_bars_container_test.dart
+++ b/test/features/feature_appeal/feature_appeal_bars_container_test.dart
@@ -19,16 +19,51 @@ import 'package:pilll/features/feature_appeal/reminder_notification_customize_wo
 import 'package:pilll/features/feature_appeal/rest_duration/rest_duration_announcement_bar.dart';
 import 'package:pilll/features/feature_appeal/today_pill_number/today_pill_number_announcement_bar.dart';
 import 'package:pilll/provider/shared_preferences.dart';
+import 'package:pilll/utils/analytics.dart';
 import 'package:pilll/utils/datetime/day.dart';
 import 'package:pilll/utils/shared_preference/keys.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../helper/fake.dart';
 import '../../helper/mock.mocks.dart';
 
 /// FeatureAppealBarsContainer 内部と同じ epoch。テストで index を予測するために使う。
 final DateTime _featureAppealEpoch = DateTime(2024, 1, 1);
 
 void main() {
+  setUp(() {
+    // 表示時に feature_appeal_bar_shown を送るため、Firebase 未初期化のテストで例外にならないよう Fake に差し替える
+    analytics = FakeAnalytics();
+  });
+
+  group('#weightedRotationOrder', () {
+    test('重み [A:3, B:1, C:2] → 周回ごとに候補を散らした [A, B, C, A, C, A] になる', () {
+      expect(
+        weightedRotationOrder(weightedCandidates: [(candidate: 'A', weight: 3), (candidate: 'B', weight: 1), (candidate: 'C', weight: 2)]),
+        ['A', 'B', 'C', 'A', 'C', 'A'],
+      );
+    });
+
+    test('全候補が重み 1 → 候補の並びそのまま (従来の均等ローテーションと同じ)', () {
+      expect(
+        weightedRotationOrder(weightedCandidates: [(candidate: 'A', weight: 1), (candidate: 'B', weight: 1), (candidate: 'C', weight: 1)]),
+        ['A', 'B', 'C'],
+      );
+    });
+
+    test('候補が空 → 空リスト', () {
+      expect(weightedRotationOrder<String>(weightedCandidates: []), isEmpty);
+    });
+
+    test('表示順の長さは重みの合計に一致し、各候補は重みの回数だけ現れる', () {
+      final order = weightedRotationOrder(weightedCandidates: [(candidate: 'A', weight: 3), (candidate: 'B', weight: 1), (candidate: 'C', weight: 2)]);
+      expect(order.length, 6);
+      expect(order.where((candidate) => candidate == 'A').length, 3);
+      expect(order.where((candidate) => candidate == 'B').length, 1);
+      expect(order.where((candidate) => candidate == 'C').length, 2);
+    });
+  });
+
   group('#hasAnyCandidate', () {
     test('prefs 空 → 候補があるので true を返す', () async {
       SharedPreferences.setMockInitialValues({});
@@ -184,26 +219,96 @@ void main() {
   });
 
   group('#FeatureAppealBarsContainer', () {
-    /// 候補リスト (本実装と同じ並び順) のうち、appIsReleased=true で全件存在する状態を想定。
+    /// 本実装と同じ候補の並び順・重みで組んだ表示順 (weightedRotationOrder) のうち、appIsReleased=true で全件存在する状態を想定。
     /// CriticalAlert / AlarmKit は Platform.isIOS=true の時だけ候補に含まれる。
-    /// テストでは today を任意に固定して daysBetween(epoch, today) % candidates.length が想定の Bar に一致するかを確認する。
+    /// テストでは today を任意に固定して daysBetween(epoch, today) % 表示順の長さ が想定の Bar に一致するかを確認する。
     Type expectedBarTypeForIndex(int index) {
-      return [
-        QuickRecordAnnouncementBar,
-        ReminderNotificationCustomizeWordAnnouncementBar,
-        RestDurationAnnouncementBar,
-        if (Platform.isIOS) CriticalAlertAnnouncementBar,
-        AppearanceModeDateAnnouncementBar,
-        RecordPillAnnouncementBar,
-        MenstruationAnnouncementBar,
-        CalendarDiaryAnnouncementBar,
-        FutureScheduleAnnouncementBar,
-        HealthCareIntegrationAnnouncementBar,
-        CreatingNewPillSheetAnnouncementBar,
-        if (Platform.isIOS) AlarmKitAnnouncementBar,
-        TodayPillNumberAnnouncementBar,
-      ][index];
+      return weightedRotationOrder(
+        weightedCandidates: [
+          (candidate: QuickRecordAnnouncementBar, weight: FeatureAppealBarWeight.highConversion),
+          (candidate: ReminderNotificationCustomizeWordAnnouncementBar, weight: FeatureAppealBarWeight.noConversion),
+          (candidate: RestDurationAnnouncementBar, weight: FeatureAppealBarWeight.noConversion),
+          if (Platform.isIOS) (candidate: CriticalAlertAnnouncementBar, weight: FeatureAppealBarWeight.noConversion),
+          (candidate: AppearanceModeDateAnnouncementBar, weight: FeatureAppealBarWeight.someConversion),
+          (candidate: RecordPillAnnouncementBar, weight: FeatureAppealBarWeight.noConversion),
+          (candidate: MenstruationAnnouncementBar, weight: FeatureAppealBarWeight.someConversion),
+          (candidate: CalendarDiaryAnnouncementBar, weight: FeatureAppealBarWeight.noConversion),
+          (candidate: FutureScheduleAnnouncementBar, weight: FeatureAppealBarWeight.someConversion),
+          (candidate: HealthCareIntegrationAnnouncementBar, weight: FeatureAppealBarWeight.highConversion),
+          (candidate: CreatingNewPillSheetAnnouncementBar, weight: FeatureAppealBarWeight.noConversion),
+          if (Platform.isIOS) (candidate: AlarmKitAnnouncementBar, weight: FeatureAppealBarWeight.highConversion),
+          (candidate: TodayPillNumberAnnouncementBar, weight: FeatureAppealBarWeight.noConversion),
+        ],
+      )[index];
     }
+
+    testWidgets('2 周目 (全候補を一巡した翌日) は重み 2 以上の候補だけが表示される', (tester) async {
+      final mockTodayRepository = MockTodayService();
+      // 非 iOS で 1 周目は 11 候補。epoch+11 日 → 2 周目の先頭 = 重み 3 の QuickRecord
+      when(mockTodayRepository.now()).thenReturn(_featureAppealEpoch.add(const Duration(days: 11)));
+      todayRepository = mockTodayRepository;
+
+      SharedPreferences.setMockInitialValues({});
+      final sharedPreferences = await SharedPreferences.getInstance();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
+          ],
+          child: MaterialApp(
+            home: Material(
+              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(false)),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(expectedBarTypeForIndex(11)), findsOneWidget);
+      expect(find.byType(QuickRecordAnnouncementBar), findsOneWidget);
+      expect(find.byType(ReminderNotificationCustomizeWordAnnouncementBar), findsNothing);
+    });
+
+    testWidgets('3 周目の末尾 (表示順の最終日) は重み 3 の HealthCareIntegration が表示され、翌日は先頭に戻る', (tester) async {
+      final mockTodayRepository = MockTodayService();
+      // 非 iOS: 1 周目 11 + 2 周目 5 (QuickRecord / AppearanceModeDate / Menstruation / FutureSchedule / HealthCare) + 3 周目 2 (QuickRecord / HealthCare) = 18
+      when(mockTodayRepository.now()).thenReturn(_featureAppealEpoch.add(const Duration(days: 17)));
+      todayRepository = mockTodayRepository;
+
+      SharedPreferences.setMockInitialValues({});
+      final sharedPreferences = await SharedPreferences.getInstance();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
+          ],
+          child: MaterialApp(
+            home: Material(
+              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(false)),
+            ),
+          ),
+        ),
+      );
+      expect(find.byType(expectedBarTypeForIndex(17)), findsOneWidget);
+      expect(find.byType(HealthCareIntegrationAnnouncementBar), findsOneWidget);
+
+      when(mockTodayRepository.now()).thenReturn(_featureAppealEpoch.add(const Duration(days: 18)));
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWith((ref) => sharedPreferences),
+          ],
+          child: MaterialApp(
+            home: Material(
+              child: FeatureAppealBarsContainer(appIsReleased: true, dismissedToday: ValueNotifier(false)),
+            ),
+          ),
+        ),
+      );
+      expect(find.byType(expectedBarTypeForIndex(0)), findsOneWidget);
+      expect(find.byType(QuickRecordAnnouncementBar), findsOneWidget);
+    });
 
     testWidgets('prefs 空 + appIsReleased=true → 当日 index に対応する Bar が表示される',
         (tester) async {
@@ -322,7 +427,7 @@ void main() {
       );
 
       // Platform.isIOS=false (macOS/Linux) かつ appIsReleased=false で候補は 10 件。
-      // 並び順: QuickRecord / Reminder / RestDuration / RecordPill / Menstruation / ...
+      // 1 周目の並び順: QuickRecord / Reminder / RestDuration / RecordPill / Menstruation / ...
       // epoch+2 日 → daysBetween=2 → index 2 = RestDuration。
       expect(find.byType(AppearanceModeDateAnnouncementBar), findsNothing);
       expect(find.byType(RestDurationAnnouncementBar), findsOneWidget);

--- a/test/features/feature_appeal/feature_appeal_premium_plan_button_test.dart
+++ b/test/features/feature_appeal/feature_appeal_premium_plan_button_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mockito/mockito.dart';
+import 'package:pilll/components/atoms/button.dart';
+import 'package:pilll/entity/user.codegen.dart';
+import 'package:pilll/features/feature_appeal/feature_appeal_premium_plan_button.dart';
+import 'package:pilll/features/premium_introduction/paywall_source.dart';
+import 'package:pilll/provider/user.dart';
+import 'package:pilll/utils/analytics.dart';
+import 'package:pilll/utils/datetime/day.dart';
+
+import '../../helper/fake.dart';
+import '../../helper/mock.mocks.dart';
+
+void main() {
+  final mockToday = DateTime(2026, 9, 10);
+
+  setUp(() {
+    analytics = FakeAnalytics();
+    final mockTodayRepository = MockTodayService();
+    when(mockTodayRepository.now()).thenReturn(mockToday);
+    todayRepository = mockTodayRepository;
+  });
+
+  Widget subject({required User user}) {
+    return ProviderScope(
+      overrides: [
+        userProvider.overrideWith((ref) => Stream.value(user)),
+      ],
+      child: const MaterialApp(
+        home: Material(
+          child: FeatureAppealPremiumPlanButton(featureKey: 'alarm_kit', paywallSource: PaywallSource.featureAppealAlarmKit),
+        ),
+      ),
+    );
+  }
+
+  group('#FeatureAppealPremiumPlanButton', () {
+    testWidgets('トライアル中 (isPremium=false, trialDeadlineDate が未来) → AppOutlinedButton が表示される', (tester) async {
+      await tester.pumpWidget(subject(user: User(isPremium: false, trialDeadlineDate: mockToday.add(const Duration(days: 10)))));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AppOutlinedButton), findsOneWidget);
+    });
+
+    testWidgets('トライアル終了後の無料ユーザー (trialDeadlineDate が過去) → 「確認する」が paywall を開くため表示しない', (tester) async {
+      await tester.pumpWidget(subject(user: User(isPremium: false, trialDeadlineDate: mockToday.subtract(const Duration(days: 1)))));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AppOutlinedButton), findsNothing);
+    });
+
+    testWidgets('トライアル未開始 (trialDeadlineDate=null) → 表示しない', (tester) async {
+      await tester.pumpWidget(subject(user: const User(isPremium: false, trialDeadlineDate: null)));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AppOutlinedButton), findsNothing);
+    });
+
+    testWidgets('Premium 会員 (トライアル期間内でも) → 表示しない', (tester) async {
+      await tester.pumpWidget(subject(user: User(isPremium: true, trialDeadlineDate: mockToday.add(const Duration(days: 10)))));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AppOutlinedButton), findsNothing);
+    });
+  });
+}

--- a/test/features/initial_setting/onboarding_paywall_variant_test.dart
+++ b/test/features/initial_setting/onboarding_paywall_variant_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pilll/features/initial_setting/onboarding_paywall_variant.dart';
+
+void main() {
+  group('#onboardingPaywallVariantFromRemoteConfig', () {
+    test("'control' → control", () {
+      expect(onboardingPaywallVariantFromRemoteConfig('control'), OnboardingPaywallVariant.control);
+    });
+
+    test("'paywall' → paywall", () {
+      expect(onboardingPaywallVariantFromRemoteConfig('paywall'), OnboardingPaywallVariant.paywall);
+    });
+
+    test('空文字 (Remote Config 未設定・実験未参加) → null', () {
+      expect(onboardingPaywallVariantFromRemoteConfig(''), isNull);
+    });
+
+    test('未知の値 → null (現行フローにフォールバック)', () {
+      expect(onboardingPaywallVariantFromRemoteConfig('unknown'), isNull);
+    });
+  });
+
+  group('#OnboardingPaywallVariantFunction', () {
+    test('value は Remote Config / Analytics の variant パラメータと一致する', () {
+      expect(OnboardingPaywallVariant.control.value, 'control');
+      expect(OnboardingPaywallVariant.paywall.value, 'paywall');
+    });
+
+    test('全 variant の value から元の variant に戻せる (Remote Config の値と 1:1)', () {
+      for (final variant in OnboardingPaywallVariant.values) {
+        expect(onboardingPaywallVariantFromRemoteConfig(variant.value), variant);
+      }
+    });
+  });
+}

--- a/test/features/premium_introduction/paywall_source_test.dart
+++ b/test/features/premium_introduction/paywall_source_test.dart
@@ -21,6 +21,7 @@ void main() {
           'ended_pill_sheet_dialog_history');
       expect(PaywallSource.endedPillSheetDialogSummary.value,
           'ended_pill_sheet_dialog_summary');
+      expect(PaywallSource.onboarding.value, 'onboarding');
     });
   });
 }


### PR DESCRIPTION
## Abstract

FeatureAppeal 分析 (bannzai/PilllBackend#373) を反映した課金導線の改善 (bannzai/PilllBackend#417) の Flutter 側。

### 1. FeatureAppeal Bar の露出を転換実績に基づく重み付きローテーションにする

- `feature_appeal_bars_container.dart`: 均等ローテーション (`daysBetween(epoch, today) % candidates.length`) を、`FeatureAppealBarWeight` (3 / 2 / 1) で重み付けした表示順 `weightedRotationOrder` に対する `daysBetween(epoch, today) % 表示順の長さ` に変更
  - 重み 3: alarm_kit / health_care_integration / quick_record (トライアル 30 日転換率 25.0% / 18.2% / 14.3%)
  - 重み 2: future_schedule / menstruation / appearance_mode_date (転換あり)
  - 重み 1: 転換 0 の 7 機能 (rest_duration / creating_new_pillsheet / record_pill / today_pill_number / reminder_notification_customize_word / calendar_diary / critical_alert)。表示廃止ではなく頻度を下げて測定を続ける
  - 表示順は「全候補を一巡 → 重みが残る候補だけで一巡 → ...」と周回ごとに候補を散らし、同じ Bar が連日続かないようにする (例: 重み [A:3, B:1, C:2] → A, B, C, A, C, A)。全候補ありの iOS では 1 周期 22 日、非 iOS では 18 日
  - `_featureAppealEpoch` は変更しない。重みを付けた時点で「今日表示される Bar」は必然的に変わるため、既存ユーザーの互換性は epoch を保つことで「切替日以降の並びが端末間で一致する」ところまでを担保する
  - 表示分布を BigQuery で検証できるよう、表示する Bar が変わった時に `feature_appeal_bar_shown` (`feature_key` / `feature_type` / `weight` / `rotation_length`) を送る

### 2. try → paywall の導線

- Premium 機能の 6 つの HelpPage (alarm_kit / quick_record / critical_alert / appearance_mode_date / creating_new_pillsheet / reminder_notification_customize_word) の「確認する」の下に `FeatureAppealPremiumPlanButton` (「プレミアムプランを見る」、既存の `L.viewPremiumPlan`) を追加
  - 「確認する」はトライアル中ユーザーには機能画面 (タブ) へ遷移して paywall に到達しない (try 後 paywall 未到達 667 人の主因)。トライアル中 (isTrial かつ非 Premium) のユーザーにだけ表示し、機能を試す前後どちらでも paywall へ進める入口にする
  - 無料ユーザーは「確認する」自体が paywall を開くため表示しない。Premium 会員にも表示しない
  - タップで `feature_appeal_paywall_shown` (`feature_key`, `trigger: premium_plan_button`) を送り、各機能の既存 `PaywallSource` で `PremiumIntroductionSheet` を開く。「確認する」経由の `feature_appeal_paywall_shown` には `trigger: try` を付けて区別する (既存の funnel クエリはパラメータ追加の影響を受けない)

### 3. オンボーディング内 Paywall 表示の A/B テスト

- Remote Config `onboardingPaywallVariant` (文字列。`control` / `paywall` / `''` = 実験未参加) を追加 (`RemoteConfigKeys` / `RemoteConfigParameterDefaultValues` / `RemoteConfigParameter` / provider / `setDefaults`)
- `initial_setting/reminder_times/page.dart` の「次へ」で、variant が設定されていれば `onboarding_paywall_assigned {variant}` を送り (対照群も送って群間比較の分母にする)、`paywall` なら premium_trial 紹介ページへ進む前に `showPremiumIntroductionSheet(source: PaywallSource.onboarding)` を表示する
- `PaywallSource.onboarding` (`'onboarding'`) を追加。既存の `paywall_viewed` / `pressed_*_purchase_button` / `purchase_succeeded` で群の購入行動を追跡できる
- 割当は Firebase A/B Testing で行う (パラメータ作成と実験開始はユーザー作業。bannzai/PilllBackend#422 に記録済み)

## Why

bannzai/PilllBackend#373 の分析 (2026-09-01) で、転換に効く機能 (alarm_kit / health_care_integration / quick_record) と露出が多いだけの機能 (rest_duration 等) が分かれ、ファネル離脱は paywall 手前 (tap→try 661 人、try→paywall 667 人) に集中していた。露出を転換実績に寄せ、トライアル中ユーザーが paywall に接続できる入口を作り、オンボーディングでの Paywall 提示を A/B で検証する。

## Links

- Issue: https://github.com/bannzai/PilllBackend/issues/417
- 分析結果: https://github.com/bannzai/PilllBackend/issues/373#issuecomment-5491959910
- BigQuery 側 PR (view の更新・効果測定クエリ): https://github.com/bannzai/PilllBackend/pull/453
- ユーザー作業 (Remote Config パラメータ作成・A/B テスト開始・view デプロイ): https://github.com/bannzai/PilllBackend/issues/422#issuecomment-5625689236

## 検証

- `flutter pub run build_runner build --delete-conflicting-outputs` → `dart format lib` (CI と同じ手順。生成ファイルの差分をコミット済み)
- `flutter analyze --no-pub --no-fatal-infos --fatal-warnings`: exit 0 (info 118 件は既存のもの)
- `flutter test`: 1642 件 pass (1 件は既存の skip)
  - 追加・更新: `weightedRotationOrder` の単体テスト、`FeatureAppealBarsContainer` の 2 周目 / 3 周目末尾 / 折り返しの表示、`FeatureAppealPremiumPlanButton` の表示条件 (トライアル中 / 終了後 / 未開始 / Premium)、`AlarmKitHelpPage` でのボタン有無、`OnboardingPaywallVariant` の解決、`PaywallSource.onboarding`
- 動作確認 (ローカル iOS Simulator `pilll-無名-iOS26.5`、dev 環境、Maestro で操作): 下記スクリーンショット。記録は `lib/features/feature_appeal/QA.md` / `lib/features/initial_setting/QA.md`
  - ホーム画面の FeatureAppeal Bar が future_schedule (2026-09-11 = epoch から 984 日 → 984 % 22 = 16 → 2 周目の重み 2 の候補) で、重み付き表示順と一致
  - トライアル中ユーザーの AlarmKit HelpPage に「プレミアムプランを見る」が表示され、タップで PremiumIntroductionSheet が開く
  - 新規アカウントのオンボーディングで、Remote Config 未設定 (実験未参加) では「次へ」→ プレミアム体験開始画面 (現行フロー)
  - simtunnel (リモート Simulator) は Tailscale の OIDC 認証が `token exchange failed with status 404` で失敗し使えなかったため (2026-09-06 の run も同じ失敗。bannzai/PilllBackend#422 に記録)、ios-simulator skill の「caller workflow の導入が未完了」条件でローカル sim-boot に倒した
  - 未検証: オンボーディング Paywall の実験群 (`paywall`) の表示。Remote Config の値は Firebase コンソールでしか設定できず、dev / prod いずれのプロジェクトにもパラメータが未作成のため。分岐のロジックは `onboarding_paywall_variant_test.dart` と、既定値 `''` で現行フローのままであることの動作確認でカバーする
  - 未検証: `feature_appeal_bar_shown` の BigQuery 着弾 (リリース後に PilllBackend の `feature_appeal_bar_exposure.sql` で確認)

<!-- screenshots begin -->
<!-- screenshot key="home_after_onboarding_trial.png" sha256="fe301bf5d5bcc9e76e56001e6216647086d7c180f55f9aa9886f6b2ecbda7d92" url="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/af689445-e66b-48a2-9834-1a53a068b59d-home_after_onboarding_trial.png" -->

ホーム &#40;重み付きローテーションで future&#95;schedule の Bar&#41;

<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/af689445-e66b-48a2-9834-1a53a068b59d-home_after_onboarding_trial.png" alt="ホーム (重み付きローテーションで future_schedule の Bar)" width="320">

ホーム &#40;重み付きローテーションで future&#95;schedule の Bar&#41;

<!-- screenshot key="help_page_alarm_kit_trial.png" sha256="b933411f0f266d6a6a4c8861d82f2a65ba2958c251a24b676144fd7fff1098bb" url="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/7ed2ae90-ec65-4698-8b3d-1d24cd9e853c-help_page_alarm_kit_trial.png" -->

AlarmKit HelpPage &#40;トライアル中: プレミアムプランを見る&#41;

<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/7ed2ae90-ec65-4698-8b3d-1d24cd9e853c-help_page_alarm_kit_trial.png" alt="AlarmKit HelpPage (トライアル中: プレミアムプランを見る)" width="320">

AlarmKit HelpPage &#40;トライアル中: プレミアムプランを見る&#41;

<!-- screenshot key="help_page_alarm_kit_paywall.png" sha256="aed22ece0087fd374acca9dd7ea61f1170058adeb3962304c71aaf036d101f07" url="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/4a389084-f00c-4375-b072-6d8db1f27174-help_page_alarm_kit_paywall.png" -->

プレミアムプランを見る → PremiumIntroductionSheet

<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/4a389084-f00c-4375-b072-6d8db1f27174-help_page_alarm_kit_paywall.png" alt="プレミアムプランを見る → PremiumIntroductionSheet" width="320">

プレミアムプランを見る → PremiumIntroductionSheet

<!-- screenshot key="onboarding_reminder_times.png" sha256="935870a68fbb370bee748c1cd1452cc5921557c4f2774569aac926892790a57f" url="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/d3688cf5-c3bc-40af-9ecf-25151a05451c-onboarding_reminder_times.png" -->

オンボーディング 3/3 リマインダー時刻設定

<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/d3688cf5-c3bc-40af-9ecf-25151a05451c-onboarding_reminder_times.png" alt="オンボーディング 3/3 リマインダー時刻設定" width="320">

オンボーディング 3/3 リマインダー時刻設定

<!-- screenshot key="onboarding_after_next_control.png" sha256="25f3b5de667d46255e65e9288d0e6f768f2718fda7e269f70c4cdf39461b9a67" url="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/e77f6bbe-ae79-4b21-b348-6062c4be0028-onboarding_after_next_control.png" -->

次へ → プレミアム体験開始画面 &#40;実験未参加: Paywall なし&#41;

<img src="https://pub-7f3469dd3e2e445b9b8ec2d1381b5ea8.r2.dev/2026/09/10/e77f6bbe-ae79-4b21-b348-6062c4be0028-onboarding_after_next_control.png" alt="次へ → プレミアム体験開始画面 (実験未参加: Paywall なし)" width="320">

次へ → プレミアム体験開始画面 &#40;実験未参加: Paywall なし&#41;


<!-- screenshots end -->

## Checked
- [ ] Analyticsのログを入れたか
- [ ] 境界値に対してのUnitTestを書いた
- [ ] パターン分岐が発生するWidgetに対してWidgetTestを書いた

<!-- codex-local-review:start -->
## Codex ローカルレビュー
<!-- codex-local-review: head=bd1f1644a786e83412aa7d491840045562cca696 status=clean scope=base:origin/main model=gpt-6-astra effort=medium rounds=3 -->
- 対象: origin/main...bd1f164 (PR #1866)
- モデル / effort: gpt-6-astra / medium (complex: feature_appeal / initial_setting / premium_introduction / entity / provider を跨ぐ変更)
- ラウンド: 3 (最終ラウンドの指摘 0 件。3 ラウンド目は QA.md の記録 commit を含む head で再実行)
- 修正した指摘: 1 件 (本文は commit message に記録)
  - ラウンド 1 [P2]: オンボーディング Paywall の variant を、起動直後の値を保持し続ける remoteConfigParameterProvider ではなくタップ時点の Remote Config から読む
- reject した指摘: 0 件
<!-- codex-local-review:end -->

## 人間が確認

なし

## セッション再開

```sh
cd /Users/bannzai/ghq/github.com/bannzai/Pilll
claude --resume b91821ec-370b-42f1-a89e-9b1a653c5a55
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - オンボーディング中のペイウォール表示にA/Bテストを導入しました。
  - 試用期間中のユーザーに、プレミアムプラン紹介への導線を追加しました。
  - オンボーディング経由のペイウォール表示に対応しました。

- **改善**
  - 機能紹介バーを転換実績に基づく重み付きローテーションで表示するよう変更しました。
  - ペイウォールや機能紹介バーの表示状況を分析できるようイベント情報を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
