### PR TITLE
fix(flutter-deploy): flavor 別の secret を GITHUB_ENV ではなく job の env で選ぶ

### DIFF
--- a/.github/workflows/flutter-deploy.yml
+++ b/.github/workflows/flutter-deploy.yml
@@ -371,7 +371,7 @@ jobs:
           echo "keystore: $SIZE bytes"
           [ "$SIZE" -gt 100 ] || { echo "::error::keystore が $SIZE bytes しかありません。ANDROID_KEYSTORE_JKS_BASE64 が壊れています"; exit 1; }
           keytool -list -keystore "$ANDROID_KEYSTORE_PATH" -storepass "$ANDROID_KEYSTORE_PASSWORD" -alias "$ANDROID_KEYSTORE_ALIAS" > /dev/null \
-            || { echo "::error::keystore を ANDROID_KEYSTORE_PASSWORD / ANDROID_KEYSTORE_ALIAS で開けません。Bitrise の Secrets と同じ値か確認してください"; exit 1; }
+            || { echo "::error::keystore を ANDROID_KEYSTORE_PASSWORD / ANDROID_KEYSTORE_ALIAS で開けません。Secret の値を登録し直してください"; exit 1; }
 
       - run: make secret
 

--- a/.github/workflows/flutter-deploy.yml
+++ b/.github/workflows/flutter-deploy.yml
@@ -16,6 +16,10 @@ name: flutter-deploy
 # 原因を直して workflow_dispatch で新しく起動する (アップロードより前で失敗した run は Re-run してよい)。
 #
 # Makefile の `base64 -D` は macOS の書式のため、Android の job も macOS runner で実行する (ci.yml と同じ)。
+#
+# flavor 別の secret は job の env で `matrix.flavor == 'dev' && secrets.X_DEV || secrets.X_PROD` の形で選ぶ。
+# GITHUB_ENV 経由で secret の値を後続 step に渡す方式は、base64 の長い値が後続 step で空になり
+# 初回 run (34595908831) が失敗したためやめた。
 on:
   workflow_dispatch:
     inputs:
@@ -48,10 +52,6 @@ env:
   BUILD_NUMBER_OFFSET: 6300
   # 署名は project.pbxproj の Release / Release-Development 設定 (CODE_SIGN_STYLE = Manual + 下記の profile 名) に従う
   IOS_TEAM_ID: TQPN82UBBY
-  IOS_PROFILE_NAME_PROD: Pilll.Production.AppStore
-  IOS_WIDGET_PROFILE_NAME_PROD: Pilll.Production.Widget.AppStore
-  IOS_PROFILE_NAME_DEV: Pilll.Development.AppStore
-  IOS_WIDGET_PROFILE_NAME_DEV: Pilll.Development.Widget.AppStore
   SLACK_NOTIFY_CHANNEL: pilll-notification
 
 jobs:
@@ -100,85 +100,50 @@ jobs:
       matrix:
         flavor: ${{ fromJSON(needs.plan.outputs.ios) }}
     name: ios-${{ matrix.flavor }}
+    env:
+      # bitrise.yml の release-ios-{dev,prod} の script step と同じ環境変数を flavor で選ぶ
+      FILE_FIREBASE_IOS: ${{ matrix.flavor == 'dev' && secrets.FILE_FIREBASE_IOS_DEVELOPMENT || secrets.FILE_FIREBASE_IOS_PRODUCTION }}
+      XCCONFIG_SECRET: ${{ matrix.flavor == 'dev' && secrets.XCCONFIG_SECRET_DEVELOPMENT || secrets.XCCONFIG_SECRET_PRODUCTION }}
+      REVENUE_CAT_PUBLIC_API_KEY: ${{ matrix.flavor == 'dev' && secrets.REVENUE_CAT_PUBLIC_API_KEY || secrets.PROD_REVENUE_CAT_PUBLIC_API_KEY }}
+      IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER: ${{ matrix.flavor == 'dev' && secrets.IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER || secrets.PROD_IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER }}
+      IOS_ADMOB_BANNER_IDENTIFIER: ${{ matrix.flavor == 'dev' && secrets.IOS_ADMOB_BANNER_IDENTIFIER || secrets.PROD_IOS_ADMOB_BANNER_IDENTIFIER }}
+      IOS_PROVISIONING_PROFILE_BASE64: ${{ matrix.flavor == 'dev' && secrets.IOS_PROVISIONING_PROFILE_BASE64_DEV || secrets.IOS_PROVISIONING_PROFILE_BASE64_PROD }}
+      IOS_WIDGET_PROVISIONING_PROFILE_BASE64: ${{ matrix.flavor == 'dev' && secrets.IOS_WIDGET_PROVISIONING_PROFILE_BASE64_DEV || secrets.IOS_WIDGET_PROVISIONING_PROFILE_BASE64_PROD }}
+      IOS_PROFILE_NAME: ${{ matrix.flavor == 'dev' && 'Pilll.Development.AppStore' || 'Pilll.Production.AppStore' }}
+      IOS_WIDGET_PROFILE_NAME: ${{ matrix.flavor == 'dev' && 'Pilll.Development.Widget.AppStore' || 'Pilll.Production.Widget.AppStore' }}
+      IOS_BUNDLE_ID: ${{ matrix.flavor == 'dev' && 'com.mizuki.Ohashi.Pilll.dev' || 'com.mizuki.Ohashi.Pilll' }}
+      FLUTTER_TARGET: ${{ matrix.flavor == 'dev' && 'lib/main.dev.dart' || 'lib/main.prod.dart' }}
+      FLUTTER_FLAVOR_ARGS: ${{ matrix.flavor == 'dev' && '--flavor development' || '' }}
+      DART_DEFINE_FILE: ${{ matrix.flavor == 'dev' && 'environment/dev.json' || 'environment/prod.json' }}
+      # flavor 共通
+      STOREKIT_TESTING_CONFIGURATION_PUBLIC_CERT: ${{ secrets.STOREKIT_TESTING_CONFIGURATION_PUBLIC_CERT }}
+      DART_DEFINE_FROM_FILE_DEV: ${{ secrets.DART_DEFINE_FROM_FILE_DEV }}
+      DART_DEFINE_FROM_FILE_PROD: ${{ secrets.DART_DEFINE_FROM_FILE_PROD }}
+      ANDROID_RES_VALUES: ${{ secrets.ANDROID_RES_VALUES }}
+      # iOS では使わないが make secret / secret.sh / secret_properties.sh が参照するため値を渡す (Bitrise と同じく dev の値)
+      ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER: ${{ secrets.ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER }}
+      ANDROID_ADMOB_BANNER_IDENTIFIER: ${{ secrets.ANDROID_ADMOB_BANNER_IDENTIFIER }}
+      ANDROID_ADMOB_APP_IDENTIFIER: ${{ secrets.ANDROID_ADMOB_APP_IDENTIFIER }}
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD }}
+      ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
+      ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/android/app/bannzai.key.jks
+      IOS_P12_CERTIFICATE_BASE64: ${{ secrets.IOS_P12_CERTIFICATE_BASE64 }}
+      IOS_P12_PASSWORD: ${{ secrets.IOS_P12_PASSWORD }}
+      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_KEY_ISSUER_ID: ${{ secrets.ASC_API_KEY_ISSUER_ID }}
+      ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      # bitrise.yml の script step と同じ環境変数で make secret を実行する。
-      # `echo $(VAR) | base64 -D > file` は VAR が空でも exit 0 で空ファイルを書くため、先に全変数の非空を検査する。
-      # flavor 別の値は DEV_ / PROD_ 接頭辞の環境変数から選び、接頭辞なしの名前で GITHUB_ENV に書く (値は secrets 由来のためログではマスクされる)
-      - name: Resolve secrets for flavor
-        env:
-          FLAVOR: ${{ matrix.flavor }}
-          DEV_FILE_FIREBASE_IOS: ${{ secrets.FILE_FIREBASE_IOS_DEVELOPMENT }}
-          PROD_FILE_FIREBASE_IOS: ${{ secrets.FILE_FIREBASE_IOS_PRODUCTION }}
-          DEV_XCCONFIG_SECRET: ${{ secrets.XCCONFIG_SECRET_DEVELOPMENT }}
-          PROD_XCCONFIG_SECRET: ${{ secrets.XCCONFIG_SECRET_PRODUCTION }}
-          DEV_REVENUE_CAT_PUBLIC_API_KEY: ${{ secrets.REVENUE_CAT_PUBLIC_API_KEY }}
-          PROD_REVENUE_CAT_PUBLIC_API_KEY: ${{ secrets.PROD_REVENUE_CAT_PUBLIC_API_KEY }}
-          DEV_IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER: ${{ secrets.IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER }}
-          PROD_IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER: ${{ secrets.PROD_IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER }}
-          DEV_IOS_ADMOB_BANNER_IDENTIFIER: ${{ secrets.IOS_ADMOB_BANNER_IDENTIFIER }}
-          PROD_IOS_ADMOB_BANNER_IDENTIFIER: ${{ secrets.PROD_IOS_ADMOB_BANNER_IDENTIFIER }}
-          DEV_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64_DEV }}
-          PROD_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64_PROD }}
-          DEV_IOS_WIDGET_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_WIDGET_PROVISIONING_PROFILE_BASE64_DEV }}
-          PROD_IOS_WIDGET_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_WIDGET_PROVISIONING_PROFILE_BASE64_PROD }}
-          # flavor 共通
-          STOREKIT_TESTING_CONFIGURATION_PUBLIC_CERT: ${{ secrets.STOREKIT_TESTING_CONFIGURATION_PUBLIC_CERT }}
-          DART_DEFINE_FROM_FILE_DEV: ${{ secrets.DART_DEFINE_FROM_FILE_DEV }}
-          DART_DEFINE_FROM_FILE_PROD: ${{ secrets.DART_DEFINE_FROM_FILE_PROD }}
-          ANDROID_RES_VALUES: ${{ secrets.ANDROID_RES_VALUES }}
-          # iOS では使わないが make secret / secret.sh / secret_properties.sh が参照するため値を渡す (Bitrise と同じく dev の値)
-          ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER: ${{ secrets.ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER }}
-          ANDROID_ADMOB_BANNER_IDENTIFIER: ${{ secrets.ANDROID_ADMOB_BANNER_IDENTIFIER }}
-          ANDROID_ADMOB_APP_IDENTIFIER: ${{ secrets.ANDROID_ADMOB_APP_IDENTIFIER }}
-          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD }}
-          ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
-          IOS_P12_CERTIFICATE_BASE64: ${{ secrets.IOS_P12_CERTIFICATE_BASE64 }}
-          IOS_P12_PASSWORD: ${{ secrets.IOS_P12_PASSWORD }}
-          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
-          ASC_API_KEY_ISSUER_ID: ${{ secrets.ASC_API_KEY_ISSUER_ID }}
-          ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
+      # `echo $(VAR) | base64 -D > file` は VAR が空でも exit 0 で空ファイルを書くため、make secret の前に全変数の非空を検査する
+      - name: Check secrets
         run: |
-          set -eu
-          case "$FLAVOR" in
-            dev) P=DEV_ ;;
-            prod) P=PROD_ ;;
-          esac
-          for name in FILE_FIREBASE_IOS XCCONFIG_SECRET REVENUE_CAT_PUBLIC_API_KEY IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER IOS_ADMOB_BANNER_IDENTIFIER IOS_PROVISIONING_PROFILE_BASE64 IOS_WIDGET_PROVISIONING_PROFILE_BASE64; do
-            src="${P}${name}"
-            val="${!src:-}"
-            [ -n "$val" ] || { echo "::error::${FLAVOR} 用の Secret (env ${src}) が未登録または空です"; exit 1; }
-            echo "${name}=${val}" >> "$GITHUB_ENV"
+          for name in FILE_FIREBASE_IOS XCCONFIG_SECRET REVENUE_CAT_PUBLIC_API_KEY IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER IOS_ADMOB_BANNER_IDENTIFIER IOS_PROVISIONING_PROFILE_BASE64 IOS_WIDGET_PROVISIONING_PROFILE_BASE64 STOREKIT_TESTING_CONFIGURATION_PUBLIC_CERT DART_DEFINE_FROM_FILE_DEV DART_DEFINE_FROM_FILE_PROD ANDROID_RES_VALUES ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER ANDROID_ADMOB_BANNER_IDENTIFIER ANDROID_ADMOB_APP_IDENTIFIER ANDROID_KEYSTORE_PASSWORD ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD ANDROID_KEYSTORE_ALIAS IOS_P12_CERTIFICATE_BASE64 IOS_P12_PASSWORD ASC_API_KEY_ID ASC_API_KEY_ISSUER_ID ASC_API_KEY_P8_BASE64; do
+            [ -n "${!name:-}" ] || { echo "::error::Secret ${name} (${{ matrix.flavor }} 用) が未登録または空です"; exit 1; }
           done
-          for name in STOREKIT_TESTING_CONFIGURATION_PUBLIC_CERT DART_DEFINE_FROM_FILE_DEV DART_DEFINE_FROM_FILE_PROD ANDROID_RES_VALUES ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER ANDROID_ADMOB_BANNER_IDENTIFIER ANDROID_ADMOB_APP_IDENTIFIER ANDROID_KEYSTORE_PASSWORD ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD ANDROID_KEYSTORE_ALIAS IOS_P12_CERTIFICATE_BASE64 IOS_P12_PASSWORD ASC_API_KEY_ID ASC_API_KEY_ISSUER_ID ASC_API_KEY_P8_BASE64; do
-            val="${!name:-}"
-            [ -n "$val" ] || { echo "::error::Secret ${name} が未登録または空です"; exit 1; }
-            echo "${name}=${val}" >> "$GITHUB_ENV"
-          done
-          # Android の keystore は iOS では使わないが、secret_properties.sh が置換するためパスだけ与える
-          echo "ANDROID_KEYSTORE_PATH=${GITHUB_WORKSPACE}/android/app/bannzai.key.jks" >> "$GITHUB_ENV"
-          case "$FLAVOR" in
-            dev)
-              echo "FLUTTER_TARGET=lib/main.dev.dart" >> "$GITHUB_ENV"
-              echo "FLUTTER_FLAVOR_ARGS=--flavor development" >> "$GITHUB_ENV"
-              echo "DART_DEFINE_FILE=environment/dev.json" >> "$GITHUB_ENV"
-              echo "IOS_BUNDLE_ID=com.mizuki.Ohashi.Pilll.dev" >> "$GITHUB_ENV"
-              echo "IOS_PROFILE_NAME=${IOS_PROFILE_NAME_DEV}" >> "$GITHUB_ENV"
-              echo "IOS_WIDGET_PROFILE_NAME=${IOS_WIDGET_PROFILE_NAME_DEV}" >> "$GITHUB_ENV"
-              ;;
-            prod)
-              echo "FLUTTER_TARGET=lib/main.prod.dart" >> "$GITHUB_ENV"
-              echo "FLUTTER_FLAVOR_ARGS=" >> "$GITHUB_ENV"
-              echo "DART_DEFINE_FILE=environment/prod.json" >> "$GITHUB_ENV"
-              echo "IOS_BUNDLE_ID=com.mizuki.Ohashi.Pilll" >> "$GITHUB_ENV"
-              echo "IOS_PROFILE_NAME=${IOS_PROFILE_NAME_PROD}" >> "$GITHUB_ENV"
-              echo "IOS_WIDGET_PROFILE_NAME=${IOS_WIDGET_PROFILE_NAME_PROD}" >> "$GITHUB_ENV"
-              ;;
-          esac
           echo "BUILD_NUMBER=$((GITHUB_RUN_NUMBER + BUILD_NUMBER_OFFSET))" >> "$GITHUB_ENV"
 
       - run: make secret
@@ -193,8 +158,8 @@ jobs:
       # certificate-and-profile-installer@1 の置き換え。P12 証明書のインポート (一時キーチェーンの作成・登録は action が行う)
       - uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
         with:
-          p12-file-base64: ${{ env.IOS_P12_CERTIFICATE_BASE64 }}
-          p12-password: ${{ env.IOS_P12_PASSWORD }}
+          p12-file-base64: ${{ secrets.IOS_P12_CERTIFICATE_BASE64 }}
+          p12-password: ${{ secrets.IOS_P12_PASSWORD }}
 
       # Runner と WidgetExtension の profile を、従来の MobileDevice 配下と Xcode 16 以降の走査先の両方に置く
       - name: Install provisioning profiles
@@ -202,8 +167,9 @@ jobs:
           PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
           XCODE_PROFILE_DIR="$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"
           mkdir -p "$PROFILE_DIR" "$XCODE_PROFILE_DIR"
-          echo -n "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_DIR/runner.mobileprovision"
-          echo -n "$IOS_WIDGET_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_DIR/widget.mobileprovision"
+          printf '%s' "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_DIR/runner.mobileprovision"
+          printf '%s' "$IOS_WIDGET_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_DIR/widget.mobileprovision"
+          ls -la "$PROFILE_DIR"
           cp "$PROFILE_DIR/runner.mobileprovision" "$PROFILE_DIR/widget.mobileprovision" "$XCODE_PROFILE_DIR/"
           # 展開した profile 名が pbxproj / ExportOptions の指定と一致することを検査する (Secret の取り違え検出)
           for pair in "runner:$IOS_PROFILE_NAME" "widget:$IOS_WIDGET_PROFILE_NAME"; do
@@ -217,7 +183,7 @@ jobs:
       - name: Restore App Store Connect API key
         run: |
           mkdir -p ~/.appstoreconnect/private_keys
-          echo -n "$ASC_API_KEY_P8_BASE64" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8
+          printf '%s' "$ASC_API_KEY_P8_BASE64" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8
 
       # Bitrise の FILE_EXPORT_OPTIONS_PLIST_* と同じ内容 (manageAppVersionAndBuildNumber / uploadSymbols / stripSwiftSymbols) を、
       # profile 名だけ project.pbxproj の PROVISIONING_PROFILE_SPECIFIER に合わせて生成する
@@ -352,6 +318,33 @@ jobs:
       matrix:
         flavor: ${{ fromJSON(needs.plan.outputs.android) }}
     name: android-${{ matrix.flavor }}
+    env:
+      # bitrise.yml の release-android-{dev,prod} の script step と同じ環境変数を flavor で選ぶ
+      FILE_FIREBASE_ANDROID: ${{ matrix.flavor == 'dev' && secrets.FILE_FIREBASE_ANDROID_DEVELOPMENT || secrets.FILE_FIREBASE_ANDROID_PRODUCTION }}
+      ANDROID_RES_VALUES: ${{ matrix.flavor == 'dev' && secrets.ANDROID_RES_VALUES_DEV || secrets.ANDROID_RES_VALUES_PROD }}
+      REVENUE_CAT_PUBLIC_API_KEY: ${{ matrix.flavor == 'dev' && secrets.REVENUE_CAT_PUBLIC_API_KEY || secrets.PROD_REVENUE_CAT_PUBLIC_API_KEY }}
+      ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER: ${{ matrix.flavor == 'dev' && secrets.ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER || secrets.PROD_ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER }}
+      ANDROID_ADMOB_BANNER_IDENTIFIER: ${{ matrix.flavor == 'dev' && secrets.ANDROID_ADMOB_BANNER_IDENTIFIER || secrets.PROD_ANDROID_ADMOB_BANNER_IDENTIFIER }}
+      ANDROID_ADMOB_APP_IDENTIFIER: ${{ matrix.flavor == 'dev' && secrets.ANDROID_ADMOB_APP_IDENTIFIER || secrets.PROD_ANDROID_ADMOB_APP_IDENTIFIER }}
+      ANDROID_PACKAGE_NAME: ${{ matrix.flavor == 'dev' && 'com.mizuki.Ohashi.Pilll.development' || 'com.mizuki.Ohashi.Pilll' }}
+      FLUTTER_TARGET: ${{ matrix.flavor == 'dev' && 'lib/main.dev.dart' || 'lib/main.prod.dart' }}
+      DART_DEFINE_FILE: ${{ matrix.flavor == 'dev' && 'environment/dev.json' || 'environment/prod.json' }}
+      # flavor 共通
+      STOREKIT_TESTING_CONFIGURATION_PUBLIC_CERT: ${{ secrets.STOREKIT_TESTING_CONFIGURATION_PUBLIC_CERT }}
+      DART_DEFINE_FROM_FILE_DEV: ${{ secrets.DART_DEFINE_FROM_FILE_DEV }}
+      DART_DEFINE_FROM_FILE_PROD: ${{ secrets.DART_DEFINE_FROM_FILE_PROD }}
+      # Android では使わないが make secret / secret.sh が参照するため値を渡す (Bitrise と同じく dev の値)
+      FILE_FIREBASE_IOS: ${{ secrets.FILE_FIREBASE_IOS_DEVELOPMENT }}
+      XCCONFIG_SECRET: ${{ secrets.XCCONFIG_SECRET_DEVELOPMENT }}
+      IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER: ${{ secrets.IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER }}
+      IOS_ADMOB_BANNER_IDENTIFIER: ${{ secrets.IOS_ADMOB_BANNER_IDENTIFIER }}
+      # keystore の置き場所は file-downloader@1 の destination と同じ (android/app/*.jks は .gitignore 済み)
+      ANDROID_KEYSTORE_JKS_BASE64: ${{ secrets.ANDROID_KEYSTORE_JKS_BASE64 }}
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD }}
+      ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
+      ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/android/app/bannzai.key.jks
+      PLAY_SA_JSON_BASE64: ${{ secrets.PLAY_SA_JSON_BASE64 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -362,77 +355,23 @@ jobs:
           distribution: "zulu"
           java-version: '17'
 
-      # bitrise.yml の script step と同じ環境変数で make secret を実行する (iOS job と同じ方式)
-      - name: Resolve secrets for flavor
-        env:
-          FLAVOR: ${{ matrix.flavor }}
-          DEV_FILE_FIREBASE_ANDROID: ${{ secrets.FILE_FIREBASE_ANDROID_DEVELOPMENT }}
-          PROD_FILE_FIREBASE_ANDROID: ${{ secrets.FILE_FIREBASE_ANDROID_PRODUCTION }}
-          DEV_ANDROID_RES_VALUES: ${{ secrets.ANDROID_RES_VALUES_DEV }}
-          PROD_ANDROID_RES_VALUES: ${{ secrets.ANDROID_RES_VALUES_PROD }}
-          DEV_REVENUE_CAT_PUBLIC_API_KEY: ${{ secrets.REVENUE_CAT_PUBLIC_API_KEY }}
-          PROD_REVENUE_CAT_PUBLIC_API_KEY: ${{ secrets.PROD_REVENUE_CAT_PUBLIC_API_KEY }}
-          DEV_ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER: ${{ secrets.ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER }}
-          PROD_ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER: ${{ secrets.PROD_ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER }}
-          DEV_ANDROID_ADMOB_BANNER_IDENTIFIER: ${{ secrets.ANDROID_ADMOB_BANNER_IDENTIFIER }}
-          PROD_ANDROID_ADMOB_BANNER_IDENTIFIER: ${{ secrets.PROD_ANDROID_ADMOB_BANNER_IDENTIFIER }}
-          DEV_ANDROID_ADMOB_APP_IDENTIFIER: ${{ secrets.ANDROID_ADMOB_APP_IDENTIFIER }}
-          PROD_ANDROID_ADMOB_APP_IDENTIFIER: ${{ secrets.PROD_ANDROID_ADMOB_APP_IDENTIFIER }}
-          # flavor 共通
-          STOREKIT_TESTING_CONFIGURATION_PUBLIC_CERT: ${{ secrets.STOREKIT_TESTING_CONFIGURATION_PUBLIC_CERT }}
-          DART_DEFINE_FROM_FILE_DEV: ${{ secrets.DART_DEFINE_FROM_FILE_DEV }}
-          DART_DEFINE_FROM_FILE_PROD: ${{ secrets.DART_DEFINE_FROM_FILE_PROD }}
-          # Android では使わないが make secret / secret.sh が参照するため値を渡す (Bitrise と同じく dev の値)
-          FILE_FIREBASE_IOS: ${{ secrets.FILE_FIREBASE_IOS_DEVELOPMENT }}
-          XCCONFIG_SECRET: ${{ secrets.XCCONFIG_SECRET_DEVELOPMENT }}
-          IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER: ${{ secrets.IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER }}
-          IOS_ADMOB_BANNER_IDENTIFIER: ${{ secrets.IOS_ADMOB_BANNER_IDENTIFIER }}
-          ANDROID_KEYSTORE_JKS_BASE64: ${{ secrets.ANDROID_KEYSTORE_JKS_BASE64 }}
-          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD }}
-          ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
-          PLAY_SA_JSON_BASE64: ${{ secrets.PLAY_SA_JSON_BASE64 }}
+      - name: Check secrets
         run: |
-          set -eu
-          case "$FLAVOR" in
-            dev) P=DEV_ ;;
-            prod) P=PROD_ ;;
-          esac
-          for name in FILE_FIREBASE_ANDROID ANDROID_RES_VALUES REVENUE_CAT_PUBLIC_API_KEY ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER ANDROID_ADMOB_BANNER_IDENTIFIER ANDROID_ADMOB_APP_IDENTIFIER; do
-            src="${P}${name}"
-            val="${!src:-}"
-            [ -n "$val" ] || { echo "::error::${FLAVOR} 用の Secret (env ${src}) が未登録または空です"; exit 1; }
-            echo "${name}=${val}" >> "$GITHUB_ENV"
+          for name in FILE_FIREBASE_ANDROID ANDROID_RES_VALUES REVENUE_CAT_PUBLIC_API_KEY ANDROID_ADMOB_NATIVE_ADVANCE_IDENTIFIER ANDROID_ADMOB_BANNER_IDENTIFIER ANDROID_ADMOB_APP_IDENTIFIER STOREKIT_TESTING_CONFIGURATION_PUBLIC_CERT DART_DEFINE_FROM_FILE_DEV DART_DEFINE_FROM_FILE_PROD FILE_FIREBASE_IOS XCCONFIG_SECRET IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER IOS_ADMOB_BANNER_IDENTIFIER ANDROID_KEYSTORE_JKS_BASE64 ANDROID_KEYSTORE_PASSWORD ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD ANDROID_KEYSTORE_ALIAS PLAY_SA_JSON_BASE64; do
+            [ -n "${!name:-}" ] || { echo "::error::Secret ${name} (${{ matrix.flavor }} 用) が未登録または空です"; exit 1; }
           done
-          for name in STOREKIT_TESTING_CONFIGURATION_PUBLIC_CERT DART_DEFINE_FROM_FILE_DEV DART_DEFINE_FROM_FILE_PROD FILE_FIREBASE_IOS XCCONFIG_SECRET IOS_ADMOB_NATIVE_ADVANCE_IDENTIFIER IOS_ADMOB_BANNER_IDENTIFIER ANDROID_KEYSTORE_JKS_BASE64 ANDROID_KEYSTORE_PASSWORD ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD ANDROID_KEYSTORE_ALIAS PLAY_SA_JSON_BASE64; do
-            val="${!name:-}"
-            [ -n "$val" ] || { echo "::error::Secret ${name} が未登録または空です"; exit 1; }
-            echo "${name}=${val}" >> "$GITHUB_ENV"
-          done
-          # keystore の置き場所は file-downloader@1 の destination と同じ (android/app/*.jks は .gitignore 済み)
-          echo "ANDROID_KEYSTORE_PATH=${GITHUB_WORKSPACE}/android/app/bannzai.key.jks" >> "$GITHUB_ENV"
-          case "$FLAVOR" in
-            dev)
-              echo "FLUTTER_TARGET=lib/main.dev.dart" >> "$GITHUB_ENV"
-              echo "DART_DEFINE_FILE=environment/dev.json" >> "$GITHUB_ENV"
-              echo "ANDROID_PACKAGE_NAME=com.mizuki.Ohashi.Pilll.development" >> "$GITHUB_ENV"
-              ;;
-            prod)
-              echo "FLUTTER_TARGET=lib/main.prod.dart" >> "$GITHUB_ENV"
-              echo "DART_DEFINE_FILE=environment/prod.json" >> "$GITHUB_ENV"
-              echo "ANDROID_PACKAGE_NAME=com.mizuki.Ohashi.Pilll" >> "$GITHUB_ENV"
-              ;;
-          esac
           echo "BUILD_NUMBER=$((GITHUB_RUN_NUMBER + BUILD_NUMBER_OFFSET))" >> "$GITHUB_ENV"
 
       # file-downloader@1 (BITRISEIO_ANDROID_KEYSTORE_URL → android/app/bannzai.key.jks) の置き換え。
       # keystore のパスワードと alias で開けることを先に検査し、Gradle の署名で初めて失敗する状況を避ける
       - name: Restore release keystore
         run: |
-          echo -n "$ANDROID_KEYSTORE_JKS_BASE64" | base64 --decode > "$ANDROID_KEYSTORE_PATH"
+          printf '%s' "$ANDROID_KEYSTORE_JKS_BASE64" | base64 --decode > "$ANDROID_KEYSTORE_PATH"
           SIZE=$(wc -c < "$ANDROID_KEYSTORE_PATH")
+          echo "keystore: $SIZE bytes"
           [ "$SIZE" -gt 100 ] || { echo "::error::keystore が $SIZE bytes しかありません。ANDROID_KEYSTORE_JKS_BASE64 が壊れています"; exit 1; }
-          keytool -list -keystore "$ANDROID_KEYSTORE_PATH" -storepass "$ANDROID_KEYSTORE_PASSWORD" -alias "$ANDROID_KEYSTORE_ALIAS" > /dev/null
+          keytool -list -keystore "$ANDROID_KEYSTORE_PATH" -storepass "$ANDROID_KEYSTORE_PASSWORD" -alias "$ANDROID_KEYSTORE_ALIAS" > /dev/null \
+            || { echo "::error::keystore を ANDROID_KEYSTORE_PASSWORD / ANDROID_KEYSTORE_ALIAS で開けません。Bitrise の Secrets と同じ値か確認してください"; exit 1; }
 
       - run: make secret
 
@@ -456,7 +395,7 @@ jobs:
 
       - name: Restore Play service account JSON
         run: |
-          echo -n "$PLAY_SA_JSON_BASE64" | base64 --decode > "$RUNNER_TEMP/play-service-account.json"
+          printf '%s' "$PLAY_SA_JSON_BASE64" | base64 --decode > "$RUNNER_TEMP/play-service-account.json"
           jq -e '.client_email' "$RUNNER_TEMP/play-service-account.json" > /dev/null
 
       # google-play-deploy@3 の置き換え。Bitrise と同じく dev / prod とも内部テストトラックへ配布する


### PR DESCRIPTION
## Abstract

flutter-deploy.yml で flavor 別の secret を GITHUB_ENV 経由で後続 step に渡していた方式をやめ、job の `env` で `matrix.flavor == 'dev' && secrets.X_DEV || secrets.X_PROD` の形で選ぶ。

## Why

#1870 のマージで起動した初回 run https://github.com/bannzai/Pilll/actions/runs/34595908831 が両 job とも失敗した。

- ios-dev: `Install provisioning profiles` で `Cannot parse a NULL or zero-length data` (展開した profile が空)
- android-dev: `Restore release keystore` の base64 復元で exit 1

どちらも「Resolve secrets for flavor」step で GITHUB_ENV に書いた base64 の長い値が、後続 step で空 (または壊れた値) になっていた。同じ run で `${{ secrets.* }}` を直接渡した P12 のインポートは成功しているため、GITHUB_ENV 経由をやめて secrets を job env で直接参照する。

## 変更内容

- `ios` / `android` job に `env:` を置き、flavor 別の secret と非 secret の値 (target・flavor 引数・bundle ID・profile 名) を三項演算子で選ぶ
- 「Resolve secrets for flavor」を「Check secrets」(非空検査 + BUILD_NUMBER の算出) に置き換える
- base64 の復元は `echo -n` ではなく `printf '%s'` にする
- keystore を開けない時のエラーに、GitHub の `ANDROID_KEYSTORE_PASSWORD` / `ANDROID_KEYSTORE_ALIAS` が Bitrise の Secrets と同じ値か確認する旨を出す (初回 run のログで secret 名 `ANDROID_KEYSTORE_ALIAS` 自体がマスクされており、その Secret の値が名前と同じプレースホルダーになっている疑いがある)

## 検証

- `actionlint`: エラーなし
- 実配布は未検証。マージ (main push) で dev 配布が再度起動する。keystore のパスワード・alias が正しくない場合は `Restore release keystore` で止まる (配布はされない)

## Links

- 初回 run: https://github.com/bannzai/Pilll/actions/runs/34595908831
- 移行 PR: https://github.com/bannzai/Pilll/pull/1870

## Checked

CI 設定のみの変更のため、Analytics ログ・UnitTest・WidgetTest は対象外。

## 人間が確認

なし

## セッション再開

```sh
cd /Users/bannzai/ghq/github.com/bannzai/pilll
claude --resume 886ac739-a1d8-4903-9617-4c00ef39bfef
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - iOS・Androidアプリのビルドおよび配布処理を見直し、環境ごとの設定をより確実に適用できるようにしました。
  - 必要な認証情報や署名ファイルの検証を強化し、設定不備による配布失敗を早期に検知できるようにしました。
  - iOSの証明書・プロファイル、Androidの署名キーの復元処理を改善し、モバイルアプリのリリース安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->