### PR TITLE
fix(flutter-deploy): BUILD_NUMBER_OFFSET を dev アプリの実績値を超える 6400 にする

### DIFF
--- a/.github/workflows/flutter-deploy.yml
+++ b/.github/workflows/flutter-deploy.yml
@@ -11,7 +11,9 @@ name: flutter-deploy
 # - workflow_dispatch      → 対象を選んで手動起動
 #
 # ビルド番号 = github.run_number + BUILD_NUMBER_OFFSET。iOS (CFBundleVersion) と Android (versionCode) で共通。
-# Bitrise 時代の最終値は App Store Connect 6283 / Google Play 6282 のため、それを超える offset にしている。
+# Bitrise 時代の最終値は dev アプリの方が大きい (main push のたびに dev を配布していたため)。
+# 2026-09-12 時点の実測: App Store Connect prod 6283 / dev 6314、Google Play prod 6282 / dev 6304。
+# offset はこの最大値 6314 を超えるように決める (Google Play は同じパッケージで versionCode の重複を拒否する)。
 # アップロード step まで進んで失敗した run を Re-run すると同じビルド番号の再送になり拒否されるため、その場合は
 # 原因を直して workflow_dispatch で新しく起動する (アップロードより前で失敗した run は Re-run してよい)。
 #
@@ -49,7 +51,7 @@ concurrency:
 
 env:
   FLUTTER_VERSION: '3.41.9'
-  BUILD_NUMBER_OFFSET: 6300
+  BUILD_NUMBER_OFFSET: 6400
   # 署名は project.pbxproj の Release / Release-Development 設定 (CODE_SIGN_STYLE = Manual + 下記の profile 名) に従う
   IOS_TEAM_ID: TQPN82UBBY
   SLACK_NOTIFY_CHANNEL: pilll-notification


### PR DESCRIPTION
## Abstract

flutter-deploy の `BUILD_NUMBER_OFFSET` を 6300 から 6400 に上げる。

## Why

run https://github.com/bannzai/Pilll/actions/runs/34668900318 の android-dev が Google Play へのアップロードで失敗した。

```
##[error]Version code 6304 has already been used.
```

offset を決めた時に prod アプリの実績値だけを見ており、main push のたびに配布していた **dev アプリの方が番号が大きい** ことを見落としていた。2026-09-12 時点で実測した値:

| ストア | prod | dev |
| --- | --- | --- |
| App Store Connect | 6283 | 6314 |
| Google Play | 6282 | 6304 |

Google Play は同じパッケージで versionCode の重複を拒否するため、最大の 6314 を超える必要がある。offset を 6400 にすると次の run (run_number 5) は 6405 になる。

## 同じ run の iOS は成功している

ios-dev は profile 検査を越えてビルド・アップロードまで完走した。

```
UPLOAD SUCCEEDED with no errors
No errors uploading archive at 'build/ios/ipa/Pilll.ipa'.
```

App Store Connect の dev アプリ (1571408311) に build 6304 が `processingState=VALID` で到着していることを API で確認した。#1873 の profile 名検査の修正が効いている。

Android も keystore の復元・署名・AAB のビルドまでは成功しており、残っていたのは versionCode の重複だけだった。

## 検証

- `actionlint`: エラーなし
- Play の versionCode は `edits/{id}/bundles` の全件、ASC は `/v1/builds` で取得した実測値

## 未検証の範囲

- マージ (main push) で起動する次の run が初めて Android の Play アップロードまで到達する
- iOS は 2 回目のアップロードになる (6405)

## 別に判断が要ること (この PR では変えない)

Slack 通知の step が毎回失敗している (`continue-on-error` のため配布の成否には影響しない)。通知先に指定した `#pilll-notification` チャンネルが存在しないため。作るか、既存チャンネルへ向けるかを決める必要がある。

## Links

- 失敗した run: https://github.com/bannzai/Pilll/actions/runs/34668900318
- profile 検査の修正: https://github.com/bannzai/Pilll/pull/1873
- 移行 PR: https://github.com/bannzai/Pilll/pull/1870

## Checked

CI 設定のみの変更のため、Analytics ログ・UnitTest・WidgetTest は対象外。

## 人間が確認

なし

## セッション再開

```sh
cd /Users/bannzai/ghq/github.com/bannzai/pilll
claude --resume 886ac739-a1d8-4903-9617-4c00ef39bfef
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - アプリのビルド番号を更新し、ストア上の既存ビルド番号との重複を避けられるようにしました。
  - iOS・Android版の配信時に、より適切なビルド番号が設定されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->