### PR TITLE
fix(flutter-deploy): profile 名の検査を /dev/stdin ではなくファイル経由で行う

### DIFF
--- a/.github/workflows/flutter-deploy.yml
+++ b/.github/workflows/flutter-deploy.yml
@@ -169,12 +169,13 @@ jobs:
           mkdir -p "$PROFILE_DIR" "$XCODE_PROFILE_DIR"
           printf '%s' "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_DIR/runner.mobileprovision"
           printf '%s' "$IOS_WIDGET_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_DIR/widget.mobileprovision"
-          ls -la "$PROFILE_DIR"
           cp "$PROFILE_DIR/runner.mobileprovision" "$PROFILE_DIR/widget.mobileprovision" "$XCODE_PROFILE_DIR/"
-          # 展開した profile 名が pbxproj / ExportOptions の指定と一致することを検査する (Secret の取り違え検出)
+          # 展開した profile 名が pbxproj / ExportOptions の指定と一致することを検査する (Secret の取り違え検出)。
+          # PlistBuddy は /dev/stdin を読めない (Error Reading File: /dev/stdin) ため、復号した plist をファイルに落としてから読む
           for pair in "runner:$IOS_PROFILE_NAME" "widget:$IOS_WIDGET_PROFILE_NAME"; do
             f="${pair%%:*}"; expected="${pair#*:}"
-            actual=$(security cms -D -i "$PROFILE_DIR/$f.mobileprovision" | /usr/libexec/PlistBuddy -c 'Print :Name' /dev/stdin)
+            security cms -D -i "$PROFILE_DIR/$f.mobileprovision" > "$RUNNER_TEMP/$f.plist"
+            actual=$(/usr/libexec/PlistBuddy -c 'Print :Name' "$RUNNER_TEMP/$f.plist")
             echo "$f: $actual"
             [ "$actual" = "$expected" ] || { echo "::error::$f の profile 名が $expected ではなく $actual です。Secret の登録内容を確認してください"; exit 1; }
           done


### PR DESCRIPTION
## Abstract

flutter-deploy の iOS job で、provisioning profile 名の検査が必ず失敗していた不具合を直す。復号した plist を `/dev/stdin` で PlistBuddy に渡すのをやめ、ファイルへ落としてから読む。

## Why

run https://github.com/bannzai/Pilll/actions/runs/34642013751 の ios-dev が `Install provisioning profiles` で `Cannot parse a NULL or zero-length data` で失敗した。ログで profile の展開自体は成功している (`runner.mobileprovision` 13618 bytes / `widget.mobileprovision` 12529 bytes) ため、原因は展開ではなく検査コマンドだった。

ローカルで同じコマンドを実行して再現した。

```console
$ security cms -D -i Pilll.Development.AppStore.mobileprovision | /usr/libexec/PlistBuddy -c 'Print :Name' /dev/stdin
Cannot parse a NULL or zero-length data
Error Reading File: /dev/stdin
```

PlistBuddy は `/dev/stdin` を読めず、パイプの相手側の `security cms` も出力先が閉じて `Cannot parse a NULL or zero-length data` を出して終了する。前回の修正 (#1872) は GITHUB_ENV 経由の値渡しを疑ったが、実際の原因はこちらだった。

## 変更内容

- 復号した plist を `$RUNNER_TEMP/<runner|widget>.plist` へ書き、PlistBuddy にそのファイルを渡す
- 展開サイズは run のログで確認できたため、デバッグ用に入れていた `ls -la` を外す

## 検証

ローカルで 4 つの profile (Development / Production × Runner / Widget) を base64 から復号し、修正後と同じ手順で名前を取り出した。

```console
$ bash ./tmp/verify-profile-name-check.sh
Pilll.Development.AppStore: OK
Pilll.Development.Widget.AppStore: OK
Pilll.Production.AppStore: OK
Pilll.Production.Widget.AppStore: OK
```

`actionlint`: エラーなし。

## 未検証の範囲

- 実配布は未検証。マージ (main push) で dev 配布が再度起動する。この PR で iOS は profile 検査を越えてビルドへ進むが、その先 (archive / export / アップロード) は初めて実行される
- **Android は別の問題で止まったままになる**。下記参照

## Android の keystore について (この PR では直せない)

同じ run の android-dev は `Restore release keystore` で失敗した。調査した結果:

- Secret `ANDROID_KEYSTORE_JKS_BASE64` の展開は成功している (2242 bytes)。ファイルは有効な JKS 形式 (magic `feedfeed`、version 2) で、ローカルの `~/bannzai.key.jks` とバイト単位で一致する
- そのファイルを、ローカル環境変数の `ANDROID_KEYSTORE_PASSWORD` / `ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD` のどちらで開こうとしても `Keystore was tampered with, or password was incorrect` になる。`ANDROID_KEYSTORE_ALIAS` の alias も見つからない
- GitHub に登録済みの同名 Secret (2023-09-18 登録) も同じ値と見られ、run でも開けなかった

つまり **keystore ファイルと、手元にあるパスワード・alias の組み合わせが一致していない**。どちらかが古い。復旧には次のいずれかが必要:

1. Bitrise の Code Signing タブにアップロード済みの Android keystore ファイルと、その登録時のパスワード・alias を取り直して `gh secret set` する (keystore ファイル自体は Bitrise からダウンロードできる)
2. 正しいパスワードがパスワードマネージャ等にあれば、それを登録する
3. どちらも取れない場合は、Google Play Console → 設定 → アプリの署名 で「アップロード鍵のリセット」を申請し、新しい keystore を作って登録する (Play アプリ署名が有効なら配信中のアプリへの影響はない)

この判断はユーザーにしかできないため、https://github.com/bannzai/PilllBackend/issues/422 に項目として記録する。

## Links

- 失敗した run: https://github.com/bannzai/Pilll/actions/runs/34642013751
- 前回の修正 (原因の推定が外れたもの): https://github.com/bannzai/Pilll/pull/1872
- 移行 PR: https://github.com/bannzai/Pilll/pull/1870

## Checked

CI 設定のみの変更のため、Analytics ログ・UnitTest・WidgetTest は対象外。

## 人間が確認

なし

## セッション再開

```sh
cd /Users/bannzai/ghq/github.com/bannzai/pilll
claude --resume 886ac739-a1d8-4903-9617-4c00ef39bfef
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * iOSアプリのプロビジョニングプロファイル名の検証処理を修正し、デプロイ時の処理が正常に完了するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->